### PR TITLE
test: only run renovate config check when file changes

### DIFF
--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -3,7 +3,7 @@ name: Validate renovate config
 on:
   push:
     paths:
-      - renovate.json
+      - "renovate.json"
 
 jobs:
   validate:


### PR DESCRIPTION
This should fix the action being triggered for all pushes
