### PR TITLE
chore(renovate): enable go mod tidy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "rangeStrategy": "pin",
   "rebaseWhen": "behind-base-branch",
   "semanticCommits": "enabled",
+  "postUpdateOptions": ["gomodTidy"],
   "regexManagers": [
     {
       "description": "Upgrade go version",


### PR DESCRIPTION
This will make renovate run `go mod tidy` on **all** updates, satisfying the pre-commit hook.
