### PR TITLE
feat: add version endpoint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,3 +54,5 @@ jobs:
           push: ${{ steps.push_check.outputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 tmp
-data/gorm.db
+gorm.db
 coverage.out
+/backend

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,12 @@ You will need the following tools:
 
 Once those are installed, run `make setup` to perform the repository setup.
 
-## Development server
+## Development commands
 
-Run `make devserver` in the repository root, which will build and rebuild the project every time the code changes.
+- `make devserver` will start a development server on port 8080 and and rebuild the project every time the code changes.
+- `make test` runs all tests
+- `make coverage` runs all tests and opens the coverage report in your browser
+- `make build` builds the software with production configuration
 
 ## Commit messages
 
@@ -22,6 +25,4 @@ to enable better overview over changes and enables automated tooling based on co
 
 ## Tests & test coverage
 
-The test coverage goal is 100%. Please try to add tests for everything you add to the codebase. If in doubt, you’re always welcome to open an issue and ask for help.
-
-To run tests, run `make test`. To show the test coverage graphically in your browser, run `make coverage`.
+The test coverage goal is > 95%. Please try to add tests for everything you add to the codebase. If in doubt, you’re always welcome to open an issue and ask for help.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-# syntax=docker/dockerfile:1
 FROM golang:1.18-alpine as builder
 
-# needed for github.com/mattn/go-sqlite3
-RUN apk add --no-cache gcc g++
+RUN apk add --no-cache make
 
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY internal ./internal
-COPY main.go ./
-RUN CGO_ENABLED=0 go build -o /backend
+COPY main.go Makefile ./
+
+ARG VERSION=0.0.0
+RUN CGO_ENABLED=0 make build VERSION=${VERSION}
 
 # Build final image
 FROM scratch
 WORKDIR /
-COPY --from=builder /backend /backend
+COPY --from=builder /app/backend /backend
 ENTRYPOINT ["/backend"]

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,9 @@ test:
 .PHONY: coverage
 coverage: test
 	go tool cover -html=coverage.out
+
+VERSION ?= $(shell git rev-parse HEAD)
+.PHONY: build
+build:
+	go build -ldflags "-X github.com/envelope-zero/backend/internal/controllers.version=${VERSION}"
+

--- a/internal/controllers/main_list_test.go
+++ b/internal/controllers/main_list_test.go
@@ -12,8 +12,9 @@ var getOverviewTests = []struct {
 	path     string
 	expected string
 }{
-	{"/", `{ "links": { "v1": "http:///v1" }}`},
+	{"/", `{ "links": { "v1": "http:///v1", "version": "http:///version }}`},
 	{"/v1", `{ "links": { "budgets": "http:///v1/budgets" }}`},
+	{"/version", `{"data": { "version": "0.0.0" }}`},
 }
 
 func TestGetOverview(t *testing.T) {

--- a/internal/controllers/main_list_test.go
+++ b/internal/controllers/main_list_test.go
@@ -12,7 +12,7 @@ var getOverviewTests = []struct {
 	path     string
 	expected string
 }{
-	{"/", `{ "links": { "v1": "http:///v1", "version": "http:///version }}`},
+	{"/", `{ "links": { "v1": "http:///v1", "version": "http:///version" }}`},
 	{"/v1", `{ "links": { "budgets": "http:///v1/budgets" }}`},
 	{"/version", `{"data": { "version": "0.0.0" }}`},
 }

--- a/internal/controllers/main_options_test.go
+++ b/internal/controllers/main_options_test.go
@@ -13,6 +13,7 @@ var optionsHeaderTests = []struct {
 	expected string
 }{
 	{"/", "GET"},
+	{"/version", "GET"},
 	{"/v1", "GET"},
 	{"/v1/budgets", "GET, POST"},
 	{"/v1/budgets/1", "GET, PATCH, DELETE"},

--- a/internal/controllers/routing.go
+++ b/internal/controllers/routing.go
@@ -14,6 +14,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// This is set at build time, see Makefile.
+var version = "0.0.0"
+
 // Router controls the routes for the API.
 func Router() (*gin.Engine, error) {
 	// Set up the router and middlewares
@@ -36,8 +39,6 @@ func Router() (*gin.Engine, error) {
 				Logger()
 		})))
 
-	// 12:47AM INF Request ip=::1 latency=0.711125 method=GET path=/v1/budgets status=200 user_agent=HTTPie/3.1.0
-
 	err := models.ConnectDatabase()
 	if err != nil {
 		return nil, fmt.Errorf("Database connection failed with: %s", err.Error())
@@ -47,13 +48,26 @@ func Router() (*gin.Engine, error) {
 	r.GET("", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
 			"links": map[string]string{
-				"v1": requestURL(c) + "v1",
+				"v1":      requestURL(c) + "v1",
+				"version": requestURL(c) + "version",
 			},
 		})
 	})
 
 	// Options lists the allowed HTTP verbs
 	r.OPTIONS("", func(c *gin.Context) {
+		c.Header("allow", "GET")
+	})
+
+	r.GET("/version", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"data": map[string]string{
+				"version": version,
+			},
+		})
+	})
+
+	r.OPTIONS("/version", func(c *gin.Context) {
 		c.Header("allow", "GET")
 	})
 


### PR DESCRIPTION
This adds the `/version` endpoint which has the version set at build. The configuration is as follows:

* `make build` uses the long hash of the git HEAD as default
* The `Dockerfile` uses `0.0.0` as default. This will only be used when someone runs `docker build` directly, which is not recommended.
* The GitHub action building the image for releases uses the GitHub context `github.ref_name`, which is the branch or tag name.

Resolves #56.
