### PR TITLE
feat: use HTTP 405 responses for existing routes that don’t support a method

### DIFF
--- a/internal/controllers/main_list_test.go
+++ b/internal/controllers/main_list_test.go
@@ -25,3 +25,23 @@ func TestGetOverview(t *testing.T) {
 		assert.JSONEq(t, tt.expected, recorder.Body.String())
 	}
 }
+
+var methodNotAllowedTests = []struct {
+	path   string
+	method string
+}{
+	{"/", "POST"},
+	{"/", "DELETE"},
+	{"/v1", "POST"},
+	{"/v1", "DELETE"},
+	{"/v1/budgets", "HEAD"},
+	{"/v1/budgets", "PUT"},
+}
+
+func TestMethodNotAllowed(t *testing.T) {
+	for _, tt := range methodNotAllowedTests {
+		recorder := test.Request(t, tt.method, tt.path, "")
+
+		test.AssertHTTPStatus(t, http.StatusMethodNotAllowed, &recorder, tt.path, tt.method)
+	}
+}

--- a/internal/controllers/routing.go
+++ b/internal/controllers/routing.go
@@ -26,6 +26,10 @@ func Router() (*gin.Engine, error) {
 	// client IPs
 	r.ForwardedByClientIP = false
 
+	// Send a HTTP 405 (Method not allowed) for all paths where there is
+	// a handler, but not for the specific method used
+	r.HandleMethodNotAllowed = true
+
 	r.Use(gin.Recovery())
 	r.Use(requestid.New())
 	r.Use(logger.SetLogger(

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -45,6 +46,6 @@ func Request(t *testing.T, method, url, body string, headers ...map[string]strin
 	return *recorder
 }
 
-func AssertHTTPStatus(t *testing.T, expected int, r *httptest.ResponseRecorder) {
-	assert.Equal(t, expected, r.Code, "Status is '%v', body is '%v'", r.Code, r.Body.String())
+func AssertHTTPStatus(t *testing.T, expected int, r *httptest.ResponseRecorder, args ...string) {
+	assert.Equal(t, expected, r.Code, "Status is '%v', body is '%v'. Additional context: %v", r.Code, r.Body.String(), strings.Join(args, " "))
 }


### PR DESCRIPTION
Return HTTP 405 if there is a matching route, but it does not support the request method
