### PR TITLE
feat: use x-forwarded-prefix to generate links

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ ingress:
         - envelope-zero.example.com
 ```
 
+If you do not use the root path `/`, but a prefix, make sure your reverse proxy writes the used prefix in the `x-forwarded-prefix` header. That header is used by the backend to generate the correct URLs for resources.
+
 ## Supported Versions
 
 This project is under heavy development. Therefore, only the latest release is supported.

--- a/internal/controllers/helper.go
+++ b/internal/controllers/helper.go
@@ -37,7 +37,8 @@ func requestURL(c *gin.Context) string {
 		scheme = "https"
 	}
 
-	return scheme + "://" + c.Request.Host + c.Request.URL.Path
+	forwardedPrefix := c.Request.Header.Get("x-forwarded-prefix")
+	return scheme + "://" + c.Request.Host + forwardedPrefix + c.Request.URL.Path
 }
 
 // FetchErrorHandler handles errors for fetching data from the database.

--- a/internal/controllers/helper_test.go
+++ b/internal/controllers/helper_test.go
@@ -19,3 +19,15 @@ func TestRequestURLHTTPS(t *testing.T) {
 
 	assert.Equal(t, "https:///v1/budgets", apiResponse.Links["budgets"])
 }
+
+func TestRequestForwardedPrefix(t *testing.T) {
+	recorder := test.Request(t, "GET", "/v1", "", map[string]string{"x-forwarded-prefix": "/api"})
+
+	var apiResponse test.APIResponse
+	err := json.NewDecoder(recorder.Body).Decode(&apiResponse)
+	if err != nil {
+		assert.Fail(t, "Unable to parse response from server %q into APIResponse, '%v'", recorder.Body, err)
+	}
+
+	assert.Equal(t, "http:///api/v1/budgets", apiResponse.Links["budgets"])
+}


### PR DESCRIPTION
Use the x-forwarded-prefix header to add a prefix if it is set. 

Resolves #86.
