### PR TITLE
fix: return empty list, not null if there are no accounts

### DIFF
--- a/internal/controllers/account.go
+++ b/internal/controllers/account.go
@@ -69,21 +69,21 @@ func CreateAccount(c *gin.Context) {
 
 // GetAccounts retrieves all accounts.
 func GetAccounts(c *gin.Context) {
-	var accounts, apiResponses []models.Account
+	var accounts []models.Account
 
 	models.DB.Where("budget_id = ?", c.Param("budgetId")).Find(&accounts)
 
-	for _, account := range accounts {
+	for i, account := range accounts {
 		response, err := account.WithCalculations()
 		if err != nil {
 			FetchErrorHandler(c, fmt.Errorf("could not get values for account %v: %v", account.Name, err))
 			return
 		}
 
-		apiResponses = append(apiResponses, *response)
+		accounts[i] = *response
 	}
 
-	c.JSON(http.StatusOK, gin.H{"data": apiResponses})
+	c.JSON(http.StatusOK, gin.H{"data": accounts})
 }
 
 // GetAccount retrieves an account by its ID.

--- a/internal/controllers/account_test.go
+++ b/internal/controllers/account_test.go
@@ -196,9 +196,35 @@ func TestUpdateNonExistingAccount(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
 }
 
-func TestDeleteAccount(t *testing.T) {
+func TestDeleteAccountsAndEmptyList(t *testing.T) {
 	recorder := test.Request(t, "DELETE", "/v1/budgets/1/accounts/1", "")
 	test.AssertHTTPStatus(t, http.StatusNoContent, &recorder)
+
+	recorder = test.Request(t, "DELETE", "/v1/budgets/1/accounts/2", "")
+	test.AssertHTTPStatus(t, http.StatusNoContent, &recorder)
+
+	recorder = test.Request(t, "DELETE", "/v1/budgets/1/accounts/3", "")
+	test.AssertHTTPStatus(t, http.StatusNoContent, &recorder)
+
+	recorder = test.Request(t, "DELETE", "/v1/budgets/1/accounts/4", "")
+	test.AssertHTTPStatus(t, http.StatusNoContent, &recorder)
+
+	recorder = test.Request(t, "DELETE", "/v1/budgets/1/accounts/5", "")
+	test.AssertHTTPStatus(t, http.StatusNoContent, &recorder)
+
+	recorder = test.Request(t, "DELETE", "/v1/budgets/1/accounts/6", "")
+	test.AssertHTTPStatus(t, http.StatusNoContent, &recorder)
+
+	recorder = test.Request(t, "GET", "/v1/budgets/1/accounts", "")
+	var apiResponse AccountListResponse
+	err := json.NewDecoder(recorder.Body).Decode(&apiResponse)
+	if err != nil {
+		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+	}
+
+	// Verify that the account list is an empty list, not null
+	assert.NotNil(t, apiResponse.Data)
+	assert.Empty(t, apiResponse.Data)
 }
 
 func TestDeleteNonExistingAccount(t *testing.T) {


### PR DESCRIPTION
When there are no accounts, an empty list should be returned, not `nil` (`null` in JSON).
