### PR TITLE
chore: move configuration to router initialization

### DIFF
--- a/internal/controllers/routing_test.go
+++ b/internal/controllers/routing_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/envelope-zero/backend/internal/controllers"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,4 +16,14 @@ func TestDBConnectionErrorHandled(t *testing.T) {
 
 	assert.NotNil(t, err)
 	os.Unsetenv("DB_HOST")
+}
+
+func TestGinMode(t *testing.T) {
+	os.Setenv("GIN_MODE", "debug")
+	_, err := controllers.Router()
+
+	assert.Nil(t, err, "%T: %v", err, err)
+	assert.True(t, gin.IsDebugging())
+
+	os.Unsetenv("GIN_MODE")
 }

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -27,6 +28,7 @@ type APIResponse struct {
 func Request(t *testing.T, method, url, body string, headers ...map[string]string) httptest.ResponseRecorder {
 	byteStr := []byte(body)
 
+	os.Setenv("LOG_FORMAT", "human")
 	router, err := controllers.Router()
 	if err != nil {
 		t.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -1,41 +1,12 @@
 package main
 
 import (
-	"io"
-	"os"
-
-	"github.com/gin-gonic/gin"
-	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
 	"github.com/envelope-zero/backend/internal/controllers"
 )
 
 func main() {
-	// gin uses debug as the default mode, we use release for
-	// security reasons
-	ginMode, ok := os.LookupEnv("GIN_MODE")
-	if !ok {
-		gin.SetMode("release")
-	} else {
-		gin.SetMode(ginMode)
-	}
-
-	// Log format can be explicitly set.
-	// If it is not set, it defaults to human readable for development
-	// and JSON for release
-	logFormat, ok := os.LookupEnv("LOG_FORMAT")
-	output := io.Writer(os.Stdout)
-	if (!ok && gin.IsDebugging()) || (ok && logFormat == "human") {
-		output = zerolog.ConsoleWriter{Out: os.Stdout}
-	}
-
-	zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	if gin.IsDebugging() {
-		zerolog.SetGlobalLevel(zerolog.DebugLevel)
-	}
-	log.Logger = log.Output(output).With().Timestamp().Logger()
-
 	r, err := controllers.Router()
 	if err != nil {
 		log.Fatal().Msg(err.Error())


### PR DESCRIPTION
This moves the configuration to the router initialization, which makes it configurable for tests, too.
