### PR TITLE
fix: return 404 instead of empty list for non-existing parent

### DIFF
--- a/internal/controllers/account.go
+++ b/internal/controllers/account.go
@@ -71,7 +71,15 @@ func CreateAccount(c *gin.Context) {
 func GetAccounts(c *gin.Context) {
 	var accounts []models.Account
 
-	models.DB.Where("budget_id = ?", c.Param("budgetId")).Find(&accounts)
+	// Check if the budget exists at all
+	budgetID, err := checkBudgetExists(c, c.Param("budgetId"))
+	if err != nil {
+		return
+	}
+
+	models.DB.Where(&models.Account{
+		BudgetID: budgetID,
+	}).Find(&accounts)
 
 	for i, account := range accounts {
 		response, err := account.WithCalculations()

--- a/internal/controllers/account.go
+++ b/internal/controllers/account.go
@@ -72,13 +72,13 @@ func GetAccounts(c *gin.Context) {
 	var accounts []models.Account
 
 	// Check if the budget exists at all
-	budgetID, err := checkBudgetExists(c, c.Param("budgetId"))
+	budget, err := getBudget(c)
 	if err != nil {
 		return
 	}
 
 	models.DB.Where(&models.Account{
-		BudgetID: budgetID,
+		BudgetID: budget.ID,
 	}).Find(&accounts)
 
 	for i, account := range accounts {

--- a/internal/controllers/account_test.go
+++ b/internal/controllers/account_test.go
@@ -1,7 +1,6 @@
 package controllers_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -27,10 +26,7 @@ func TestGetAccounts(t *testing.T) {
 	recorder := test.Request(t, "GET", "/v1/budgets/1/accounts", "")
 
 	var response AccountListResponse
-	err := json.NewDecoder(recorder.Body).Decode(&response)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &response)
 
 	assert.Equal(t, 200, recorder.Code)
 	if !assert.Len(t, response.Data, 3) {
@@ -100,10 +96,7 @@ func TestCreateAccount(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var apiAccount AccountDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&apiAccount)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &apiAccount)
 
 	var dbAccount models.Account
 	models.DB.First(&dbAccount, apiAccount.Data.ID)
@@ -124,10 +117,7 @@ func TestGetAccount(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusOK, &recorder)
 
 	var account AccountDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&account)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &account)
 
 	var dbAccount models.Account
 	models.DB.First(&dbAccount, account.Data.ID)
@@ -142,10 +132,7 @@ func TestGetAccountTransactions(t *testing.T) {
 	recorder := test.Request(t, "GET", "/v1/budgets/1/accounts/1/transactions", "")
 
 	var response TransactionListResponse
-	err := json.NewDecoder(recorder.Body).Decode(&response)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &response)
 
 	assert.Equal(t, 200, recorder.Code)
 	assert.Len(t, response.Data, 3)
@@ -161,20 +148,14 @@ func TestUpdateAccount(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var account AccountDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&account)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &account)
 
 	path := fmt.Sprintf("/v1/budgets/1/accounts/%v", account.Data.ID)
 	recorder = test.Request(t, "PATCH", path, `{ "name": "Updated new account for testing" }`)
 	test.AssertHTTPStatus(t, http.StatusOK, &recorder)
 
 	var updatedAccount AccountDetailResponse
-	err = json.NewDecoder(recorder.Body).Decode(&updatedAccount)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &updatedAccount)
 
 	assert.Equal(t, "Updated new account for testing", updatedAccount.Data.Name)
 }
@@ -184,10 +165,7 @@ func TestUpdateAccountBroken(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var account AccountDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&account)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &account)
 
 	path := fmt.Sprintf("/v1/budgets/1/accounts/%v", account.Data.ID)
 	recorder = test.Request(t, "PATCH", path, `{ "name": 2" }`)
@@ -220,10 +198,7 @@ func TestDeleteAccountsAndEmptyList(t *testing.T) {
 
 	recorder = test.Request(t, "GET", "/v1/budgets/1/accounts", "")
 	var apiResponse AccountListResponse
-	err := json.NewDecoder(recorder.Body).Decode(&apiResponse)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &apiResponse)
 
 	// Verify that the account list is an empty list, not null
 	assert.NotNil(t, apiResponse.Data)
@@ -240,10 +215,7 @@ func TestDeleteAccountWithBody(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var account AccountDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&account)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &account)
 
 	path := fmt.Sprintf("/v1/budgets/1/accounts/%v", account.Data.ID)
 	recorder = test.Request(t, "DELETE", path, `{ "name": "test name 23" }`)

--- a/internal/controllers/account_test.go
+++ b/internal/controllers/account_test.go
@@ -86,6 +86,15 @@ func TestNoAccountNotFound(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
 }
 
+// TestNonexistingBudgetAccounts404 is a regression test for https://github.com/envelope-zero/backend/issues/89.
+//
+// It verifies that for a non-existing budget, the accounts endpoint raises a 404
+// instead of returning an empty list.
+func TestNonexistingBudgetAccounts404(t *testing.T) {
+	recorder := test.Request(t, "GET", "/v1/budgets/999/accounts", "")
+	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
+}
+
 func TestCreateAccount(t *testing.T) {
 	recorder := test.Request(t, "POST", "/v1/budgets/1/accounts", `{ "name": "New Account", "note": "More tests something something" }`)
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
@@ -144,15 +153,7 @@ func TestGetAccountTransactions(t *testing.T) {
 
 func TestGetAccountTransactionsNonExistingAccount(t *testing.T) {
 	recorder := test.Request(t, "GET", "/v1/budgets/1/accounts/57372/transactions", "")
-
-	var response TransactionListResponse
-	err := json.NewDecoder(recorder.Body).Decode(&response)
-	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
-
 	assert.Equal(t, 404, recorder.Code)
-	assert.Len(t, response.Data, 0)
 }
 
 func TestUpdateAccount(t *testing.T) {

--- a/internal/controllers/account_test.go
+++ b/internal/controllers/account_test.go
@@ -29,11 +29,13 @@ func TestGetAccounts(t *testing.T) {
 	var response AccountListResponse
 	err := json.NewDecoder(recorder.Body).Decode(&response)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	assert.Equal(t, 200, recorder.Code)
-	assert.Len(t, response.Data, 3)
+	if !assert.Len(t, response.Data, 3) {
+		assert.FailNow(t, "Response does not have exactly 3 items")
+	}
 
 	bankAccount := response.Data[0]
 	assert.Equal(t, uint64(1), bankAccount.BudgetID)
@@ -91,7 +93,7 @@ func TestCreateAccount(t *testing.T) {
 	var apiAccount AccountDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&apiAccount)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	var dbAccount models.Account
@@ -115,7 +117,7 @@ func TestGetAccount(t *testing.T) {
 	var account AccountDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&account)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	var dbAccount models.Account
@@ -133,7 +135,7 @@ func TestGetAccountTransactions(t *testing.T) {
 	var response TransactionListResponse
 	err := json.NewDecoder(recorder.Body).Decode(&response)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	assert.Equal(t, 200, recorder.Code)
@@ -160,7 +162,7 @@ func TestUpdateAccount(t *testing.T) {
 	var account AccountDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&account)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/1/accounts/%v", account.Data.ID)
@@ -170,7 +172,7 @@ func TestUpdateAccount(t *testing.T) {
 	var updatedAccount AccountDetailResponse
 	err = json.NewDecoder(recorder.Body).Decode(&updatedAccount)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	assert.Equal(t, "Updated new account for testing", updatedAccount.Data.Name)
@@ -183,7 +185,7 @@ func TestUpdateAccountBroken(t *testing.T) {
 	var account AccountDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&account)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/1/accounts/%v", account.Data.ID)
@@ -219,7 +221,7 @@ func TestDeleteAccountsAndEmptyList(t *testing.T) {
 	var apiResponse AccountListResponse
 	err := json.NewDecoder(recorder.Body).Decode(&apiResponse)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	// Verify that the account list is an empty list, not null
@@ -239,7 +241,7 @@ func TestDeleteAccountWithBody(t *testing.T) {
 	var account AccountDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&account)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/1/accounts/%v", account.Data.ID)

--- a/internal/controllers/allocation.go
+++ b/internal/controllers/allocation.go
@@ -76,7 +76,16 @@ func CreateAllocation(c *gin.Context) {
 // GetAllocations retrieves all allocations.
 func GetAllocations(c *gin.Context) {
 	var allocations []models.Allocation
-	models.DB.Where("envelope_id = ?", c.Param("envelopeId")).Find(&allocations)
+
+	// Check if the envelope exists
+	envelope, err := getEnvelope(c)
+	if err != nil {
+		return
+	}
+
+	models.DB.Where(&models.Allocation{
+		EnvelopeID: envelope.ID,
+	}).Find(&allocations)
 
 	c.JSON(http.StatusOK, gin.H{"data": allocations})
 }

--- a/internal/controllers/allocation_test.go
+++ b/internal/controllers/allocation_test.go
@@ -54,6 +54,33 @@ func TestNoAllocationNotFound(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
 }
 
+// TestNonexistingEnvelopeAllocations404 is a regression test for https://github.com/envelope-zero/backend/issues/89.
+//
+// It verifies that for a non-existing envelope, no matter if the category or budget exists,
+// the allocations endpoint raises a 404 instead of returning an empty list.
+func TestNonexistingEnvelopeAllocations404(t *testing.T) {
+	recorder := test.Request(t, "GET", "/v1/budgets/1/categories/1/envelopes/999/allocations", "")
+	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
+}
+
+// TestNonexistingCategoryAllocations404 is a regression test for https://github.com/envelope-zero/backend/issues/89.
+//
+// It verifies that for a non-existing category, no matter if the envelope or budget exists,
+// the allocations endpoint raises a 404 instead of returning an empty list.
+func TestNonexistingCategoryAllocations404(t *testing.T) {
+	recorder := test.Request(t, "GET", "/v1/budgets/1/categories/999/envelopes/1/allocations", "")
+	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
+}
+
+// TestNonexistingBudgetAllocations404 is a regression test for https://github.com/envelope-zero/backend/issues/89.
+//
+// It verifies that for a non-existing budget, no matter if the envelope or category exists,
+// the allocations endpoint raises a 404 instead of returning an empty list.
+func TestNonexistingBudgetAllocations404(t *testing.T) {
+	recorder := test.Request(t, "GET", "/v1/budgets/999/categories/1/envelopes/1/allocations", "")
+	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
+}
+
 func TestCreateAllocation(t *testing.T) {
 	recorder := test.Request(t, "POST", "/v1/budgets/1/categories/1/envelopes/1/allocations", `{ "month": 10, "year": 2022, "amount": 15.42 }`)
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)

--- a/internal/controllers/allocation_test.go
+++ b/internal/controllers/allocation_test.go
@@ -29,11 +29,14 @@ func TestGetAllocations(t *testing.T) {
 	var response AllocationListResponse
 	err := json.NewDecoder(recorder.Body).Decode(&response)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	assert.Equal(t, 200, recorder.Code)
-	assert.Len(t, response.Data, 3)
+	if !assert.Len(t, response.Data, 3) {
+		assert.FailNow(t, "Response does not have exactly 3 items")
+	}
+
 	assert.Equal(t, uint64(1), response.Data[0].EnvelopeID)
 	assert.Equal(t, uint8(1), response.Data[0].Month)
 	assert.Equal(t, uint(2022), response.Data[0].Year)
@@ -62,7 +65,7 @@ func TestCreateAllocation(t *testing.T) {
 	var apiAllocation AllocationDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&apiAllocation)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	var dbAllocation models.Allocation
@@ -106,7 +109,7 @@ func TestGetAllocation(t *testing.T) {
 	var allocation AllocationDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&allocation)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	var dbAllocation models.Allocation
@@ -122,7 +125,7 @@ func TestUpdateAllocation(t *testing.T) {
 	var allocation AllocationDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&allocation)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/1/envelopes/1/allocations/%v", allocation.Data.ID)
@@ -132,7 +135,7 @@ func TestUpdateAllocation(t *testing.T) {
 	var updatedAllocation AllocationDetailResponse
 	err = json.NewDecoder(recorder.Body).Decode(&updatedAllocation)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	assert.Equal(t, uint(2022), updatedAllocation.Data.Year)
@@ -145,7 +148,7 @@ func TestUpdateAllocationBroken(t *testing.T) {
 	var allocation AllocationDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&allocation)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/1/envelopes/1/allocations/%v", allocation.Data.ID)
@@ -175,7 +178,7 @@ func TestDeleteAllocationWithBody(t *testing.T) {
 	var allocation AllocationDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&allocation)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/1/envelopes/1/allocations/%v", allocation.Data.ID)

--- a/internal/controllers/allocation_test.go
+++ b/internal/controllers/allocation_test.go
@@ -1,7 +1,6 @@
 package controllers_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -27,10 +26,7 @@ func TestGetAllocations(t *testing.T) {
 	recorder := test.Request(t, "GET", "/v1/budgets/1/categories/1/envelopes/1/allocations", "")
 
 	var response AllocationListResponse
-	err := json.NewDecoder(recorder.Body).Decode(&response)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &response)
 
 	assert.Equal(t, 200, recorder.Code)
 	if !assert.Len(t, response.Data, 3) {
@@ -63,10 +59,7 @@ func TestCreateAllocation(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var apiAllocation AllocationDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&apiAllocation)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &apiAllocation)
 
 	var dbAllocation models.Allocation
 	models.DB.First(&dbAllocation, apiAllocation.Data.ID)
@@ -107,10 +100,7 @@ func TestGetAllocation(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusOK, &recorder)
 
 	var allocation AllocationDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&allocation)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &allocation)
 
 	var dbAllocation models.Allocation
 	models.DB.First(&dbAllocation, allocation.Data.ID)
@@ -123,20 +113,14 @@ func TestUpdateAllocation(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var allocation AllocationDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&allocation)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &allocation)
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/1/envelopes/1/allocations/%v", allocation.Data.ID)
 	recorder = test.Request(t, "PATCH", path, `{  "year": 2022 }`)
 	test.AssertHTTPStatus(t, http.StatusOK, &recorder)
 
 	var updatedAllocation AllocationDetailResponse
-	err = json.NewDecoder(recorder.Body).Decode(&updatedAllocation)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &updatedAllocation)
 
 	assert.Equal(t, uint(2022), updatedAllocation.Data.Year)
 }
@@ -146,10 +130,7 @@ func TestUpdateAllocationBroken(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var allocation AllocationDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&allocation)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &allocation)
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/1/envelopes/1/allocations/%v", allocation.Data.ID)
 	recorder = test.Request(t, "PATCH", path, `{ "name": 2" }`)
@@ -176,10 +157,7 @@ func TestDeleteAllocationWithBody(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var allocation AllocationDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&allocation)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &allocation)
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/1/envelopes/1/allocations/%v", allocation.Data.ID)
 	recorder = test.Request(t, "DELETE", path, `{ "name": "test name 23" }`)

--- a/internal/controllers/budget.go
+++ b/internal/controllers/budget.go
@@ -58,10 +58,8 @@ func GetBudgets(c *gin.Context) {
 
 // GetBudget retrieves a budget by its ID.
 func GetBudget(c *gin.Context) {
-	var budget models.Budget
-	err := models.DB.First(&budget, c.Param("budgetId")).Error
+	budget, err := getBudget(c)
 	if err != nil {
-		FetchErrorHandler(c, err)
 		return
 	}
 

--- a/internal/controllers/budget_test.go
+++ b/internal/controllers/budget_test.go
@@ -28,11 +28,14 @@ func TestGetBudgets(t *testing.T) {
 	var response BudgetListResponse
 	err := json.NewDecoder(recorder.Body).Decode(&response)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	assert.Equal(t, 200, recorder.Code)
-	assert.Len(t, response.Data, 1)
+	if !assert.Len(t, response.Data, 1) {
+		assert.FailNow(t, "Response does not have exactly 1 item")
+	}
+
 	assert.Equal(t, "Testing Budget", response.Data[0].Name)
 	assert.Equal(t, "GNU: Terry Pratchett", response.Data[0].Note)
 
@@ -56,7 +59,7 @@ func TestCreateBudget(t *testing.T) {
 	var apiBudget BudgetDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&apiBudget)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	var dbBudget models.Budget
@@ -82,7 +85,7 @@ func TestGetBudget(t *testing.T) {
 	var budget BudgetDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&budget)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	var dbBudget models.Budget
@@ -98,7 +101,7 @@ func TestUpdateBudget(t *testing.T) {
 	var budget BudgetDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&budget)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/%v", budget.Data.ID)
@@ -108,7 +111,7 @@ func TestUpdateBudget(t *testing.T) {
 	var updatedBudget BudgetDetailResponse
 	err = json.NewDecoder(recorder.Body).Decode(&updatedBudget)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	assert.Equal(t, budget.Data.Note, updatedBudget.Data.Note)
@@ -122,7 +125,7 @@ func TestUpdateBudgetBroken(t *testing.T) {
 	var budget BudgetDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&budget)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/%v", budget.Data.ID)
@@ -136,7 +139,17 @@ func TestUpdateNonExistingBudget(t *testing.T) {
 }
 
 func TestDeleteBudget(t *testing.T) {
-	recorder := test.Request(t, "DELETE", "/v1/budgets/1", "")
+	recorder := test.Request(t, "POST", "/v1/budgets", `{ "name": "Delete me now!" }`)
+	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
+
+	var budget BudgetDetailResponse
+	err := json.NewDecoder(recorder.Body).Decode(&budget)
+	if err != nil {
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+	}
+
+	path := fmt.Sprintf("/v1/budgets/%v", budget.Data.ID)
+	recorder = test.Request(t, "DELETE", path, "")
 	test.AssertHTTPStatus(t, http.StatusNoContent, &recorder)
 }
 
@@ -152,7 +165,7 @@ func TestDeleteBudgetWithBody(t *testing.T) {
 	var budget BudgetDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&budget)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/%v", budget.Data.ID)

--- a/internal/controllers/budget_test.go
+++ b/internal/controllers/budget_test.go
@@ -1,7 +1,6 @@
 package controllers_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -26,10 +25,7 @@ func TestGetBudgets(t *testing.T) {
 	recorder := test.Request(t, "GET", "/v1/budgets", "")
 
 	var response BudgetListResponse
-	err := json.NewDecoder(recorder.Body).Decode(&response)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &response)
 
 	assert.Equal(t, 200, recorder.Code)
 	if !assert.Len(t, response.Data, 1) {
@@ -57,10 +53,7 @@ func TestCreateBudget(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var apiBudget BudgetDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&apiBudget)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &apiBudget)
 
 	var dbBudget models.Budget
 	models.DB.First(&dbBudget, apiBudget.Data.ID)
@@ -83,10 +76,7 @@ func TestGetBudget(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusOK, &recorder)
 
 	var budget BudgetDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&budget)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &budget)
 
 	var dbBudget models.Budget
 	models.DB.First(&dbBudget, budget.Data.ID)
@@ -99,20 +89,14 @@ func TestUpdateBudget(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var budget BudgetDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&budget)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &budget)
 
 	path := fmt.Sprintf("/v1/budgets/%v", budget.Data.ID)
 	recorder = test.Request(t, "PATCH", path, `{ "name": "Updated new budget" }`)
 	test.AssertHTTPStatus(t, http.StatusOK, &recorder)
 
 	var updatedBudget BudgetDetailResponse
-	err = json.NewDecoder(recorder.Body).Decode(&updatedBudget)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &updatedBudget)
 
 	assert.Equal(t, budget.Data.Note, updatedBudget.Data.Note)
 	assert.Equal(t, "Updated new budget", updatedBudget.Data.Name)
@@ -123,10 +107,7 @@ func TestUpdateBudgetBroken(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var budget BudgetDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&budget)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &budget)
 
 	path := fmt.Sprintf("/v1/budgets/%v", budget.Data.ID)
 	recorder = test.Request(t, "PATCH", path, `{ "name": 2" }`)
@@ -143,10 +124,7 @@ func TestDeleteBudget(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var budget BudgetDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&budget)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &budget)
 
 	path := fmt.Sprintf("/v1/budgets/%v", budget.Data.ID)
 	recorder = test.Request(t, "DELETE", path, "")
@@ -163,10 +141,7 @@ func TestDeleteBudgetWithBody(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var budget BudgetDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&budget)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &budget)
 
 	path := fmt.Sprintf("/v1/budgets/%v", budget.Data.ID)
 	recorder = test.Request(t, "DELETE", path, `{ "name": "test name 23" }`)

--- a/internal/controllers/category.go
+++ b/internal/controllers/category.go
@@ -20,7 +20,7 @@ func RegisterCategoryRoutes(r *gin.RouterGroup) {
 		r.POST("", CreateCategory)
 	}
 
-	// Transaction with ID
+	// Category with ID
 	{
 		r.OPTIONS("/:categoryId", func(c *gin.Context) {
 			c.Header("allow", "GET, PATCH, DELETE")
@@ -51,7 +51,16 @@ func CreateCategory(c *gin.Context) {
 // GetCategories retrieves all categories.
 func GetCategories(c *gin.Context) {
 	var categories []models.Category
-	models.DB.Where("budget_id = ?", c.Param("budgetId")).Find(&categories)
+
+	// Check if the budget exists at all
+	budgetID, err := checkBudgetExists(c, c.Param("budgetId"))
+	if err != nil {
+		return
+	}
+
+	models.DB.Where(&models.Category{
+		BudgetID: budgetID,
+	}).Find(&categories)
 
 	c.JSON(http.StatusOK, gin.H{"data": categories})
 }

--- a/internal/controllers/category.go
+++ b/internal/controllers/category.go
@@ -53,13 +53,13 @@ func GetCategories(c *gin.Context) {
 	var categories []models.Category
 
 	// Check if the budget exists at all
-	budgetID, err := checkBudgetExists(c, c.Param("budgetId"))
+	budget, err := getBudget(c)
 	if err != nil {
 		return
 	}
 
 	models.DB.Where(&models.Category{
-		BudgetID: budgetID,
+		BudgetID: budget.ID,
 	}).Find(&categories)
 
 	c.JSON(http.StatusOK, gin.H{"data": categories})
@@ -67,10 +67,8 @@ func GetCategories(c *gin.Context) {
 
 // GetCategory retrieves a category by its ID.
 func GetCategory(c *gin.Context) {
-	var category models.Category
-	err := models.DB.First(&category, c.Param("categoryId")).Error
+	category, err := getCategory(c)
 	if err != nil {
-		FetchErrorHandler(c, err)
 		return
 	}
 

--- a/internal/controllers/category_test.go
+++ b/internal/controllers/category_test.go
@@ -1,7 +1,6 @@
 package controllers_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -26,10 +25,7 @@ func TestGetCategories(t *testing.T) {
 	recorder := test.Request(t, "GET", "/v1/budgets/1/categories", "")
 
 	var response CategoryListResponse
-	err := json.NewDecoder(recorder.Body).Decode(&response)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body.String(), err)
-	}
+	test.DecodeResponse(t, &recorder, &response)
 
 	assert.Equal(t, 200, recorder.Code)
 	if !assert.Len(t, response.Data, 1) {
@@ -67,10 +63,7 @@ func TestCreateCategory(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var apiCategory CategoryDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&apiCategory)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &apiCategory)
 
 	var dbCategory models.Category
 	models.DB.First(&dbCategory, apiCategory.Data.ID)
@@ -93,10 +86,7 @@ func TestGetCategory(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusOK, &recorder)
 
 	var category CategoryDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&category)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &category)
 
 	var dbCategory models.Category
 	models.DB.First(&dbCategory, category.Data.ID)
@@ -109,20 +99,14 @@ func TestUpdateCategory(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var category CategoryDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&category)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &category)
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/%v", category.Data.ID)
 	recorder = test.Request(t, "PATCH", path, `{ "name": "Updated new category for testing" }`)
 	test.AssertHTTPStatus(t, http.StatusOK, &recorder)
 
 	var updatedCategory CategoryDetailResponse
-	err = json.NewDecoder(recorder.Body).Decode(&updatedCategory)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &updatedCategory)
 
 	assert.Equal(t, category.Data.Note, updatedCategory.Data.Note)
 	assert.Equal(t, "Updated new category for testing", updatedCategory.Data.Name)
@@ -133,10 +117,7 @@ func TestUpdateCategoryBroken(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var category CategoryDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&category)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &category)
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/%v", category.Data.ID)
 	recorder = test.Request(t, "PATCH", path, `{ "name": 2" }`)
@@ -163,10 +144,7 @@ func TestDeleteCategoryWithBody(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var category CategoryDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&category)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &category)
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/%v", category.Data.ID)
 	recorder = test.Request(t, "DELETE", path, `{ "name": "test name 23" }`)

--- a/internal/controllers/category_test.go
+++ b/internal/controllers/category_test.go
@@ -130,7 +130,14 @@ func TestUpdateNonExistingCategory(t *testing.T) {
 }
 
 func TestDeleteCategory(t *testing.T) {
-	recorder := test.Request(t, "DELETE", "/v1/budgets/1/categories/1", "")
+	recorder := test.Request(t, "POST", "/v1/budgets/1/categories", `{ "name": "Delete me now!" }`)
+	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
+
+	var category CategoryDetailResponse
+	test.DecodeResponse(t, &recorder, &category)
+
+	path := fmt.Sprintf("/v1/budgets/1/categories/%v", category.Data.ID)
+	recorder = test.Request(t, "DELETE", path, "")
 	test.AssertHTTPStatus(t, http.StatusNoContent, &recorder)
 }
 

--- a/internal/controllers/category_test.go
+++ b/internal/controllers/category_test.go
@@ -53,6 +53,15 @@ func TestNoCategoryNotFound(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
 }
 
+// TestNonexistingBudgetCategories404 is a regression test for https://github.com/envelope-zero/backend/issues/89.
+//
+// It verifies that for a non-existing budget, the accounts endpoint raises a 404
+// instead of returning an empty list.
+func TestNonexistingBudgetCategories404(t *testing.T) {
+	recorder := test.Request(t, "GET", "/v1/budgets/999/categories", "")
+	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
+}
+
 func TestCreateCategory(t *testing.T) {
 	recorder := test.Request(t, "POST", "/v1/budgets/1/categories", `{ "name": "New Category", "note": "More tests something something" }`)
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)

--- a/internal/controllers/category_test.go
+++ b/internal/controllers/category_test.go
@@ -28,11 +28,14 @@ func TestGetCategories(t *testing.T) {
 	var response CategoryListResponse
 	err := json.NewDecoder(recorder.Body).Decode(&response)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body.String(), err)
 	}
 
 	assert.Equal(t, 200, recorder.Code)
-	assert.Len(t, response.Data, 1)
+	if !assert.Len(t, response.Data, 1) {
+		assert.FailNow(t, "Response does not have exactly 1 item")
+	}
+
 	assert.Equal(t, uint64(1), response.Data[0].BudgetID)
 	assert.Equal(t, "Running costs", response.Data[0].Name)
 	assert.Equal(t, "For e.g. groceries and energy bills", response.Data[0].Note)
@@ -57,7 +60,7 @@ func TestCreateCategory(t *testing.T) {
 	var apiCategory CategoryDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&apiCategory)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	var dbCategory models.Category
@@ -83,7 +86,7 @@ func TestGetCategory(t *testing.T) {
 	var category CategoryDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&category)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	var dbCategory models.Category
@@ -99,7 +102,7 @@ func TestUpdateCategory(t *testing.T) {
 	var category CategoryDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&category)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/%v", category.Data.ID)
@@ -109,7 +112,7 @@ func TestUpdateCategory(t *testing.T) {
 	var updatedCategory CategoryDetailResponse
 	err = json.NewDecoder(recorder.Body).Decode(&updatedCategory)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	assert.Equal(t, category.Data.Note, updatedCategory.Data.Note)
@@ -123,7 +126,7 @@ func TestUpdateCategoryBroken(t *testing.T) {
 	var category CategoryDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&category)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/%v", category.Data.ID)
@@ -153,7 +156,7 @@ func TestDeleteCategoryWithBody(t *testing.T) {
 	var category CategoryDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&category)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/%v", category.Data.ID)

--- a/internal/controllers/envelope.go
+++ b/internal/controllers/envelope.go
@@ -51,17 +51,24 @@ func CreateEnvelope(c *gin.Context) {
 // GetEnvelopes retrieves all envelopes.
 func GetEnvelopes(c *gin.Context) {
 	var envelopes []models.Envelope
-	models.DB.Where("category_id = ?", c.Param("categoryId")).Find(&envelopes)
+
+	// Check if the category exists at all
+	category, err := getCategory(c)
+	if err != nil {
+		return
+	}
+
+	models.DB.Where(&models.Envelope{
+		CategoryID: category.ID,
+	}).Find(&envelopes)
 
 	c.JSON(http.StatusOK, gin.H{"data": envelopes})
 }
 
 // GetEnvelope retrieves a envelope by its ID.
 func GetEnvelope(c *gin.Context) {
-	var envelope models.Envelope
-	err := models.DB.First(&envelope, c.Param("envelopeId")).Error
+	envelope, err := getEnvelope(c)
 	if err != nil {
-		FetchErrorHandler(c, err)
 		return
 	}
 

--- a/internal/controllers/envelope_test.go
+++ b/internal/controllers/envelope_test.go
@@ -28,11 +28,14 @@ func TestGetEnvelopes(t *testing.T) {
 	var response EnvelopeListResponse
 	err := json.NewDecoder(recorder.Body).Decode(&response)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	assert.Equal(t, 200, recorder.Code)
-	assert.Len(t, response.Data, 1)
+	if !assert.Len(t, response.Data, 1) {
+		assert.FailNow(t, "Response does not have exactly 1 item")
+	}
+
 	assert.Equal(t, uint64(1), response.Data[0].CategoryID)
 	assert.Equal(t, "Utilities", response.Data[0].Name)
 	assert.Equal(t, "Energy & Water", response.Data[0].Note)
@@ -57,7 +60,7 @@ func TestCreateEnvelope(t *testing.T) {
 	var apiEnvelope EnvelopeDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&apiEnvelope)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	var dbEnvelope models.Envelope
@@ -83,7 +86,7 @@ func TestGetEnvelope(t *testing.T) {
 	var envelope EnvelopeDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&envelope)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	var dbEnvelope models.Envelope
@@ -99,7 +102,7 @@ func TestUpdateEnvelope(t *testing.T) {
 	var envelope EnvelopeDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&envelope)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/1/envelopes/%v", envelope.Data.ID)
@@ -109,7 +112,7 @@ func TestUpdateEnvelope(t *testing.T) {
 	var updatedEnvelope EnvelopeDetailResponse
 	err = json.NewDecoder(recorder.Body).Decode(&updatedEnvelope)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	assert.Equal(t, envelope.Data.Note, updatedEnvelope.Data.Note)
@@ -123,7 +126,7 @@ func TestUpdateEnvelopeBroken(t *testing.T) {
 	var envelope EnvelopeDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&envelope)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/1/envelopes/%v", envelope.Data.ID)
@@ -153,7 +156,7 @@ func TestDeleteEnvelopeWithBody(t *testing.T) {
 	var envelope EnvelopeDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&envelope)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/1/envelopes/%v", envelope.Data.ID)

--- a/internal/controllers/envelope_test.go
+++ b/internal/controllers/envelope_test.go
@@ -1,7 +1,6 @@
 package controllers_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -26,10 +25,7 @@ func TestGetEnvelopes(t *testing.T) {
 	recorder := test.Request(t, "GET", "/v1/budgets/1/categories/1/envelopes", "")
 
 	var response EnvelopeListResponse
-	err := json.NewDecoder(recorder.Body).Decode(&response)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &response)
 
 	assert.Equal(t, 200, recorder.Code)
 	if !assert.Len(t, response.Data, 1) {
@@ -58,10 +54,7 @@ func TestCreateEnvelope(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var apiEnvelope EnvelopeDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&apiEnvelope)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &apiEnvelope)
 
 	var dbEnvelope models.Envelope
 	models.DB.First(&dbEnvelope, apiEnvelope.Data.ID)
@@ -84,10 +77,7 @@ func TestGetEnvelope(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusOK, &recorder)
 
 	var envelope EnvelopeDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&envelope)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &envelope)
 
 	var dbEnvelope models.Envelope
 	models.DB.First(&dbEnvelope, envelope.Data.ID)
@@ -100,20 +90,14 @@ func TestUpdateEnvelope(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var envelope EnvelopeDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&envelope)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &envelope)
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/1/envelopes/%v", envelope.Data.ID)
 	recorder = test.Request(t, "PATCH", path, `{ "name": "Updated new envelope for testing" }`)
 	test.AssertHTTPStatus(t, http.StatusOK, &recorder)
 
 	var updatedEnvelope EnvelopeDetailResponse
-	err = json.NewDecoder(recorder.Body).Decode(&updatedEnvelope)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &updatedEnvelope)
 
 	assert.Equal(t, envelope.Data.Note, updatedEnvelope.Data.Note)
 	assert.Equal(t, "Updated new envelope for testing", updatedEnvelope.Data.Name)
@@ -124,10 +108,7 @@ func TestUpdateEnvelopeBroken(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var envelope EnvelopeDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&envelope)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &envelope)
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/1/envelopes/%v", envelope.Data.ID)
 	recorder = test.Request(t, "PATCH", path, `{ "name": 2" }`)
@@ -154,10 +135,7 @@ func TestDeleteEnvelopeWithBody(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var envelope EnvelopeDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&envelope)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &envelope)
 
 	path := fmt.Sprintf("/v1/budgets/1/categories/1/envelopes/%v", envelope.Data.ID)
 	recorder = test.Request(t, "DELETE", path, `{ "name": "test name 23" }`)

--- a/internal/controllers/envelope_test.go
+++ b/internal/controllers/envelope_test.go
@@ -49,6 +49,24 @@ func TestNoEnvelopeNotFound(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
 }
 
+// TestNonexistingCategoryEnvelopes404 is a regression test for https://github.com/envelope-zero/backend/issues/89.
+//
+// It verifies that for a non-existing category, the envelopes endpoint raises a 404
+// instead of returning an empty list.
+func TestNonexistingCategoryEnvelopes404(t *testing.T) {
+	recorder := test.Request(t, "GET", "/v1/budgets/1/categories/999/envelopes", "")
+	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
+}
+
+// TestNonexistingBudgetEnvelopes404 is a regression test for https://github.com/envelope-zero/backend/issues/89.
+//
+// It verifies that for a non-existing budget, no matter if the category with the ID exists,
+// the envelopes endpoint raises a 404 instead of returning an empty list.
+func TestNonexistingBudgetEnvelopes404(t *testing.T) {
+	recorder := test.Request(t, "GET", "/v1/budgets/999/categories/1/envelopes", "")
+	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
+}
+
 func TestCreateEnvelope(t *testing.T) {
 	recorder := test.Request(t, "POST", "/v1/budgets/1/categories/1/envelopes", `{ "name": "New Envelope", "note": "More tests something something" }`)
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)

--- a/internal/controllers/helper_test.go
+++ b/internal/controllers/helper_test.go
@@ -1,7 +1,6 @@
 package controllers_test
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/envelope-zero/backend/internal/test"
@@ -12,10 +11,7 @@ func TestRequestURLHTTPS(t *testing.T) {
 	recorder := test.Request(t, "GET", "/v1", "", map[string]string{"x-forwarded-proto": "https"})
 
 	var apiResponse test.APIResponse
-	err := json.NewDecoder(recorder.Body).Decode(&apiResponse)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &apiResponse)
 
 	assert.Equal(t, "https:///v1/budgets", apiResponse.Links["budgets"])
 }
@@ -24,10 +20,7 @@ func TestRequestForwardedPrefix(t *testing.T) {
 	recorder := test.Request(t, "GET", "/v1", "", map[string]string{"x-forwarded-prefix": "/api"})
 
 	var apiResponse test.APIResponse
-	err := json.NewDecoder(recorder.Body).Decode(&apiResponse)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &apiResponse)
 
 	assert.Equal(t, "http:///api/v1/budgets", apiResponse.Links["budgets"])
 }

--- a/internal/controllers/helper_test.go
+++ b/internal/controllers/helper_test.go
@@ -14,7 +14,7 @@ func TestRequestURLHTTPS(t *testing.T) {
 	var apiResponse test.APIResponse
 	err := json.NewDecoder(recorder.Body).Decode(&apiResponse)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIResponse, '%v'", recorder.Body, err)
 	}
 
 	assert.Equal(t, "https:///v1/budgets", apiResponse.Links["budgets"])
@@ -26,7 +26,7 @@ func TestRequestForwardedPrefix(t *testing.T) {
 	var apiResponse test.APIResponse
 	err := json.NewDecoder(recorder.Body).Decode(&apiResponse)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIResponse, '%v'", recorder.Body, err)
 	}
 
 	assert.Equal(t, "http:///api/v1/budgets", apiResponse.Links["budgets"])

--- a/internal/controllers/main_error_handler_test.go
+++ b/internal/controllers/main_error_handler_test.go
@@ -1,7 +1,6 @@
 package controllers_test
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -21,10 +20,7 @@ func TestFetchErrorHandler(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusInternalServerError, recorder)
 
 	var apiResponse test.APIResponse
-	err := json.NewDecoder(recorder.Body).Decode(&apiResponse)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, recorder, &apiResponse)
 
 	assert.Equal(t, "An error occured on the server during your request, please contact your server administrator. The request id is '', send this to your server administrator to help them finding the problem.", apiResponse.Error)
 }

--- a/internal/controllers/main_error_handler_test.go
+++ b/internal/controllers/main_error_handler_test.go
@@ -23,7 +23,7 @@ func TestFetchErrorHandler(t *testing.T) {
 	var apiResponse test.APIResponse
 	err := json.NewDecoder(recorder.Body).Decode(&apiResponse)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	assert.Equal(t, "An error occured on the server during your request, please contact your server administrator. The request id is '', send this to your server administrator to help them finding the problem.", apiResponse.Error)

--- a/internal/controllers/transaction.go
+++ b/internal/controllers/transaction.go
@@ -56,7 +56,16 @@ func CreateTransaction(c *gin.Context) {
 // GetTransactions retrieves all transactions.
 func GetTransactions(c *gin.Context) {
 	var transactions []models.Transaction
-	models.DB.Where("budget_id = ?", c.Param("budgetId")).Find(&transactions)
+
+	// Check if the budget exists at all
+	budgetID, err := checkBudgetExists(c, c.Param("budgetId"))
+	if err != nil {
+		return
+	}
+
+	models.DB.Where(&models.Category{
+		BudgetID: budgetID,
+	}).Find(&transactions)
 
 	c.JSON(http.StatusOK, gin.H{"data": transactions})
 }

--- a/internal/controllers/transaction.go
+++ b/internal/controllers/transaction.go
@@ -58,13 +58,13 @@ func GetTransactions(c *gin.Context) {
 	var transactions []models.Transaction
 
 	// Check if the budget exists at all
-	budgetID, err := checkBudgetExists(c, c.Param("budgetId"))
+	budget, err := getBudget(c)
 	if err != nil {
 		return
 	}
 
 	models.DB.Where(&models.Category{
-		BudgetID: budgetID,
+		BudgetID: budget.ID,
 	}).Find(&transactions)
 
 	c.JSON(http.StatusOK, gin.H{"data": transactions})

--- a/internal/controllers/transaction_test.go
+++ b/internal/controllers/transaction_test.go
@@ -1,7 +1,6 @@
 package controllers_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -27,10 +26,7 @@ func TestGetTransactions(t *testing.T) {
 	recorder := test.Request(t, "GET", "/v1/budgets/1/transactions", "")
 
 	var response TransactionListResponse
-	err := json.NewDecoder(recorder.Body).Decode(&response)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &response)
 
 	assert.Equal(t, 200, recorder.Code)
 	if !assert.Len(t, response.Data, 3) {
@@ -99,10 +95,7 @@ func TestCreateTransaction(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var apiTransaction TransactionDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&apiTransaction)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &apiTransaction)
 
 	var dbTransaction models.Transaction
 	models.DB.First(&dbTransaction, apiTransaction.Data.ID)
@@ -138,10 +131,7 @@ func TestGetTransaction(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusOK, &recorder)
 
 	var transaction TransactionDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&transaction)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &transaction)
 
 	var dbTransaction models.Transaction
 	models.DB.First(&dbTransaction, transaction.Data.ID)
@@ -161,20 +151,14 @@ func TestUpdateTransaction(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var transaction TransactionDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&transaction)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &transaction)
 
 	path := fmt.Sprintf("/v1/budgets/1/transactions/%v", transaction.Data.ID)
 	recorder = test.Request(t, "PATCH", path, `{ "note": "Updated new transaction for testing" }`)
 	test.AssertHTTPStatus(t, http.StatusOK, &recorder)
 
 	var updatedTransaction TransactionDetailResponse
-	err = json.NewDecoder(recorder.Body).Decode(&updatedTransaction)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &updatedTransaction)
 
 	assert.Equal(t, "Updated new transaction for testing", updatedTransaction.Data.Note)
 }
@@ -184,10 +168,7 @@ func TestUpdateTransactionBroken(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var transaction TransactionDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&transaction)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &transaction)
 
 	path := fmt.Sprintf("/v1/budgets/1/transactions/%v", transaction.Data.ID)
 	recorder = test.Request(t, "PATCH", path, `{ "note": 2" }`)
@@ -199,10 +180,7 @@ func TestUpdateTransactionNegativeAmount(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var transaction TransactionDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&transaction)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &transaction)
 
 	path := fmt.Sprintf("/v1/budgets/1/transactions/%v", transaction.Data.ID)
 	recorder = test.Request(t, "PATCH", path, `{ "amount": -58.23 }`)
@@ -229,10 +207,7 @@ func TestDeleteTransactionWithBody(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)
 
 	var transaction TransactionDetailResponse
-	err := json.NewDecoder(recorder.Body).Decode(&transaction)
-	if err != nil {
-		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
-	}
+	test.DecodeResponse(t, &recorder, &transaction)
 
 	path := fmt.Sprintf("/v1/budgets/1/transactions/%v", transaction.Data.ID)
 	recorder = test.Request(t, "DELETE", path, `{ "name": "test name 23" }`)

--- a/internal/controllers/transaction_test.go
+++ b/internal/controllers/transaction_test.go
@@ -29,11 +29,13 @@ func TestGetTransactions(t *testing.T) {
 	var response TransactionListResponse
 	err := json.NewDecoder(recorder.Body).Decode(&response)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	assert.Equal(t, 200, recorder.Code)
-	assert.Len(t, response.Data, 3)
+	if !assert.Len(t, response.Data, 3) {
+		assert.FailNow(t, "Response does not have exactly 3 items")
+	}
 
 	januaryTransaction := response.Data[0]
 	assert.Equal(t, uint64(1), januaryTransaction.BudgetID)
@@ -90,7 +92,7 @@ func TestCreateTransaction(t *testing.T) {
 	var apiTransaction TransactionDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&apiTransaction)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	var dbTransaction models.Transaction
@@ -129,7 +131,7 @@ func TestGetTransaction(t *testing.T) {
 	var transaction TransactionDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&transaction)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	var dbTransaction models.Transaction
@@ -152,7 +154,7 @@ func TestUpdateTransaction(t *testing.T) {
 	var transaction TransactionDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&transaction)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/1/transactions/%v", transaction.Data.ID)
@@ -162,7 +164,7 @@ func TestUpdateTransaction(t *testing.T) {
 	var updatedTransaction TransactionDetailResponse
 	err = json.NewDecoder(recorder.Body).Decode(&updatedTransaction)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	assert.Equal(t, "Updated new transaction for testing", updatedTransaction.Data.Note)
@@ -175,7 +177,7 @@ func TestUpdateTransactionBroken(t *testing.T) {
 	var transaction TransactionDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&transaction)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/1/transactions/%v", transaction.Data.ID)
@@ -190,7 +192,7 @@ func TestUpdateTransactionNegativeAmount(t *testing.T) {
 	var transaction TransactionDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&transaction)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/1/transactions/%v", transaction.Data.ID)
@@ -220,7 +222,7 @@ func TestDeleteTransactionWithBody(t *testing.T) {
 	var transaction TransactionDetailResponse
 	err := json.NewDecoder(recorder.Body).Decode(&transaction)
 	if err != nil {
-		assert.Fail(t, "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
+		assert.Fail(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", recorder.Body, err)
 	}
 
 	path := fmt.Sprintf("/v1/budgets/1/transactions/%v", transaction.Data.ID)

--- a/internal/controllers/transaction_test.go
+++ b/internal/controllers/transaction_test.go
@@ -85,6 +85,15 @@ func TestNoTransactionNotFound(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
 }
 
+// TestNonexistingBudgetTransactions404 is a regression test for https://github.com/envelope-zero/backend/issues/89.
+//
+// It verifies that for a non-existing budget, the accounts endpoint raises a 404
+// instead of returning an empty list.
+func TestNonexistingBudgetTransactions404(t *testing.T) {
+	recorder := test.Request(t, "GET", "/v1/budgets/999/transactions", "")
+	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
+}
+
 func TestCreateTransaction(t *testing.T) {
 	recorder := test.Request(t, "POST", "/v1/budgets/1/transactions", `{ "note": "More tests something something", "amount": 1253.17 }`)
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -50,4 +51,12 @@ func Request(t *testing.T, method, url, body string, headers ...map[string]strin
 
 func AssertHTTPStatus(t *testing.T, expected int, r *httptest.ResponseRecorder, args ...string) {
 	assert.Equal(t, expected, r.Code, "Status is '%v', body is '%v'. Additional context: %v", r.Code, r.Body.String(), strings.Join(args, " "))
+}
+
+// DecodeResponse decodes an HTTP response into a target struct.
+func DecodeResponse(t *testing.T, r *httptest.ResponseRecorder, target interface{}) {
+	err := json.NewDecoder(r.Body).Decode(target)
+	if err != nil {
+		assert.FailNow(t, "Parsing error", "Unable to parse response from server %q into APIListResponse, '%v'", r.Body, err)
+	}
 }

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -32,7 +32,7 @@ func Request(t *testing.T, method, url, body string, headers ...map[string]strin
 	os.Setenv("LOG_FORMAT", "human")
 	router, err := controllers.Router()
 	if err != nil {
-		t.Fatal(err)
+		assert.FailNow(t, "Router could not be initialized")
 	}
 
 	recorder := httptest.NewRecorder()

--- a/internal/test/helpers_test.go
+++ b/internal/test/helpers_test.go
@@ -11,3 +11,10 @@ func TestRequest(t *testing.T) {
 	recorder := test.Request(t, "GET", "/v1", "", map[string]string{"x-helper-id": "17481"})
 	test.AssertHTTPStatus(t, http.StatusOK, &recorder)
 }
+
+func TestDecodeResponse(t *testing.T) {
+	var budgets test.APIResponse
+
+	r := test.Request(t, "GET", "/v1/budgets", "")
+	test.DecodeResponse(t, &r, &budgets)
+}


### PR DESCRIPTION
This contains multiple commits, improving tests and resolving #89.

- test: improve tests with better output and less cross-dependencies
- fix: return 404 for endpoints of non-existing budgets
- test: deduplicate test code
- fix: verify that parent resource exists before returning child
