### PR TITLE
fix: check parent for account

### DIFF
--- a/internal/controllers/account.go
+++ b/internal/controllers/account.go
@@ -96,10 +96,8 @@ func GetAccounts(c *gin.Context) {
 
 // GetAccount retrieves an account by its ID.
 func GetAccount(c *gin.Context) {
-	var account models.Account
-	err := models.DB.First(&account, c.Param("accountId")).Error
+	account, err := getAccount(c)
 	if err != nil {
-		FetchErrorHandler(c, err)
 		return
 	}
 

--- a/internal/controllers/allocation.go
+++ b/internal/controllers/allocation.go
@@ -92,10 +92,8 @@ func GetAllocations(c *gin.Context) {
 
 // GetAllocation retrieves a allocation by its ID.
 func GetAllocation(c *gin.Context) {
-	var allocation models.Allocation
-	err := models.DB.First(&allocation, c.Param("allocationId")).Error
+	allocation, err := getAllocation(c)
 	if err != nil {
-		FetchErrorHandler(c, err)
 		return
 	}
 

--- a/internal/controllers/budget_test.go
+++ b/internal/controllers/budget_test.go
@@ -48,6 +48,16 @@ func TestNoBudgetNotFound(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
 }
 
+// TestBudgetInvalidIDs verifies that on non-number requests for budget IDs,
+// the API returs a Bad Request status code.
+func TestBudgetInvalidIDs(t *testing.T) {
+	r := test.Request(t, "GET", "/v1/budgets/-17", "")
+	test.AssertHTTPStatus(t, http.StatusBadRequest, &r)
+
+	r = test.Request(t, "GET", "/v1/budgets/DefinitelyNotAUint64", "")
+	test.AssertHTTPStatus(t, http.StatusBadRequest, &r)
+}
+
 func TestCreateBudget(t *testing.T) {
 	recorder := test.Request(t, "POST", "/v1/budgets", `{ "name": "New Budget", "note": "More tests something something" }`)
 	test.AssertHTTPStatus(t, http.StatusCreated, &recorder)

--- a/internal/controllers/category_test.go
+++ b/internal/controllers/category_test.go
@@ -49,6 +49,16 @@ func TestNoCategoryNotFound(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
 }
 
+// TestCategoryInvalidIDs verifies that on non-number requests for category IDs,
+// the API returs a Bad Request status code.
+func TestCategoryInvalidIDs(t *testing.T) {
+	r := test.Request(t, "GET", "/v1/budgets/1/categories/-557", "")
+	test.AssertHTTPStatus(t, http.StatusBadRequest, &r)
+
+	r = test.Request(t, "GET", "/v1/budgets/1/categories/HanShotFirst", "")
+	test.AssertHTTPStatus(t, http.StatusBadRequest, &r)
+}
+
 // TestNonexistingBudgetCategories404 is a regression test for https://github.com/envelope-zero/backend/issues/89.
 //
 // It verifies that for a non-existing budget, the accounts endpoint raises a 404

--- a/internal/controllers/envelope_test.go
+++ b/internal/controllers/envelope_test.go
@@ -49,6 +49,16 @@ func TestNoEnvelopeNotFound(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
 }
 
+// TestEnvelopeInvalidIDs verifies that on non-number requests for envelope IDs,
+// the API returs a Bad Request status code.
+func TestEnvelopeInvalidIDs(t *testing.T) {
+	r := test.Request(t, "GET", "/v1/budgets/1/categories/1/envelopes/-1985", "")
+	test.AssertHTTPStatus(t, http.StatusBadRequest, &r)
+
+	r = test.Request(t, "GET", "/v1/budgets/1/categories/1/envelopes/OhNoOurTable", "")
+	test.AssertHTTPStatus(t, http.StatusBadRequest, &r)
+}
+
 // TestNonexistingCategoryEnvelopes404 is a regression test for https://github.com/envelope-zero/backend/issues/89.
 //
 // It verifies that for a non-existing category, the envelopes endpoint raises a 404

--- a/internal/controllers/helper.go
+++ b/internal/controllers/helper.go
@@ -148,12 +148,13 @@ func getEnvelope(c *gin.Context) (models.Envelope, error) {
 		return models.Envelope{}, err
 	}
 
-	_, err = getCategory(c)
+	category, err := getCategory(c)
 	if err != nil {
 		return models.Envelope{}, err
 	}
 
 	err = models.DB.Where(&models.Envelope{
+		CategoryID: category.ID,
 		Model: models.Model{
 			ID: envelopeID,
 		},

--- a/internal/controllers/helper.go
+++ b/internal/controllers/helper.go
@@ -167,6 +167,34 @@ func getEnvelope(c *gin.Context) (models.Envelope, error) {
 	return envelope, nil
 }
 
+// getAllocation verifies that the request URI is valid for the transaction and returns it.
+func getAllocation(c *gin.Context) (models.Allocation, error) {
+	var allocation models.Allocation
+
+	envelope, err := getEnvelope(c)
+	if err != nil {
+		return models.Allocation{}, err
+	}
+
+	allocationID, err := parseID(c, "allocationId")
+	if err != nil {
+		return models.Allocation{}, err
+	}
+
+	err = models.DB.First(&allocation, &models.Allocation{
+		EnvelopeID: envelope.ID,
+		Model: models.Model{
+			ID: allocationID,
+		},
+	}).Error
+	if err != nil {
+		FetchErrorHandler(c, err)
+		return models.Allocation{}, err
+	}
+
+	return allocation, nil
+}
+
 // getTransaction verifies that the request URI is valid for the transaction and returns it.
 func getTransaction(c *gin.Context) (models.Transaction, error) {
 	var transaction models.Transaction

--- a/internal/controllers/helper.go
+++ b/internal/controllers/helper.go
@@ -165,6 +165,34 @@ func getEnvelope(c *gin.Context) (models.Envelope, error) {
 	return envelope, nil
 }
 
+// getTransaction verifies that the request URI is valid for the transaction and returns it.
+func getTransaction(c *gin.Context) (models.Transaction, error) {
+	var transaction models.Transaction
+
+	budget, err := getBudget(c)
+	if err != nil {
+		return models.Transaction{}, err
+	}
+
+	accountID, err := parseID(c, "transactionId")
+	if err != nil {
+		return models.Transaction{}, err
+	}
+
+	err = models.DB.First(&transaction, &models.Transaction{
+		BudgetID: budget.ID,
+		Model: models.Model{
+			ID: accountID,
+		},
+	}).Error
+	if err != nil {
+		FetchErrorHandler(c, err)
+		return models.Transaction{}, err
+	}
+
+	return transaction, nil
+}
+
 // FetchErrorHandler handles errors for fetching data from the database.
 func FetchErrorHandler(c *gin.Context, err error) {
 	if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/internal/controllers/helper.go
+++ b/internal/controllers/helper.go
@@ -118,12 +118,13 @@ func getCategory(c *gin.Context) (models.Category, error) {
 		return models.Category{}, err
 	}
 
-	_, err = getBudget(c)
+	budget, err := getBudget(c)
 	if err != nil {
 		return models.Category{}, err
 	}
 
 	err = models.DB.Where(&models.Category{
+		BudgetID: budget.ID,
 		Model: models.Model{
 			ID: categoryID,
 		},

--- a/internal/controllers/transaction.go
+++ b/internal/controllers/transaction.go
@@ -72,10 +72,8 @@ func GetTransactions(c *gin.Context) {
 
 // GetTransaction retrieves an transaction by its ID.
 func GetTransaction(c *gin.Context) {
-	var transaction models.Transaction
-	err := models.DB.First(&transaction, c.Param("transactionId")).Error
+	transaction, err := getTransaction(c)
 	if err != nil {
-		FetchErrorHandler(c, err)
 		return
 	}
 

--- a/internal/controllers/transaction_test.go
+++ b/internal/controllers/transaction_test.go
@@ -81,6 +81,22 @@ func TestNoTransactionNotFound(t *testing.T) {
 	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
 }
 
+// TestTransactionInvalidIDs verifies that on non-number requests for transaction IDs,
+// the API returs a Bad Request status code.
+func TestTransactionInvalidIDs(t *testing.T) {
+	r := test.Request(t, "GET", "/v1/budgets/1/transactions/-56", "")
+	test.AssertHTTPStatus(t, http.StatusBadRequest, &r)
+
+	r = test.Request(t, "GET", "/v1/budgets/1/transactions/notANumber", "")
+	test.AssertHTTPStatus(t, http.StatusBadRequest, &r)
+
+	r = test.Request(t, "GET", "/v1/budgets/-61/transactions/56", "")
+	test.AssertHTTPStatus(t, http.StatusBadRequest, &r)
+
+	r = test.Request(t, "GET", "/v1/budgets/RandomStringThatIsNotAUint64/transactions/1", "")
+	test.AssertHTTPStatus(t, http.StatusBadRequest, &r)
+}
+
 // TestNonexistingBudgetTransactions404 is a regression test for https://github.com/envelope-zero/backend/issues/89.
 //
 // It verifies that for a non-existing budget, the accounts endpoint raises a 404
@@ -88,6 +104,25 @@ func TestNoTransactionNotFound(t *testing.T) {
 func TestNonexistingBudgetTransactions404(t *testing.T) {
 	recorder := test.Request(t, "GET", "/v1/budgets/999/transactions", "")
 	test.AssertHTTPStatus(t, http.StatusNotFound, &recorder)
+}
+
+// TestTransactionParentChecked is a regression test for https://github.com/envelope-zero/backend/issues/90.
+//
+// It verifies that the transaction details endpoint for a budget only returns transactions that belong to the
+// budget.
+func TestTransactionParentChecked(t *testing.T) {
+	r := test.Request(t, "POST", "/v1/budgets", `{ "name": "New Budget", "note": "More tests something something" }`)
+	test.AssertHTTPStatus(t, http.StatusCreated, &r)
+
+	var budget BudgetDetailResponse
+	test.DecodeResponse(t, &r, &budget)
+
+	path := fmt.Sprintf("/v1/budgets/%v", budget.Data.ID)
+	r = test.Request(t, "GET", path+"/transactions/1", "")
+	test.AssertHTTPStatus(t, http.StatusNotFound, &r)
+
+	r = test.Request(t, "DELETE", path, "")
+	test.AssertHTTPStatus(t, http.StatusNoContent, &r)
 }
 
 func TestCreateTransaction(t *testing.T) {


### PR DESCRIPTION
With this PR, all GET endpoints for a single resource verify that the resource belongs to the specified parent.

Resolves #90.
