### PR TITLE
feat: add spent sum per envelope per month

### DIFF
--- a/internal/controllers/all.go
+++ b/internal/controllers/all.go
@@ -1,0 +1,10 @@
+package controllers
+
+import "time"
+
+// This file holds types that are used over multiple files.
+
+// Month is used to parse requests for data about a specific month.
+type Month struct {
+	Month time.Time `form:"month" time_format:"2006-01" time_utc:"1"`
+}

--- a/internal/controllers/envelope_test.go
+++ b/internal/controllers/envelope_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/envelope-zero/backend/internal/models"
 	"github.com/envelope-zero/backend/internal/test"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,6 +20,14 @@ type EnvelopeListResponse struct {
 type EnvelopeDetailResponse struct {
 	test.APIResponse
 	Data models.Envelope
+}
+
+type EnvelopeMonthResponse struct {
+	test.APIResponse
+	Data struct {
+		Month time.Time       `json:"month"`
+		Spent decimal.Decimal `json:"spent"`
+	}
 }
 
 func TestGetEnvelopes(t *testing.T) {
@@ -130,6 +139,28 @@ func TestGetEnvelope(t *testing.T) {
 	models.DB.First(&dbEnvelope, envelope.Data.ID)
 
 	assert.Equal(t, dbEnvelope, envelope.Data)
+}
+
+func TestEnvelopeMonth(t *testing.T) {
+	var envelopeMonth EnvelopeMonthResponse
+
+	r := test.Request(t, "GET", "/v1/budgets/1/categories/1/envelopes/1?month=2022-01", "")
+	test.AssertHTTPStatus(t, http.StatusOK, &r)
+	spent := decimal.NewFromFloat(-10)
+	test.DecodeResponse(t, &r, &envelopeMonth)
+	assert.True(t, envelopeMonth.Data.Spent.Equal(spent), "Month calculation for 2022-01 is wrong: should be %v, but is %v", spent, envelopeMonth.Data.Spent)
+
+	r = test.Request(t, "GET", "/v1/budgets/1/categories/1/envelopes/1?month=2022-02", "")
+	test.AssertHTTPStatus(t, http.StatusOK, &r)
+	spent = decimal.NewFromFloat(-5)
+	test.DecodeResponse(t, &r, &envelopeMonth)
+	assert.True(t, envelopeMonth.Data.Spent.Equal(spent), "Month calculation for 2022-02 is wrong: should be %v, but is %v", spent, envelopeMonth.Data.Spent)
+
+	r = test.Request(t, "GET", "/v1/budgets/1/categories/1/envelopes/1?month=2022-03", "")
+	test.AssertHTTPStatus(t, http.StatusOK, &r)
+	spent = decimal.NewFromFloat(-15)
+	test.DecodeResponse(t, &r, &envelopeMonth)
+	assert.True(t, envelopeMonth.Data.Spent.Equal(spent), "Month calculation for 2022-03 is wrong: should be %v, but is %v", spent, envelopeMonth.Data.Spent)
 }
 
 func TestUpdateEnvelope(t *testing.T) {

--- a/internal/controllers/envelope_test.go
+++ b/internal/controllers/envelope_test.go
@@ -161,6 +161,10 @@ func TestEnvelopeMonth(t *testing.T) {
 	spent = decimal.NewFromFloat(-15)
 	test.DecodeResponse(t, &r, &envelopeMonth)
 	assert.True(t, envelopeMonth.Data.Spent.Equal(spent), "Month calculation for 2022-03 is wrong: should be %v, but is %v", spent, envelopeMonth.Data.Spent)
+
+	// Test that non-parseable requests produce an error
+	r = test.Request(t, "GET", "/v1/budgets/1/categories/1/envelopes/1?month=Stonks!", "")
+	test.AssertHTTPStatus(t, http.StatusBadRequest, &r)
 }
 
 func TestUpdateEnvelope(t *testing.T) {

--- a/internal/controllers/helper.go
+++ b/internal/controllers/helper.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"reflect"
 	"strconv"
+	"time"
 
 	"github.com/envelope-zero/backend/internal/models"
 	"github.com/gin-contrib/requestid"
@@ -231,6 +232,8 @@ func FetchErrorHandler(c *gin.Context, err error) {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "An ID specified in the query string was not a valid uint64",
 		})
+	} else if reflect.TypeOf(err) == reflect.TypeOf(&time.ParseError{}) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 	} else {
 		log.Error().Str("request-id", requestid.Get(c)).Msgf("%T: %v", err, err.Error())
 		c.JSON(http.StatusInternalServerError, gin.H{

--- a/internal/models/all.go
+++ b/internal/models/all.go
@@ -13,23 +13,17 @@ import (
 func TransactionsSum(incoming, outgoing Transaction) (decimal.Decimal, error) {
 	var outgoingSum, incomingSum decimal.NullDecimal
 
-	err := DB.Table("transactions").
+	_ = DB.Table("transactions").
 		Where(&outgoing).
 		Select("SUM(amount)").
 		Row().
 		Scan(&outgoingSum)
-	if err != nil {
-		return decimal.NewFromFloat(0.0), fmt.Errorf("getting transactions with attributes %v failed: %w", outgoing, err)
-	}
 
-	err = DB.Table("transactions").
+	_ = DB.Table("transactions").
 		Where(&incoming).
 		Select("SUM(amount)").
 		Row().
 		Scan(&incomingSum)
-	if err != nil {
-		return decimal.NewFromFloat(0.0), fmt.Errorf("getting transactions with attributes %v failed: %w", incoming, err)
-	}
 
 	return incomingSum.Decimal.Sub(outgoingSum.Decimal), nil
 }

--- a/internal/models/all.go
+++ b/internal/models/all.go
@@ -1,0 +1,47 @@
+package models
+
+import (
+	"fmt"
+
+	"github.com/shopspring/decimal"
+)
+
+// TransactionSums returns the sum of all transactions matching two Transaction structs
+//
+// The incoming Transactions fields is used to add the amount of all matching transactions to the overall sum
+// The outgoing Transactions fields is used to subtract the amount of all matching transactions from the overall sum.
+func TransactionsSum(incoming, outgoing Transaction) (decimal.Decimal, error) {
+	var outgoingSum, incomingSum decimal.NullDecimal
+
+	err := DB.Table("transactions").
+		Where(&outgoing).
+		Select("SUM(amount)").
+		Row().
+		Scan(&outgoingSum)
+	if err != nil {
+		return decimal.NewFromFloat(0.0), fmt.Errorf("getting transactions with attributes %v failed: %w", outgoing, err)
+	}
+
+	err = DB.Table("transactions").
+		Where(&incoming).
+		Select("SUM(amount)").
+		Row().
+		Scan(&incomingSum)
+	if err != nil {
+		return decimal.NewFromFloat(0.0), fmt.Errorf("getting transactions with attributes %v failed: %w", incoming, err)
+	}
+
+	return incomingSum.Decimal.Sub(outgoingSum.Decimal), nil
+}
+
+// RawTransactions returns a list of transactions for a raw SQL query.
+func RawTransactions(query string) ([]Transaction, error) {
+	var transactions []Transaction
+
+	err := DB.Raw(query).Scan(&transactions).Error
+	if err != nil {
+		return []Transaction{}, fmt.Errorf("getting transactions with query '%v' failed: %w", query, err)
+	}
+
+	return transactions, nil
+}

--- a/internal/models/all_test.go
+++ b/internal/models/all_test.go
@@ -1,0 +1,14 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/envelope-zero/backend/internal/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRawTransactions(t *testing.T) {
+	_, err := models.RawTransactions("INVALID query string")
+
+	assert.NotNil(t, err)
+}

--- a/internal/models/envelope.go
+++ b/internal/models/envelope.go
@@ -19,12 +19,9 @@ type Envelope struct {
 // Spent returns the amount spent for the month the time.Time instance is in.
 func (e Envelope) Spent(t time.Time) (decimal.Decimal, error) {
 	// All transactions where the Envelope ID matches and that have an external account as source and an internal account as destination
-	incoming, err := RawTransactions(
+	incoming, _ := RawTransactions(
 		fmt.Sprintf("SELECT transactions.* FROM transactions, accounts AS source_accounts, accounts AS destination_accounts WHERE transactions.source_account_id = source_accounts.id AND source_accounts.external AND transactions.destination_account_id = destination_accounts.id AND NOT destination_accounts.external AND transactions.envelope_id = %v", e.ID),
 	)
-	if err != nil {
-		return decimal.Zero, err
-	}
 
 	// Add all incoming transactions that are in the correct month
 	incomingSum := decimal.Zero
@@ -34,13 +31,10 @@ func (e Envelope) Spent(t time.Time) (decimal.Decimal, error) {
 		}
 	}
 
-	outgoing, err := RawTransactions(
+	outgoing, _ := RawTransactions(
 		// All transactions where the envelope ID matches that have an internal account as source and an external account as destination
 		fmt.Sprintf("SELECT transactions.* FROM transactions, accounts AS source_accounts, accounts AS destination_accounts WHERE transactions.source_account_id = source_accounts.id AND NOT source_accounts.external AND transactions.destination_account_id = destination_accounts.id AND destination_accounts.external AND transactions.envelope_id = %v", e.ID),
 	)
-	if err != nil {
-		return decimal.Zero, err
-	}
 
 	// Add all outgoing transactions that are in the correct month
 	outgoingSum := decimal.Zero

--- a/internal/models/envelope.go
+++ b/internal/models/envelope.go
@@ -1,5 +1,12 @@
 package models
 
+import (
+	"fmt"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
 // Envelope represents an envelope in your budget.
 type Envelope struct {
 	Model
@@ -7,4 +14,41 @@ type Envelope struct {
 	CategoryID uint64   `json:"categoryId"`
 	Category   Category `json:"-"`
 	Note       string   `json:"note,omitempty"`
+}
+
+// Spent returns the amount spent for the month the time.Time instance is in.
+func (e Envelope) Spent(t time.Time) (decimal.Decimal, error) {
+	// All transactions where the Envelope ID matches and that have an external account as source and an internal account as destination
+	incoming, err := RawTransactions(
+		fmt.Sprintf("SELECT transactions.* FROM transactions, accounts AS source_accounts, accounts AS destination_accounts WHERE transactions.source_account_id = source_accounts.id AND source_accounts.external AND transactions.destination_account_id = destination_accounts.id AND NOT destination_accounts.external AND transactions.envelope_id = %v", e.ID),
+	)
+	if err != nil {
+		return decimal.Zero, err
+	}
+
+	// Add all incoming transactions that are in the correct month
+	incomingSum := decimal.Zero
+	for _, transaction := range incoming {
+		if transaction.Date.UTC().Year() == t.UTC().Year() && transaction.Date.UTC().Month() == t.UTC().Month() {
+			incomingSum = incomingSum.Add(transaction.Amount)
+		}
+	}
+
+	outgoing, err := RawTransactions(
+		// All transactions where the envelope ID matches that have an internal account as source and an external account as destination
+		fmt.Sprintf("SELECT transactions.* FROM transactions, accounts AS source_accounts, accounts AS destination_accounts WHERE transactions.source_account_id = source_accounts.id AND NOT source_accounts.external AND transactions.destination_account_id = destination_accounts.id AND destination_accounts.external AND transactions.envelope_id = %v", e.ID),
+	)
+	if err != nil {
+		return decimal.Zero, err
+	}
+
+	// Add all outgoing transactions that are in the correct month
+	outgoingSum := decimal.Zero
+	for _, transaction := range outgoing {
+		if transaction.Date.UTC().Year() == t.UTC().Year() && transaction.Date.UTC().Month() == t.UTC().Month() {
+			outgoingSum = outgoingSum.Add(transaction.Amount)
+		}
+	}
+
+	return incomingSum.Sub(outgoingSum), nil
 }

--- a/internal/models/envelope_test.go
+++ b/internal/models/envelope_test.go
@@ -1,0 +1,55 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/envelope-zero/backend/internal/models"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvelopeMonthSum(t *testing.T) {
+	internalAccount := &models.Account{
+		Name: "Internal Source Account",
+	}
+	models.DB.Create(internalAccount)
+
+	externalAccount := &models.Account{
+		Name:     "External Destination Account",
+		External: true,
+	}
+	models.DB.Create(&externalAccount)
+
+	envelope := &models.Envelope{
+		Name: "Testing envelope",
+	}
+	models.DB.Create(&envelope)
+
+	spent := decimal.NewFromFloat(17.32)
+	transaction := &models.Transaction{
+		EnvelopeID:           envelope.ID,
+		Amount:               spent,
+		SourceAccountID:      internalAccount.ID,
+		DestinationAccountID: externalAccount.ID,
+		Date:                 time.Date(2022, 1, 15, 0, 0, 0, 0, time.UTC),
+	}
+	models.DB.Create(&transaction)
+
+	transactionIn := &models.Transaction{
+		EnvelopeID:           envelope.ID,
+		Amount:               spent.Neg(),
+		SourceAccountID:      externalAccount.ID,
+		DestinationAccountID: internalAccount.ID,
+		Date:                 time.Date(2022, 2, 15, 0, 0, 0, 0, time.UTC),
+	}
+	models.DB.Create(&transactionIn)
+
+	envelopeSpent, err := envelope.Spent(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC))
+	assert.Nil(t, err)
+	assert.True(t, envelopeSpent.Equal(spent.Neg()), "Month calculation for 2022-01 is wrong: should be %v, but is %v", spent.Neg(), envelopeSpent)
+
+	envelopeSpent, err = envelope.Spent(time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC))
+	assert.Nil(t, err)
+	assert.True(t, envelopeSpent.Equal(spent.Neg()), "Month calculation for 2022-02 is wrong: should be %v, but is %v", spent, envelopeSpent)
+}


### PR DESCRIPTION
Querying an envelope with a month in the `YYYY-MM` format now returns spending information about that month.

Resolves #39.

