### PR TITLE
fix: defer is not called on os.Exit, wrap main test function

### DIFF
--- a/internal/controllers/main_test.go
+++ b/internal/controllers/main_test.go
@@ -13,6 +13,10 @@ import (
 
 // TestMain takes care of the test setup for this package.
 func TestMain(m *testing.M) {
+	os.Exit(runTests(m))
+}
+
+func runTests(m *testing.M) int {
 	// Always remove the DB after running tests
 	defer os.Remove("data/gorm.db")
 
@@ -152,6 +156,5 @@ func TestMain(m *testing.M) {
 
 	models.DB.Create(&waterBillTransactionMar)
 
-	code := m.Run()
-	os.Exit(code)
+	return m.Run()
 }

--- a/internal/models/main_test.go
+++ b/internal/models/main_test.go
@@ -11,6 +11,10 @@ import (
 
 // TestMain takes care of the test setup for this package.
 func TestMain(m *testing.M) {
+	os.Exit(runTests(m))
+}
+
+func runTests(m *testing.M) int {
 	// Always remove the DB after running tests
 	defer os.Remove("data/gorm.db")
 
@@ -24,6 +28,5 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Database migration failed with: %s", err.Error())
 	}
 
-	code := m.Run()
-	os.Exit(code)
+	return m.Run()
 }


### PR DESCRIPTION
Tests now run locally again and actually delete the DB afterwards.
