### PR TITLE
fix: ignore node files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ gorm.db
 coverage.out
 /backend
 dist/
+
+# Created in the workflows but need to be ignored
+node_modules/
+package-lock.json
+package.json


### PR DESCRIPTION
We’re now also ignoring any node related files.
