### PR TITLE
test: only run renovate config validator when the workflow or the config change

### DIFF
--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -3,7 +3,8 @@ name: Validate renovate config
 on:
   push:
     paths:
-      - "renovate.json"
+      - renovate.json
+      - .github/workflows/renovate-config-validator.yml
 
 jobs:
   validate:


### PR DESCRIPTION
With this, the workflow should only run when the workflow or the config itself change.

This will reduce the number of unneeded action runs.
