### PR TITLE
fix: log in to github registry

### DIFF
--- a/.github/workflows/go-test-and-release.yml
+++ b/.github/workflows/go-test-and-release.yml
@@ -9,7 +9,6 @@ on:
       - "*"
 
 permissions:
-  contents: write
   packages: write
 
 jobs:
@@ -47,6 +46,11 @@ jobs:
         with:
           # renovate: go-version
           go-version: 1.18.2
+
+      - name: Login to Docker Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+          docker login docker.pkg.github.com -u docker --password-stdin
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
This logs in to the registry. Goreleaser itself does this, but the action does not.
