### PR TITLE
fix: roll back to the separate build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: Build and release OCI image
+
+on:
+  push:
+    tags:
+      - "**"
+  pull_request:
+    branches:
+      - "main"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check if image should be pushed
+        id: push_check
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* || "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "::set-output name=push::true"
+          else
+            echo "::set-output name=push::false"
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4.0.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3.0.0
+        with:
+          context: .
+          push: ${{ steps.push_check.outputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}

--- a/.github/workflows/go-test-and-release.yml
+++ b/.github/workflows/go-test-and-release.yml
@@ -8,8 +8,8 @@ on:
     tags:
       - "*"
 
-permissions:
-  packages: write
+#permissions:
+#  packages: write
 
 jobs:
   go-test:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,11 +24,10 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
-
-dockers:
-  - dockerfile: Dockerfile.goreleaser
-    image_templates:
-      - "ghcr.io/envelope-zero/backend:{{ .Tag }}"
-      - "ghcr.io/envelope-zero/backend:v{{ .Major }}"
-      - "ghcr.io/envelope-zero/backend:v{{ .Major }}.{{ .Minor }}"
-      - "ghcr.io/envelope-zero/backend:latest"
+# dockers:
+#   - dockerfile: Dockerfile.goreleaser
+#     image_templates:
+#       - "ghcr.io/envelope-zero/backend:{{ .Tag }}"
+#       - "ghcr.io/envelope-zero/backend:v{{ .Major }}"
+#       - "ghcr.io/envelope-zero/backend:v{{ .Major }}.{{ .Minor }}"
+#       - "ghcr.io/envelope-zero/backend:latest"


### PR DESCRIPTION
This will get us back to functioning builds. Will likely be debugged at some point.

>     ⨯ release failed after 379.81s error=docker images: failed to publish
>	artifacts: failed to push ghcr.io/envelope-zero/backend:v0.20.5:
>	exit status 1: The push refers to repository [ghcr.io/envelope-zero/backend]
> 9c19cdb2b096: Preparing
> denied: unauthenticated: User cannot be authenticated with the token provided.
