### PR TITLE
test: only run renovate config validator on main and PRs to main

### DIFF
--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -2,6 +2,14 @@ name: Validate renovate config
 
 on:
   push:
+    branches:
+      - main
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-validator.yml
+  pull_request:
+    branches:
+      - main
     paths:
       - renovate.json
       - .github/workflows/renovate-config-validator.yml


### PR DESCRIPTION
On tags, the paths are not evaluated.
