### PR TITLE
feat: default prefix to /api if reverse proxy is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ The recommended and only supported way for production deployments is to run the 
 
 :warning: If you do not configure a postgresql database, sqlite will automatically be used. Mount a persistent volume to the `/data` directory - this is where the sqlite database is stored. If you do not do this, you will lose all data every time the container is deleted.
 
+If you serve the backend with a reverse proxy under a different path than `/`, note the following:
+
+- Your reverse proxy must set the `x-forwarded-host` header so that correct URIs are generated
+- If you do not serve the backend at the prefix `/api` (required by the [frontend](https://github.com/envelope-zero/frontend)), your reverse proxy needs to set the `x-forwarded-prefix` header
+
 The backend can be configured with the following environment variables. None are required.
 
 | Name                 | Type                      | Default                                              | Description                                                                                                                                                       |
@@ -66,8 +71,6 @@ ingress:
     - hosts:
         - envelope-zero.example.com
 ```
-
-If you do not use the root path `/`, but a prefix, make sure your reverse proxy writes the used prefix in the `x-forwarded-prefix` header. That header is used by the backend to generate the correct URLs for resources.
 
 ## Supported Versions
 

--- a/internal/httputil/error_test.go
+++ b/internal/httputil/error_test.go
@@ -1,0 +1,75 @@
+package httputil_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/envelope-zero/backend/internal/httputil"
+	"github.com/envelope-zero/backend/internal/test"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+func TestFetchErrorHandlerErrRecordNotFound(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", func(ctx *gin.Context) {
+		httputil.FetchErrorHandler(c, gorm.ErrRecordNotFound)
+	})
+
+	// Check without reverse proxy headers
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	r.ServeHTTP(w, c.Request)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestFetchErrorHandlerStrconvNumError(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", func(ctx *gin.Context) {
+		httputil.FetchErrorHandler(c, &strconv.NumError{})
+	})
+
+	// Check without reverse proxy headers
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	r.ServeHTTP(w, c.Request)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "An ID specified in the query string was not a valid uint64", test.DecodeError(t, w.Body.Bytes()))
+}
+
+func TestFetchErrorHandlerTimeParseError(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", func(ctx *gin.Context) {
+		httputil.FetchErrorHandler(c, &time.ParseError{})
+	})
+
+	// Check without reverse proxy headers
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	r.ServeHTTP(w, c.Request)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, test.DecodeError(t, w.Body.Bytes()), "parsing time")
+}
+
+func TestFetchErrorHandlerInternalServerError(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", func(ctx *gin.Context) {
+		httputil.FetchErrorHandler(c, errors.New("Some random error"))
+	})
+
+	// Check without reverse proxy headers
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	r.ServeHTTP(w, c.Request)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, test.DecodeError(t, w.Body.Bytes()), "an error occured on the server during your request")
+}

--- a/internal/httputil/options_test.go
+++ b/internal/httputil/options_test.go
@@ -1,0 +1,56 @@
+package httputil_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/envelope-zero/backend/internal/httputil"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionsGet(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", httputil.OptionsGet)
+
+	// Check without reverse proxy headers
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Host = "example.com"
+	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, "GET", w.Header().Get("allow"))
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestOptionsPost(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", httputil.OptionsGetPost)
+
+	// Check without reverse proxy headers
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Host = "example.com"
+	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, "GET, POST", w.Header().Get("allow"))
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestOptionsGetPatchDelete(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", httputil.OptionsGetPatchDelete)
+
+	// Check without reverse proxy headers
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Host = "example.com"
+	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, "GET, PATCH, DELETE", w.Header().Get("allow"))
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}

--- a/internal/httputil/request_test.go
+++ b/internal/httputil/request_test.go
@@ -1,11 +1,14 @@
 package httputil_test
 
 import (
+	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/envelope-zero/backend/internal/httputil"
+	"github.com/envelope-zero/backend/internal/test"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
@@ -56,4 +59,153 @@ func TestRequestHostPrefix(t *testing.T) {
 	c.Request.Header.Set("x-forwarded-prefix", "/backend")
 	r.ServeHTTP(w, c.Request)
 	assert.Equal(t, "http://example.com/backend", w.Body.String())
+}
+
+func TestRequestHostProtoHTTPS(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", func(ctx *gin.Context) {
+		c.String(http.StatusOK, httputil.RequestHost(c))
+	})
+
+	// Check with x-forwarded-prefix
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Host = "::1"
+	c.Request.Header.Set("x-forwarded-host", "example.com")
+	c.Request.Header.Set("x-forwarded-proto", "https")
+	r.ServeHTTP(w, c.Request)
+	assert.Equal(t, "https://example.com/api", w.Body.String())
+}
+
+func TestRequestPathV1(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", func(ctx *gin.Context) {
+		c.String(http.StatusOK, httputil.RequestPathV1(c))
+	})
+
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Host = "example.com"
+	r.ServeHTTP(w, c.Request)
+	assert.Equal(t, "http://example.com/v1", w.Body.String())
+}
+
+func TestRequestPathURI(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/seenotrettung/ist-kein-verbrechen", func(ctx *gin.Context) {
+		c.String(http.StatusOK, httputil.RequestURL(c))
+	})
+
+	c.Request, _ = http.NewRequest(http.MethodGet, "/seenotrettung/ist-kein-verbrechen", nil)
+	c.Request.Host = "example.com"
+	r.ServeHTTP(w, c.Request)
+	assert.Equal(t, "http://example.com/seenotrettung/ist-kein-verbrechen", w.Body.String())
+}
+
+func TestParseIDInvalid(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", func(ctx *gin.Context) {
+		id, err := httputil.ParseID(c, "NotAValidUint")
+		if err != nil {
+			return
+		}
+
+		c.String(http.StatusOK, fmt.Sprintf("%d", id))
+	})
+
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Host = "example.com"
+	r.ServeHTTP(w, c.Request)
+
+	// Not checking the error messages here as this is done in error_test.go
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestParseID(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+	c.Params = append(c.Params, gin.Param{Key: "id", Value: "171"})
+
+	r.GET("/", func(ctx *gin.Context) {
+		id, err := httputil.ParseID(c, "id")
+		if err != nil {
+			return
+		}
+
+		c.String(http.StatusOK, fmt.Sprintf("%d", id))
+	})
+
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Host = "example.com"
+	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, "171", w.Body.String())
+}
+
+func TestBindData(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", func(ctx *gin.Context) {
+		var o struct {
+			Name string `json:"name"`
+		}
+
+		_ = httputil.BindData(c, &o)
+	})
+
+	// Check without reverse proxy headers
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", bytes.NewBuffer([]byte(`{ "name": "Drink more water!" }`)))
+	c.Request.Host = "example.com"
+	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, http.StatusOK, w.Code, "Binding failed: %s", w.Body.String())
+}
+
+func TestBindBrokenData(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", func(ctx *gin.Context) {
+		var o struct {
+			Name string `json:"name"`
+		}
+
+		_ = httputil.BindData(c, &o)
+	})
+
+	// Check without reverse proxy headers
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", bytes.NewBuffer([]byte(`{ broken json: "Drink more water!" }`)))
+	c.Request.Host = "example.com"
+	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "Binding failed: %s", w.Body.String())
+	assert.Contains(t, test.DecodeError(t, w.Body.Bytes()), "the body of your request contains invalid or un-parseable data")
+}
+
+func TestBindEmptyBody(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", func(ctx *gin.Context) {
+		var o struct {
+			Name string `json:"name"`
+		}
+
+		_ = httputil.BindData(c, &o)
+	})
+
+	// Check without reverse proxy headers
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", bytes.NewBuffer([]byte("")))
+	c.Request.Host = "example.com"
+	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "Binding failed: %s", w.Body.String())
+	assert.Contains(t, test.DecodeError(t, w.Body.Bytes()), "request body must not be emtpy")
 }

--- a/internal/httputil/request_test.go
+++ b/internal/httputil/request_test.go
@@ -1,0 +1,59 @@
+package httputil_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/envelope-zero/backend/internal/httputil"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestHostNaked(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", func(ctx *gin.Context) {
+		c.String(http.StatusOK, httputil.RequestHost(c))
+	})
+
+	// Check without reverse proxy headers
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Host = "example.com"
+	r.ServeHTTP(w, c.Request)
+	assert.Equal(t, "http://example.com", w.Body.String())
+}
+
+func TestRequestHostReverseProxy(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", func(ctx *gin.Context) {
+		c.String(http.StatusOK, httputil.RequestHost(c))
+	})
+
+	// Check with reverse proxy, but without x-forwarded-prefix
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Host = "::1"
+	c.Request.Header.Set("x-forwarded-host", "example.com")
+	r.ServeHTTP(w, c.Request)
+	assert.Equal(t, "http://example.com/api", w.Body.String())
+}
+
+func TestRequestHostPrefix(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", func(ctx *gin.Context) {
+		c.String(http.StatusOK, httputil.RequestHost(c))
+	})
+
+	// Check with x-forwarded-prefix
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Host = "::1"
+	c.Request.Header.Set("x-forwarded-host", "example.com")
+	c.Request.Header.Set("x-forwarded-prefix", "/backend")
+	r.ServeHTTP(w, c.Request)
+	assert.Equal(t, "http://example.com/backend", w.Body.String())
+}

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/envelope-zero/backend/internal/controllers"
+	"github.com/envelope-zero/backend/internal/httputil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -59,4 +60,13 @@ func DecodeResponse(t *testing.T, r *httptest.ResponseRecorder, target interface
 	if err != nil {
 		assert.FailNow(t, "Parsing error", "Unable to parse response from server %q into %v, '%v'", r.Body, reflect.TypeOf(target), err)
 	}
+}
+
+func DecodeError(t *testing.T, s []byte) string {
+	var r httputil.HTTPError
+	if err := json.Unmarshal(s, &r); err != nil {
+		assert.Fail(t, "Not valid JSON!", "%s", s)
+	}
+
+	return r.Error
 }

--- a/internal/test/helpers_test.go
+++ b/internal/test/helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/envelope-zero/backend/internal/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRequest(t *testing.T) {
@@ -17,4 +18,9 @@ func TestDecodeResponse(t *testing.T) {
 
 	r := test.Request(t, "GET", "/v1/budgets", "")
 	test.DecodeResponse(t, &r, &budgets)
+}
+
+func TestDecodeError(t *testing.T) {
+	m := test.DecodeError(t, []byte(`{"error":"some string"}`))
+	assert.Equal(t, "some string", m)
 }


### PR DESCRIPTION
Resolves #163.
