### PR TITLE
test: codecov: ignore test helpers

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -14,3 +14,6 @@ coverage:
       default:
         target: auto
         threshold: 10%
+
+ignore:
+  - "internal/test" # test helpers, those are tested by the tests themselves


### PR DESCRIPTION
Ignoring the test helpers in the future as those are tested by the tests themselves
