### PR TITLE
fix: type of IDs in API docs

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -186,8 +186,8 @@ const docTemplate = `{
                 "summary": "Get account",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the account",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "accountId",
                         "in": "path",
                         "required": true
@@ -228,8 +228,8 @@ const docTemplate = `{
                 "summary": "Delete account",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the account",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "accountId",
                         "in": "path",
                         "required": true
@@ -264,8 +264,8 @@ const docTemplate = `{
                 "summary": "Allowed HTTP verbs",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the account",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "accountId",
                         "in": "path",
                         "required": true
@@ -297,8 +297,8 @@ const docTemplate = `{
                 "summary": "Update account",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the account",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "accountId",
                         "in": "path",
                         "required": true
@@ -441,8 +441,8 @@ const docTemplate = `{
                 "summary": "Get allocation",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the allocation",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "allocationId",
                         "in": "path",
                         "required": true
@@ -480,8 +480,8 @@ const docTemplate = `{
                 "summary": "Delete an allocation",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the allocation",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "allocationId",
                         "in": "path",
                         "required": true
@@ -516,8 +516,8 @@ const docTemplate = `{
                 "summary": "Allowed HTTP verbs",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the allocation",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "allocationId",
                         "in": "path",
                         "required": true
@@ -543,8 +543,8 @@ const docTemplate = `{
                 "summary": "Update an allocation",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the allocation",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "allocationId",
                         "in": "path",
                         "required": true
@@ -684,8 +684,8 @@ const docTemplate = `{
                 "summary": "Get a budget",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the budget",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "budgetId",
                         "in": "path",
                         "required": true
@@ -723,8 +723,8 @@ const docTemplate = `{
                 "summary": "Delete a budget",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the budget",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "budgetId",
                         "in": "path",
                         "required": true
@@ -759,8 +759,8 @@ const docTemplate = `{
                 "summary": "Allowed HTTP verbs",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the budget",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "budgetId",
                         "in": "path",
                         "required": true
@@ -801,8 +801,8 @@ const docTemplate = `{
                 "summary": "Update a budget",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the budget",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "budgetId",
                         "in": "path",
                         "required": true
@@ -854,8 +854,8 @@ const docTemplate = `{
                 "summary": "Get Budget month data",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the budget",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "budgetId",
                         "in": "path",
                         "required": true
@@ -1005,8 +1005,8 @@ const docTemplate = `{
                 "summary": "Get category",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the category",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "categoryId",
                         "in": "path",
                         "required": true
@@ -1044,8 +1044,8 @@ const docTemplate = `{
                 "summary": "Delete a category",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the category",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "categoryId",
                         "in": "path",
                         "required": true
@@ -1080,8 +1080,8 @@ const docTemplate = `{
                 "summary": "Allowed HTTP verbs",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the category",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "categoryId",
                         "in": "path",
                         "required": true
@@ -1116,8 +1116,8 @@ const docTemplate = `{
                 "summary": "Update a category",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the category",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "categoryId",
                         "in": "path",
                         "required": true
@@ -1260,8 +1260,8 @@ const docTemplate = `{
                 "summary": "Get envelope",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the envelope",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "envelopeId",
                         "in": "path",
                         "required": true
@@ -1299,8 +1299,8 @@ const docTemplate = `{
                 "summary": "Delete an envelope",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the envelope",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "envelopeId",
                         "in": "path",
                         "required": true
@@ -1335,8 +1335,8 @@ const docTemplate = `{
                 "summary": "Allowed HTTP verbs",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the envelope",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "envelopeId",
                         "in": "path",
                         "required": true
@@ -1362,8 +1362,8 @@ const docTemplate = `{
                 "summary": "Update an envelope",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the envelope",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "envelopeId",
                         "in": "path",
                         "required": true
@@ -1415,8 +1415,8 @@ const docTemplate = `{
                 "summary": "Get Envelope month data",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the envelope",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "envelopeId",
                         "in": "path",
                         "required": true
@@ -1557,8 +1557,8 @@ const docTemplate = `{
                 "summary": "Get transaction",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the transaction",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "transactionId",
                         "in": "path",
                         "required": true
@@ -1596,8 +1596,8 @@ const docTemplate = `{
                 "summary": "Delete a transaction",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the transaction",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "transactionId",
                         "in": "path",
                         "required": true
@@ -1632,8 +1632,8 @@ const docTemplate = `{
                 "summary": "Allowed HTTP verbs",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the transaction",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "transactionId",
                         "in": "path",
                         "required": true
@@ -1659,8 +1659,8 @@ const docTemplate = `{
                 "summary": "Update a transaction",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the transaction",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "transactionId",
                         "in": "path",
                         "required": true

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -174,8 +174,8 @@
                 "summary": "Get account",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the account",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "accountId",
                         "in": "path",
                         "required": true
@@ -216,8 +216,8 @@
                 "summary": "Delete account",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the account",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "accountId",
                         "in": "path",
                         "required": true
@@ -252,8 +252,8 @@
                 "summary": "Allowed HTTP verbs",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the account",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "accountId",
                         "in": "path",
                         "required": true
@@ -285,8 +285,8 @@
                 "summary": "Update account",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the account",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "accountId",
                         "in": "path",
                         "required": true
@@ -429,8 +429,8 @@
                 "summary": "Get allocation",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the allocation",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "allocationId",
                         "in": "path",
                         "required": true
@@ -468,8 +468,8 @@
                 "summary": "Delete an allocation",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the allocation",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "allocationId",
                         "in": "path",
                         "required": true
@@ -504,8 +504,8 @@
                 "summary": "Allowed HTTP verbs",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the allocation",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "allocationId",
                         "in": "path",
                         "required": true
@@ -531,8 +531,8 @@
                 "summary": "Update an allocation",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the allocation",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "allocationId",
                         "in": "path",
                         "required": true
@@ -672,8 +672,8 @@
                 "summary": "Get a budget",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the budget",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "budgetId",
                         "in": "path",
                         "required": true
@@ -711,8 +711,8 @@
                 "summary": "Delete a budget",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the budget",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "budgetId",
                         "in": "path",
                         "required": true
@@ -747,8 +747,8 @@
                 "summary": "Allowed HTTP verbs",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the budget",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "budgetId",
                         "in": "path",
                         "required": true
@@ -789,8 +789,8 @@
                 "summary": "Update a budget",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the budget",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "budgetId",
                         "in": "path",
                         "required": true
@@ -842,8 +842,8 @@
                 "summary": "Get Budget month data",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the budget",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "budgetId",
                         "in": "path",
                         "required": true
@@ -993,8 +993,8 @@
                 "summary": "Get category",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the category",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "categoryId",
                         "in": "path",
                         "required": true
@@ -1032,8 +1032,8 @@
                 "summary": "Delete a category",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the category",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "categoryId",
                         "in": "path",
                         "required": true
@@ -1068,8 +1068,8 @@
                 "summary": "Allowed HTTP verbs",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the category",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "categoryId",
                         "in": "path",
                         "required": true
@@ -1104,8 +1104,8 @@
                 "summary": "Update a category",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the category",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "categoryId",
                         "in": "path",
                         "required": true
@@ -1248,8 +1248,8 @@
                 "summary": "Get envelope",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the envelope",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "envelopeId",
                         "in": "path",
                         "required": true
@@ -1287,8 +1287,8 @@
                 "summary": "Delete an envelope",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the envelope",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "envelopeId",
                         "in": "path",
                         "required": true
@@ -1323,8 +1323,8 @@
                 "summary": "Allowed HTTP verbs",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the envelope",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "envelopeId",
                         "in": "path",
                         "required": true
@@ -1350,8 +1350,8 @@
                 "summary": "Update an envelope",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the envelope",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "envelopeId",
                         "in": "path",
                         "required": true
@@ -1403,8 +1403,8 @@
                 "summary": "Get Envelope month data",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the envelope",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "envelopeId",
                         "in": "path",
                         "required": true
@@ -1545,8 +1545,8 @@
                 "summary": "Get transaction",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the transaction",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "transactionId",
                         "in": "path",
                         "required": true
@@ -1584,8 +1584,8 @@
                 "summary": "Delete a transaction",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the transaction",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "transactionId",
                         "in": "path",
                         "required": true
@@ -1620,8 +1620,8 @@
                 "summary": "Allowed HTTP verbs",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the transaction",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "transactionId",
                         "in": "path",
                         "required": true
@@ -1647,8 +1647,8 @@
                 "summary": "Update a transaction",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "ID of the transaction",
+                        "type": "string",
+                        "description": "ID formatted as string",
                         "name": "transactionId",
                         "in": "path",
                         "required": true

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -586,11 +586,11 @@ paths:
     delete:
       description: Deletes the specified account.
       parameters:
-      - description: ID of the account
+      - description: ID formatted as string
         in: path
         name: accountId
         required: true
-        type: integer
+        type: string
       produces:
       - application/json
       responses:
@@ -612,11 +612,11 @@ paths:
     get:
       description: Returns a specific account
       parameters:
-      - description: ID of the account
+      - description: ID formatted as string
         in: path
         name: accountId
         required: true
-        type: integer
+        type: string
       produces:
       - application/json
       responses:
@@ -641,11 +641,11 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: ID of the account
+      - description: ID formatted as string
         in: path
         name: accountId
         required: true
-        type: integer
+        type: string
       responses:
         "204":
           description: ""
@@ -661,11 +661,11 @@ paths:
     patch:
       description: Updates an account. Only values to be updated need to be specified.
       parameters:
-      - description: ID of the account
+      - description: ID formatted as string
         in: path
         name: accountId
         required: true
-        type: integer
+        type: string
       - description: Account
         in: body
         name: account
@@ -758,11 +758,11 @@ paths:
     delete:
       description: Deletes an existing allocation
       parameters:
-      - description: ID of the allocation
+      - description: ID formatted as string
         in: path
         name: allocationId
         required: true
-        type: integer
+        type: string
       responses:
         "204":
           description: ""
@@ -782,11 +782,11 @@ paths:
     get:
       description: Returns an allocation by its ID
       parameters:
-      - description: ID of the allocation
+      - description: ID formatted as string
         in: path
         name: allocationId
         required: true
-        type: integer
+        type: string
       produces:
       - application/json
       responses:
@@ -811,11 +811,11 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: ID of the allocation
+      - description: ID formatted as string
         in: path
         name: allocationId
         required: true
-        type: integer
+        type: string
       responses:
         "204":
           description: ""
@@ -828,11 +828,11 @@ paths:
       description: Update an existing allocation. Only values to be updated need to
         be specified.
       parameters:
-      - description: ID of the allocation
+      - description: ID formatted as string
         in: path
         name: allocationId
         required: true
-        type: integer
+        type: string
       - description: Allocation
         in: body
         name: allocation
@@ -922,11 +922,11 @@ paths:
     delete:
       description: Deletes an existing budget
       parameters:
-      - description: ID of the budget
+      - description: ID formatted as string
         in: path
         name: budgetId
         required: true
-        type: integer
+        type: string
       responses:
         "204":
           description: ""
@@ -946,11 +946,11 @@ paths:
     get:
       description: Returns a specific budget
       parameters:
-      - description: ID of the budget
+      - description: ID formatted as string
         in: path
         name: budgetId
         required: true
-        type: integer
+        type: string
       produces:
       - application/json
       responses:
@@ -975,11 +975,11 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: ID of the budget
+      - description: ID formatted as string
         in: path
         name: budgetId
         required: true
-        type: integer
+        type: string
       responses:
         "204":
           description: ""
@@ -1002,11 +1002,11 @@ paths:
       description: Update an existing budget. Only values to be updated need to be
         specified.
       parameters:
-      - description: ID of the budget
+      - description: ID formatted as string
         in: path
         name: budgetId
         required: true
-        type: integer
+        type: string
       - description: Budget
         in: body
         name: budget
@@ -1037,11 +1037,11 @@ paths:
     get:
       description: Returns data about a budget for a for a specific month
       parameters:
-      - description: ID of the budget
+      - description: ID formatted as string
         in: path
         name: budgetId
         required: true
-        type: integer
+        type: string
       - description: The month in YYYY-MM format
         in: path
         name: month
@@ -1138,11 +1138,11 @@ paths:
     delete:
       description: Deletes an existing category
       parameters:
-      - description: ID of the category
+      - description: ID formatted as string
         in: path
         name: categoryId
         required: true
-        type: integer
+        type: string
       responses:
         "204":
           description: ""
@@ -1162,11 +1162,11 @@ paths:
     get:
       description: Returns a category by its ID
       parameters:
-      - description: ID of the category
+      - description: ID formatted as string
         in: path
         name: categoryId
         required: true
-        type: integer
+        type: string
       produces:
       - application/json
       responses:
@@ -1191,11 +1191,11 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: ID of the category
+      - description: ID formatted as string
         in: path
         name: categoryId
         required: true
-        type: integer
+        type: string
       responses:
         "204":
           description: ""
@@ -1214,11 +1214,11 @@ paths:
       description: Update an existing category. Only values to be updated need to
         be specified.
       parameters:
-      - description: ID of the category
+      - description: ID formatted as string
         in: path
         name: categoryId
         required: true
-        type: integer
+        type: string
       - description: Category
         in: body
         name: category
@@ -1310,11 +1310,11 @@ paths:
     delete:
       description: Deletes an existing envelope
       parameters:
-      - description: ID of the envelope
+      - description: ID formatted as string
         in: path
         name: envelopeId
         required: true
-        type: integer
+        type: string
       responses:
         "204":
           description: ""
@@ -1334,11 +1334,11 @@ paths:
     get:
       description: Returns an envelope by its ID
       parameters:
-      - description: ID of the envelope
+      - description: ID formatted as string
         in: path
         name: envelopeId
         required: true
-        type: integer
+        type: string
       produces:
       - application/json
       responses:
@@ -1363,11 +1363,11 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: ID of the envelope
+      - description: ID formatted as string
         in: path
         name: envelopeId
         required: true
-        type: integer
+        type: string
       responses:
         "204":
           description: ""
@@ -1380,11 +1380,11 @@ paths:
       description: Update an existing envelope. Only values to be updated need to
         be specified.
       parameters:
-      - description: ID of the envelope
+      - description: ID formatted as string
         in: path
         name: envelopeId
         required: true
-        type: integer
+        type: string
       - description: Envelope
         in: body
         name: envelope
@@ -1415,11 +1415,11 @@ paths:
     get:
       description: Returns data about an envelope for a for a specific month
       parameters:
-      - description: ID of the envelope
+      - description: ID formatted as string
         in: path
         name: envelopeId
         required: true
-        type: integer
+        type: string
       - description: The month in YYYY-MM format
         in: path
         name: month
@@ -1510,11 +1510,11 @@ paths:
     delete:
       description: Deletes an existing transaction
       parameters:
-      - description: ID of the transaction
+      - description: ID formatted as string
         in: path
         name: transactionId
         required: true
-        type: integer
+        type: string
       responses:
         "204":
           description: ""
@@ -1534,11 +1534,11 @@ paths:
     get:
       description: Returns a transaction by its ID
       parameters:
-      - description: ID of the transaction
+      - description: ID formatted as string
         in: path
         name: transactionId
         required: true
-        type: integer
+        type: string
       produces:
       - application/json
       responses:
@@ -1563,11 +1563,11 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: ID of the transaction
+      - description: ID formatted as string
         in: path
         name: transactionId
         required: true
-        type: integer
+        type: string
       responses:
         "204":
           description: ""
@@ -1580,11 +1580,11 @@ paths:
       description: Update an existing transaction. Only values to be updated need
         to be specified.
       parameters:
-      - description: ID of the transaction
+      - description: ID formatted as string
         in: path
         name: transactionId
         required: true
-        type: integer
+        type: string
       - description: Transaction
         in: body
         name: transaction

--- a/pkg/controllers/account.go
+++ b/pkg/controllers/account.go
@@ -64,7 +64,7 @@ func OptionsAccountList(c *gin.Context) {
 // @Success      204
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
-// @Param        accountId  path      uint64  true  "ID of the account"
+// @Param        accountId  path  string  true  "ID formatted as string"
 // @Router       /v1/accounts/{accountId} [options]
 func OptionsAccountDetail(c *gin.Context) {
 	httputil.OptionsGetPatchDelete(c)
@@ -134,7 +134,7 @@ func GetAccounts(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500        {object}  httputil.HTTPError
-// @Param        accountId  path      uint64                true  "ID of the account"
+// @Param        accountId  path      string  true  "ID formatted as string"
 // @Router       /v1/accounts/{accountId} [get]
 func GetAccount(c *gin.Context) {
 	p, err := uuid.Parse(c.Param("accountId"))
@@ -159,7 +159,7 @@ func GetAccount(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500        {object}  httputil.HTTPError
-// @Param        accountId  path      uint64  true  "ID of the account"
+// @Param        accountId  path      string                true  "ID formatted as string"
 // @Param        account    body      models.AccountCreate  true  "Account"
 // @Router       /v1/accounts/{accountId} [patch]
 func UpdateAccount(c *gin.Context) {
@@ -192,7 +192,7 @@ func UpdateAccount(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500        {object}  httputil.HTTPError
-// @Param        accountId  path  uint64  true  "ID of the account"
+// @Param        accountId  path      string  true  "ID formatted as string"
 // @Router       /v1/accounts/{accountId} [delete]
 func DeleteAccount(c *gin.Context) {
 	p, err := uuid.Parse(c.Param("accountId"))

--- a/pkg/controllers/allocation.go
+++ b/pkg/controllers/allocation.go
@@ -64,7 +64,7 @@ func OptionsAllocationList(c *gin.Context) {
 // @Description  Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 // @Tags         Allocations
 // @Success      204
-// @Param        allocationId  path  uint64  true  "ID of the allocation"
+// @Param        allocationId  path  string  true  "ID formatted as string"
 // @Router       /v1/allocations/{allocationId} [options]
 func OptionsAllocationDetail(c *gin.Context) {
 	httputil.OptionsGetPatchDelete(c)
@@ -157,7 +157,7 @@ func GetAllocations(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500           {object}  httputil.HTTPError
-// @Param        allocationId  path      uint64  true  "ID of the allocation"
+// @Param        allocationId  path      string  true  "ID formatted as string"
 // @Router       /v1/allocations/{allocationId} [get]
 func GetAllocation(c *gin.Context) {
 	p, err := uuid.Parse(c.Param("allocationId"))
@@ -183,7 +183,7 @@ func GetAllocation(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500           {object}  httputil.HTTPError
-// @Param        allocationId  path      uint64                   true  "ID of the allocation"
+// @Param        allocationId  path      string                   true  "ID formatted as string"
 // @Param        allocation  body      models.AllocationCreate  true  "Allocation"
 // @Router       /v1/allocations/{allocationId} [patch]
 func UpdateAllocation(c *gin.Context) {
@@ -216,7 +216,7 @@ func UpdateAllocation(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500         {object}  httputil.HTTPError
-// @Param        allocationId  path      uint64  true  "ID of the allocation"
+// @Param        allocationId  path      string  true  "ID formatted as string"
 // @Router       /v1/allocations/{allocationId} [delete]
 func DeleteAllocation(c *gin.Context) {
 	p, err := uuid.Parse(c.Param("allocationId"))

--- a/pkg/controllers/budget.go
+++ b/pkg/controllers/budget.go
@@ -74,7 +74,7 @@ func OptionsBudgetList(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500       {object}  httputil.HTTPError
-// @Param        budgetId  path      uint64  true  "ID of the budget"
+// @Param        budgetId  path      string  true  "ID formatted as string"
 // @Router       /v1/budgets/{budgetId} [options]
 func OptionsBudgetDetail(c *gin.Context) {
 	httputil.OptionsGetPatchDelete(c)
@@ -135,7 +135,7 @@ func GetBudgets(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500       {object}  httputil.HTTPError
-// @Param        budgetId  path      uint64  true  "ID of the budget"
+// @Param        budgetId  path      string  true  "ID formatted as string"
 // @Router       /v1/budgets/{budgetId} [get]
 func GetBudget(c *gin.Context) {
 	p, err := uuid.Parse(c.Param("budgetId"))
@@ -160,7 +160,7 @@ func GetBudget(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500  {object}  httputil.HTTPError
-// @Param        budgetId  path      uint64  true  "ID of the budget"
+// @Param        budgetId  path      string  true  "ID formatted as string"
 // @Param        month     path      string  true  "The month in YYYY-MM format"
 // @Router       /v1/budgets/{budgetId}/{month} [get]
 func GetBudgetMonth(c *gin.Context) {
@@ -224,7 +224,7 @@ func GetBudgetMonth(c *gin.Context) {
 // @Failure      400     {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500  {object}  httputil.HTTPError
-// @Param        budgetId  path      uint64               true  "ID of the budget"
+// @Param        budgetId  path      string               true  "ID formatted as string"
 // @Param        budget  body      models.BudgetCreate  true  "Budget"
 // @Router       /v1/budgets/{budgetId} [patch]
 func UpdateBudget(c *gin.Context) {
@@ -256,7 +256,7 @@ func UpdateBudget(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500     {object}  httputil.HTTPError
-// @Param        budgetId  path      uint64  true  "ID of the budget"
+// @Param        budgetId  path      string  true  "ID formatted as string"
 // @Router       /v1/budgets/{budgetId} [delete]
 func DeleteBudget(c *gin.Context) {
 	p, err := uuid.Parse(c.Param("budgetId"))

--- a/pkg/controllers/category.go
+++ b/pkg/controllers/category.go
@@ -64,7 +64,7 @@ func OptionsCategoryList(c *gin.Context) {
 // @Success      204
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
-// @Param        categoryId  path  uint64  true  "ID of the category"
+// @Param        categoryId  path  string  true  "ID formatted as string"
 // @Router       /v1/categories/{categoryId} [options]
 func OptionsCategoryDetail(c *gin.Context) {
 	httputil.OptionsGetPatchDelete(c)
@@ -134,7 +134,7 @@ func GetCategories(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500         {object}  httputil.HTTPError
-// @Param        categoryId  path      uint64  true  "ID of the category"
+// @Param        categoryId  path      string  true  "ID formatted as string"
 // @Router       /v1/categories/{categoryId} [get]
 func GetCategory(c *gin.Context) {
 	p, err := uuid.Parse(c.Param("categoryId"))
@@ -160,7 +160,7 @@ func GetCategory(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500         {object}  httputil.HTTPError
-// @Param        categoryId  path      uint64                 true  "ID of the category"
+// @Param        categoryId  path      string                 true  "ID formatted as string"
 // @Param        category  body      models.CategoryCreate  true  "Category"
 // @Router       /v1/categories/{categoryId} [patch]
 func UpdateCategory(c *gin.Context) {
@@ -192,7 +192,7 @@ func UpdateCategory(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500         {object}  httputil.HTTPError
-// @Param        categoryId  path      uint64  true  "ID of the category"
+// @Param        categoryId  path      string  true  "ID formatted as string"
 // @Router       /v1/categories/{categoryId} [delete]
 func DeleteCategory(c *gin.Context) {
 	p, err := uuid.Parse(c.Param("categoryId"))

--- a/pkg/controllers/envelope.go
+++ b/pkg/controllers/envelope.go
@@ -67,7 +67,7 @@ func OptionsEnvelopeList(c *gin.Context) {
 // @Description  Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 // @Tags         Envelopes
 // @Success      204
-// @Param        envelopeId  path  uint64  true  "ID of the envelope"
+// @Param        envelopeId  path  string  true  "ID formatted as string"
 // @Router       /v1/envelopes/{envelopeId} [options]
 func OptionsEnvelopeDetail(c *gin.Context) {
 	httputil.OptionsGetPatchDelete(c)
@@ -137,7 +137,7 @@ func GetEnvelopes(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500         {object}  httputil.HTTPError
-// @Param        envelopeId  path      uint64                 true  "ID of the envelope"
+// @Param        envelopeId  path      string  true  "ID formatted as string"
 // @Router       /v1/envelopes/{envelopeId} [get]
 func GetEnvelope(c *gin.Context) {
 	p, err := uuid.Parse(c.Param("envelopeId"))
@@ -162,7 +162,7 @@ func GetEnvelope(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500         {object}  httputil.HTTPError
-// @Param        envelopeId  path      uint64  true  "ID of the envelope"
+// @Param        envelopeId  path      string  true  "ID formatted as string"
 // @Param        month       path      string  true  "The month in YYYY-MM format"
 // @Router       /v1/envelopes/{envelopeId}/{month} [get]
 func GetEnvelopeMonth(c *gin.Context) {
@@ -196,7 +196,7 @@ func GetEnvelopeMonth(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500         {object}  httputil.HTTPError
-// @Param        envelopeId  path      uint64  true  "ID of the envelope"
+// @Param        envelopeId  path      string                 true  "ID formatted as string"
 // @Param        envelope    body      models.EnvelopeCreate  true  "Envelope"
 // @Router       /v1/envelopes/{envelopeId} [patch]
 func UpdateEnvelope(c *gin.Context) {
@@ -228,7 +228,7 @@ func UpdateEnvelope(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500         {object}  httputil.HTTPError
-// @Param        envelopeId  path      uint64  true  "ID of the envelope"
+// @Param        envelopeId  path      string  true  "ID formatted as string"
 // @Router       /v1/envelopes/{envelopeId} [delete]
 func DeleteEnvelope(c *gin.Context) {
 	p, err := uuid.Parse(c.Param("envelopeId"))

--- a/pkg/controllers/transaction.go
+++ b/pkg/controllers/transaction.go
@@ -61,7 +61,7 @@ func OptionsTransactionList(c *gin.Context) {
 // @Description  Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 // @Tags         Transactions
 // @Success      204
-// @Param        transactionId  path  uint64  true  "ID of the transaction"
+// @Param        transactionId  path  string  true  "ID formatted as string"
 // @Router       /v1/transactions/{transactionId} [options]
 func OptionsTransactionDetail(c *gin.Context) {
 	httputil.OptionsGetPatchDelete(c)
@@ -135,7 +135,7 @@ func GetTransactions(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500            {object}  httputil.HTTPError
-// @Param        transactionId  path      uint64  true  "ID of the transaction"
+// @Param        transactionId  path      string  true  "ID formatted as string"
 // @Router       /v1/transactions/{transactionId} [get]
 func GetTransaction(c *gin.Context) {
 	p, err := uuid.Parse(c.Param("transactionId"))
@@ -161,7 +161,7 @@ func GetTransaction(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500            {object}  httputil.HTTPError
-// @Param        transactionId  path      uint64                    true  "ID of the transaction"
+// @Param        transactionId  path      string                    true  "ID formatted as string"
 // @Param        transaction    body      models.TransactionCreate  true  "Transaction"
 // @Router       /v1/transactions/{transactionId} [patch]
 func UpdateTransaction(c *gin.Context) {
@@ -204,7 +204,7 @@ func UpdateTransaction(c *gin.Context) {
 // @Failure      400  {object}  httputil.HTTPError
 // @Failure      404
 // @Failure      500            {object}  httputil.HTTPError
-// @Param        transactionId  path      uint64  true  "ID of the transaction"
+// @Param        transactionId  path      string  true  "ID formatted as string"
 // @Router       /v1/transactions/{transactionId} [delete]
 func DeleteTransaction(c *gin.Context) {
 	p, err := uuid.Parse(c.Param("transactionId"))


### PR DESCRIPTION
Fixes the API documentation to use strings, not uint64 as ID value.
