### PR TITLE
test: allow code coverage of diff to be 25% less than total coverage

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -13,7 +13,7 @@ coverage:
     patch:
       default:
         target: auto
-        threshold: 10%
+        threshold: 25%
 
 ignore:
   - "internal/test" # test helpers, those are tested by the tests themselves


### PR DESCRIPTION
This allows code coverage of diff to be 25% less than total coverage. This is sometimes needed for small changes containing untestable error handling.
