### PR TITLE
feat: enable foreign keys for SQLite

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "cwd": "${workspaceFolder}",
       "program": "${workspaceFolder}/main.go",
       "env": {
-        "LOG_LEVEL": "debug"
+        "GIN_MODE": "debug"
       },
       "console": "integratedTerminal"
     },

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 			panic("Could not create data directory")
 		}
 
-		dsn = "data/gorm.db"
+		dsn = "data/gorm.db?_pragma=foreign_keys(1)"
 		dialector = sqlite.Open
 	}
 

--- a/pkg/controllers/account.go
+++ b/pkg/controllers/account.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -214,6 +215,12 @@ func DeleteAccount(c *gin.Context) {
 
 // getAccountResource is the internal helper to verify permissions and return an account.
 func getAccountResource(c *gin.Context, id uuid.UUID) (models.Account, error) {
+	if id == uuid.Nil {
+		err := errors.New("No account ID specified")
+		httputil.NewError(c, http.StatusBadRequest, err)
+		return models.Account{}, err
+	}
+
 	var account models.Account
 
 	err := database.DB.Where(&models.Account{

--- a/pkg/controllers/account_test.go
+++ b/pkg/controllers/account_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func createTestAccount(t *testing.T, c models.AccountCreate) controllers.AccountResponse {
+	if c.BudgetID == uuid.Nil {
+		c.BudgetID = createTestBudget(t, models.BudgetCreate{Name: "Testing budget"}).Data.ID
+	}
+
 	r := test.Request(t, http.MethodPost, "http://example.com/v1/accounts", c)
 	test.AssertHTTPStatus(t, http.StatusCreated, &r)
 
@@ -113,6 +117,11 @@ func (suite *TestSuiteEnv) TestCreateAccount() {
 	_ = createTestAccount(suite.T(), models.AccountCreate{Name: "Test account for creation"})
 }
 
+func (suite *TestSuiteEnv) TestCreateAccountNoBudget() {
+	r := test.Request(suite.T(), http.MethodPost, "http://example.com/v1/accounts", models.Account{})
+	test.AssertHTTPStatus(suite.T(), http.StatusBadRequest, &r)
+}
+
 func (suite *TestSuiteEnv) TestCreateBrokenAccount() {
 	recorder := test.Request(suite.T(), http.MethodPost, "http://example.com/v1/accounts", `{ "createdAt": "New Account", "note": "More tests for accounts to ensure less brokenness something" }`)
 	test.AssertHTTPStatus(suite.T(), http.StatusBadRequest, &recorder)
@@ -123,7 +132,7 @@ func (suite *TestSuiteEnv) TestCreateAccountNoBody() {
 	test.AssertHTTPStatus(suite.T(), http.StatusBadRequest, &recorder)
 }
 
-func (suite *TestSuiteEnv) TestCreateAccountNoBudget() {
+func (suite *TestSuiteEnv) TestCreateAccountNonExistingBudget() {
 	recorder := test.Request(suite.T(), http.MethodPost, "http://example.com/v1/accounts", models.AccountCreate{BudgetID: uuid.New()})
 	test.AssertHTTPStatus(suite.T(), http.StatusNotFound, &recorder)
 }

--- a/pkg/controllers/allocation.go
+++ b/pkg/controllers/allocation.go
@@ -238,6 +238,12 @@ func DeleteAllocation(c *gin.Context) {
 
 // getAllocationResource verifies that the request URI is valid for the transaction and returns it.
 func getAllocationResource(c *gin.Context, id uuid.UUID) (models.Allocation, error) {
+	if id == uuid.Nil {
+		err := errors.New("No allocation ID specified")
+		httputil.NewError(c, http.StatusBadRequest, err)
+		return models.Allocation{}, err
+	}
+
 	var allocation models.Allocation
 
 	err := database.DB.First(&allocation, &models.Allocation{

--- a/pkg/controllers/allocation_test.go
+++ b/pkg/controllers/allocation_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func createTestAllocation(t *testing.T, c models.AllocationCreate) controllers.AllocationResponse {
+	if c.EnvelopeID == uuid.Nil {
+		c.EnvelopeID = createTestEnvelope(t, models.EnvelopeCreate{Name: "Transaction Test Envelope"}).Data.ID
+	}
+
 	r := test.Request(t, "POST", "http://example.com/v1/allocations", c)
 	test.AssertHTTPStatus(t, http.StatusCreated, &r)
 
@@ -95,6 +99,11 @@ func (suite *TestSuiteEnv) TestCreateAllocation() {
 	}
 }
 
+func (suite *TestSuiteEnv) TestCreateAllocationNoEnvelope() {
+	r := test.Request(suite.T(), http.MethodPost, "http://example.com/v1/allocations", models.Allocation{})
+	test.AssertHTTPStatus(suite.T(), http.StatusBadRequest, &r)
+}
+
 func (suite *TestSuiteEnv) TestCreateBrokenAllocation() {
 	recorder := test.Request(suite.T(), "POST", "http://example.com/v1/allocations", `{ "createdAt": "New Allocation" }`)
 	test.AssertHTTPStatus(suite.T(), http.StatusBadRequest, &recorder)
@@ -171,4 +180,9 @@ func (suite *TestSuiteEnv) TestDeleteAllocationWithBody() {
 
 	r := test.Request(suite.T(), "DELETE", a.Data.Links.Self, models.AllocationCreate{Year: 2011, Month: 3})
 	test.AssertHTTPStatus(suite.T(), http.StatusNoContent, &r)
+}
+
+func (suite *TestSuiteEnv) TestDeleteNullAllocation() {
+	r := test.Request(suite.T(), "DELETE", "http://example.com/v1/allocations/00000000-0000-0000-0000-000000000000", "")
+	test.AssertHTTPStatus(suite.T(), http.StatusBadRequest, &r)
 }

--- a/pkg/controllers/budget.go
+++ b/pkg/controllers/budget.go
@@ -300,6 +300,12 @@ func DeleteBudget(c *gin.Context) {
 
 // getBudgetResource is the internal helper to verify permissions and return a budget.
 func getBudgetResource(c *gin.Context, id uuid.UUID) (models.Budget, error) {
+	if id == uuid.Nil {
+		err := errors.New("No budget ID specified")
+		httputil.NewError(c, http.StatusBadRequest, err)
+		return models.Budget{}, err
+	}
+
 	var budget models.Budget
 
 	err := database.DB.Where(&models.Budget{

--- a/pkg/controllers/category.go
+++ b/pkg/controllers/category.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -213,6 +214,12 @@ func DeleteCategory(c *gin.Context) {
 }
 
 func getCategoryResource(c *gin.Context, id uuid.UUID) (models.Category, error) {
+	if id == uuid.Nil {
+		err := errors.New("No category ID specified")
+		httputil.NewError(c, http.StatusBadRequest, err)
+		return models.Category{}, err
+	}
+
 	var category models.Category
 
 	err := database.DB.Where(&models.Category{

--- a/pkg/controllers/envelope.go
+++ b/pkg/controllers/envelope.go
@@ -250,6 +250,12 @@ func DeleteEnvelope(c *gin.Context) {
 
 // getEnvelopeResource verifies that the envelope from the URL parameters exists and returns it.
 func getEnvelopeResource(c *gin.Context, id uuid.UUID) (models.Envelope, error) {
+	if id == uuid.Nil {
+		err := errors.New("No envelope ID specified")
+		httputil.NewError(c, http.StatusBadRequest, err)
+		return models.Envelope{}, err
+	}
+
 	var envelope models.Envelope
 
 	err := database.DB.Where(&models.Envelope{

--- a/pkg/controllers/main_test.go
+++ b/pkg/controllers/main_test.go
@@ -36,7 +36,7 @@ func (suite *TestSuiteEnv) TearDownTest() {
 
 // SetupTest is called before each test in the suite.
 func (suite *TestSuiteEnv) SetupTest() {
-	err := database.ConnectDatabase(sqlite.Open, ":memory:")
+	err := database.ConnectDatabase(sqlite.Open, ":memory:?_pragma=foreign_keys(1)")
 	if err != nil {
 		log.Fatalf("Database connection failed with: %s", err.Error())
 	}

--- a/pkg/controllers/transaction.go
+++ b/pkg/controllers/transaction.go
@@ -91,6 +91,24 @@ func CreateTransaction(c *gin.Context) {
 		return
 	}
 
+	// Check the source account
+	_, err = getAccountResource(c, transaction.SourceAccountID)
+	if err != nil {
+		return
+	}
+
+	// Check the destination account
+	_, err = getAccountResource(c, transaction.DestinationAccountID)
+	if err != nil {
+		return
+	}
+
+	// Check the envelope
+	_, err = getEnvelopeResource(c, transaction.EnvelopeID)
+	if err != nil {
+		return
+	}
+
 	if !decimal.Decimal.IsPositive(transaction.Amount) {
 		httputil.NewError(c, http.StatusBadRequest, errors.New("The transaction amount must be positive"))
 		return
@@ -226,6 +244,12 @@ func DeleteTransaction(c *gin.Context) {
 
 // getTransactionResource verifies that the request URI is valid for the transaction and returns it.
 func getTransactionResource(c *gin.Context, id uuid.UUID) (models.Transaction, error) {
+	if id == uuid.Nil {
+		err := errors.New("No transaction ID specified")
+		httputil.NewError(c, http.StatusBadRequest, err)
+		return models.Transaction{}, err
+	}
+
 	var transaction models.Transaction
 
 	err := database.DB.First(&transaction, &models.Transaction{

--- a/pkg/models/main_test.go
+++ b/pkg/models/main_test.go
@@ -34,7 +34,7 @@ func (suite *TestSuiteEnv) TearDownTest() {
 
 // SetupTest is called before each test in the suite.
 func (suite *TestSuiteEnv) SetupTest() {
-	err := database.ConnectDatabase(sqlite.Open, ":memory:")
+	err := database.ConnectDatabase(sqlite.Open, ":memory:?_pragma=foreign_keys(1)")
 	if err != nil {
 		log.Fatalf("Database connection failed with: %s", err.Error())
 	}

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -60,7 +60,7 @@ func Request(t *testing.T, method, url string, body any, headers ...map[string]s
 }
 
 func AssertHTTPStatus(t *testing.T, expected int, r *httptest.ResponseRecorder) {
-	assert.Equal(t, expected, r.Code, "HTTP status is wrong. Response body: %s", r.Body.String())
+	assert.Equal(t, expected, r.Code, "HTTP status is wrong. Request ID: '%s' Response body: %s", r.Result().Header.Get("x-request-id"), r.Body.String())
 }
 
 // DecodeResponse decodes an HTTP response into a target struct.


### PR DESCRIPTION
This enables foreign keys for SQLite. As they cannot be null, tests needed to be updated. This will also break the current frontend version (0.14.0)
