### PR TITLE
feat: add query filtering for accounts

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -84,6 +84,38 @@ const docTemplate = `{
                     "Accounts"
                 ],
                 "summary": "List accounts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by note",
+                        "name": "note",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by budget ID",
+                        "name": "budget",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Filter by on/off-budget",
+                        "name": "onBudget",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Filter internal/external",
+                        "name": "external",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -597,19 +629,19 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Name of the budget",
+                        "description": "Filter by name",
                         "name": "name",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Note for the budget",
+                        "description": "Filter by note",
                         "name": "note",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Currency the budget is in",
+                        "description": "Filter by currency",
                         "name": "currency",
                         "in": "query"
                     }
@@ -1810,7 +1842,7 @@ const docTemplate = `{
                 },
                 "transactions": {
                     "type": "string",
-                    "example": "https://example.com/api/v1/transactions?account♫=af892e10-7e0a-4fb8-b1bc-4b6d88401ed2"
+                    "example": "https://example.com/api/v1/transactions?account=af892e10-7e0a-4fb8-b1bc-4b6d88401ed2"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -72,6 +72,38 @@
                     "Accounts"
                 ],
                 "summary": "List accounts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by note",
+                        "name": "note",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by budget ID",
+                        "name": "budget",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Filter by on/off-budget",
+                        "name": "onBudget",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Filter internal/external",
+                        "name": "external",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -585,19 +617,19 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Name of the budget",
+                        "description": "Filter by name",
                         "name": "name",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Note for the budget",
+                        "description": "Filter by note",
                         "name": "note",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Currency the budget is in",
+                        "description": "Filter by currency",
                         "name": "currency",
                         "in": "query"
                     }
@@ -1798,7 +1830,7 @@
                 },
                 "transactions": {
                     "type": "string",
-                    "example": "https://example.com/api/v1/transactions?account♫=af892e10-7e0a-4fb8-b1bc-4b6d88401ed2"
+                    "example": "https://example.com/api/v1/transactions?account=af892e10-7e0a-4fb8-b1bc-4b6d88401ed2"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -41,7 +41,7 @@ definitions:
         example: https://example.com/api/v1/accounts/af892e10-7e0a-4fb8-b1bc-4b6d88401ed2
         type: string
       transactions:
-        example: https://example.com/api/v1/transactions?account♫=af892e10-7e0a-4fb8-b1bc-4b6d88401ed2
+        example: https://example.com/api/v1/transactions?account=af892e10-7e0a-4fb8-b1bc-4b6d88401ed2
         type: string
     type: object
   controllers.AccountListResponse:
@@ -528,6 +528,27 @@ paths:
   /v1/accounts:
     get:
       description: Returns a list of all accounts
+      parameters:
+      - description: Filter by name
+        in: query
+        name: name
+        type: string
+      - description: Filter by note
+        in: query
+        name: note
+        type: string
+      - description: Filter by budget ID
+        in: query
+        name: budget
+        type: string
+      - description: Filter by on/off-budget
+        in: query
+        name: onBudget
+        type: boolean
+      - description: Filter internal/external
+        in: query
+        name: external
+        type: boolean
       produces:
       - application/json
       responses:
@@ -873,15 +894,15 @@ paths:
     get:
       description: Returns list of budgets
       parameters:
-      - description: Name of the budget
+      - description: Filter by name
         in: query
         name: name
         type: string
-      - description: Note for the budget
+      - description: Filter by note
         in: query
         name: note
         type: string
-      - description: Currency the budget is in
+      - description: Filter by currency
         in: query
         name: currency
         type: string

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/rs/zerolog/log"
 	gorm_zerolog "github.com/wei840222/gorm-zerolog"
 	"gorm.io/gorm"
 )
@@ -25,7 +24,6 @@ func ConnectDatabase(dialector func(string) gorm.Dialector, dsn string) error {
 		Logger: gorm_zerolog.New(),
 	}
 
-	log.Info().Str("dsn", dsn).Msg("Connecting database")
 	db, err = gorm.Open(dialector(dsn), config)
 	if err != nil {
 		return fmt.Errorf("failed to connect to database: %v", err)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -92,9 +92,8 @@ func Router() (*gin.Engine, error) {
 		}))
 	}
 
-	gin.DebugPrintRouteFunc = func(httpMethod, absolutePath, handlerName string, numHandlers int) {
-		log.Debug().Str("method", httpMethod).Str("path", absolutePath).Str("handler", handlerName).Int("handlers", numHandlers).Msg("route")
-	}
+	// Disable the gin debug route printing as it clutters logs (and test logs)
+	gin.DebugPrintRouteFunc = func(httpMethod, absolutePath, handlerName string, numHandlers int) {}
 
 	// Don’t trust any proxy. We do not process any client IPs,
 	// therefore we don’t need to trust anyone here.

--- a/pkg/controllers/budget.go
+++ b/pkg/controllers/budget.go
@@ -39,7 +39,8 @@ type BudgetMonthResponse struct {
 }
 
 type BudgetQueryFilter struct {
-	QueryFilter
+	Name     string `form:"name"`
+	Note     string `form:"note"`
 	Currency string `form:"currency"`
 }
 
@@ -117,16 +118,14 @@ func CreateBudget(c *gin.Context) {
 // @Failure      500       {object}  httputil.HTTPError
 // @Router       /v1/budgets [get]
 // @Router       /v1/budgets [get]
-// @Param        name      query  string  false  "Name of the budget"
-// @Param        note      query  string  false  "Note for the budget"
-// @Param        currency  query  string  false  "Currency the budget is in"
+// @Param        name      query  string  false  "Filter by name"
+// @Param        note      query  string  false  "Filter by note"
+// @Param        currency  query  string  false  "Filter by currency"
 func GetBudgets(c *gin.Context) {
 	var f BudgetQueryFilter
 
-	// We should find something that is not parseable and test this line
-	if err := c.Bind(&f); err != nil {
-		return
-	}
+	// Every parameter is bound into a string, so this will always succeed
+	_ = c.Bind(&f)
 
 	var budgets []models.Budget
 	database.DB.Where(&models.Budget{

--- a/pkg/controllers/types.go
+++ b/pkg/controllers/types.go
@@ -10,8 +10,3 @@ import (
 type URIMonth struct {
 	Month time.Time `uri:"month" time_format:"2006-01" time_utc:"1"`
 }
-
-type QueryFilter struct {
-	Name string `form:"name"`
-	Note string `form:"note"`
-}

--- a/pkg/httputil/error.go
+++ b/pkg/httputil/error.go
@@ -51,3 +51,7 @@ type HTTPError struct {
 func ErrorInvalidUUID(c *gin.Context) {
 	NewError(c, http.StatusBadRequest, errors.New("The specified resource ID is not a valid UUID"))
 }
+
+func ErrorInvalidQueryString(c *gin.Context) {
+	NewError(c, http.StatusBadRequest, errors.New("The query string contains unparseable data. Please check the values"))
+}

--- a/pkg/httputil/error_test.go
+++ b/pkg/httputil/error_test.go
@@ -83,3 +83,17 @@ func TestErrorInvalidUUID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, test.DecodeError(t, w.Body.Bytes()), "not a valid UUID")
 }
+
+func TestErrorUnparseableData(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", func(ctx *gin.Context) {
+		httputil.ErrorInvalidQueryString(c)
+	})
+
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	r.ServeHTTP(w, c.Request)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, test.DecodeError(t, w.Body.Bytes()), "unparseable data")
+}

--- a/pkg/httputil/query.go
+++ b/pkg/httputil/query.go
@@ -1,0 +1,23 @@
+package httputil
+
+import (
+	"net/url"
+	"reflect"
+)
+
+func GetFields(url *url.URL, filter any) []any {
+	var queryFields []any
+
+	// Add all parameters set in the query string to the queryFields
+	// This is used to determine which fields are queried in the database
+	val := reflect.Indirect(reflect.ValueOf(filter))
+	for i := 0; i < val.NumField(); i++ {
+		field := val.Type().Field(i).Name
+		param := val.Type().Field(i).Tag.Get("form")
+
+		if url.Query().Has(param) {
+			queryFields = append(queryFields, field)
+		}
+	}
+	return queryFields
+}

--- a/pkg/httputil/query_test.go
+++ b/pkg/httputil/query_test.go
@@ -1,0 +1,18 @@
+package httputil_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/envelope-zero/backend/pkg/controllers"
+	"github.com/envelope-zero/backend/pkg/httputil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFields(t *testing.T) {
+	url, _ := url.Parse("http://example.com/api/v1/accounts?budget=87645467-ad8a-4e16-ae7f-9d879b45f569&onBudget=false")
+
+	queryFields := httputil.GetFields(url, controllers.AccountQueryFilter{})
+
+	assert.Equal(t, []interface{}{"BudgetID", "OnBudget"}, queryFields)
+}

--- a/pkg/httputil/request.go
+++ b/pkg/httputil/request.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-contrib/requestid"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
 
@@ -75,4 +76,20 @@ func BindData(c *gin.Context, data interface{}) error {
 	}
 
 	return nil
+}
+
+// This is needed because gin does not support form binding to uuid.UUID currently.
+// Follow https://github.com/gin-gonic/gin/pull/3045 to see when this gets resolved.
+func UUIDFromString(c *gin.Context, s string) (uuid.UUID, error) {
+	if s == "" {
+		return uuid.UUID{}, nil
+	}
+
+	u, err := uuid.Parse(s)
+	if err != nil {
+		ErrorInvalidUUID(c)
+		return uuid.UUID{}, err
+	}
+
+	return u, nil
 }


### PR DESCRIPTION
Adds filtering for accounts. 

This adds a workaround for gin not being able to bind custom fields. The resolution of the workaround is tracked in #223.
