### PR TITLE
docs: add missing swagger types and examples

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1787,7 +1787,8 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "balance": {
-                    "type": "number"
+                    "type": "number",
+                    "example": 2735.17
                 },
                 "budgetId": {
                     "type": "string",
@@ -1798,11 +1799,13 @@ const docTemplate = `{
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "external": {
                     "type": "boolean",
-                    "example": true
+                    "default": false,
+                    "example": false
                 },
                 "id": {
                     "type": "string",
@@ -1813,19 +1816,21 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string",
-                    "example": "Checking"
+                    "example": "Cash"
                 },
                 "note": {
                     "type": "string",
-                    "example": "My bank account"
+                    "example": "Money in my wallet"
                 },
                 "onBudget": {
                     "description": "Always false when external: true",
                     "type": "boolean",
-                    "example": false
+                    "default": false,
+                    "example": true
                 },
                 "reconciledBalance": {
-                    "type": "number"
+                    "type": "number",
+                    "example": 2539.57
                 },
                 "updatedAt": {
                     "type": "string",
@@ -1869,17 +1874,24 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "amount": {
-                    "type": "number"
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 22.01
                 },
                 "createdAt": {
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "envelopeId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "a0909e84-e8f9-4cb6-82a5-025dff105ff2"
                 },
                 "id": {
                     "type": "string",
@@ -1889,14 +1901,18 @@ const docTemplate = `{
                     "$ref": "#/definitions/controllers.AllocationLinks"
                 },
                 "month": {
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 12,
+                    "minimum": 1,
+                    "example": 6
                 },
                 "updatedAt": {
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 },
                 "year": {
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 2022
                 }
             }
         },
@@ -1932,7 +1948,8 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "balance": {
-                    "type": "number"
+                    "type": "number",
+                    "example": 3423.42
                 },
                 "createdAt": {
                     "type": "string",
@@ -1943,7 +1960,8 @@ const docTemplate = `{
                     "example": "€"
                 },
                 "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "id": {
                     "type": "string",
@@ -1954,11 +1972,11 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string",
-                    "example": "My First Budget"
+                    "example": "Morre's Budget"
                 },
                 "note": {
                     "type": "string",
-                    "example": "A description so I remember what this was for"
+                    "example": "My personal expenses"
                 },
                 "updatedAt": {
                     "type": "string",
@@ -1978,8 +1996,9 @@ const docTemplate = `{
                     "example": "https://example.com/api/v1/categories?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"
                 },
                 "month": {
+                    "description": "This will always end in 'YYYY-MM' for clients to use replace with actual numbers.",
                     "type": "string",
-                    "example": "https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/2022-03"
+                    "example": "https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/YYYY-MM"
                 },
                 "self": {
                     "type": "string",
@@ -2022,14 +2041,16 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "budgetId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "52d967d3-33f4-4b04-9ba7-772e5ab9d0ce"
                 },
                 "createdAt": {
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "id": {
                     "type": "string",
@@ -2039,10 +2060,12 @@ const docTemplate = `{
                     "$ref": "#/definitions/controllers.CategoryLinks"
                 },
                 "name": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Saving"
                 },
                 "note": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "All envelopes for long-term saving"
                 },
                 "updatedAt": {
                     "type": "string",
@@ -2086,14 +2109,16 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "categoryId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "878c831f-af99-4a71-b3ca-80deb7d793c1"
                 },
                 "createdAt": {
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "id": {
                     "type": "string",
@@ -2103,10 +2128,12 @@ const docTemplate = `{
                     "$ref": "#/definitions/controllers.EnvelopeLinks"
                 },
                 "name": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Groceries"
                 },
                 "note": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "For stuff bought at supermarkets and drugstores"
                 },
                 "updatedAt": {
                     "type": "string",
@@ -2122,8 +2149,9 @@ const docTemplate = `{
                     "example": "https://example.com/api/v1/allocations?envelope=45b6b5b9-f746-4ae9-b77b-7688b91f8166"
                 },
                 "month": {
+                    "description": "This will always end in 'YYYY-MM' for clients to use replace with actual numbers.",
                     "type": "string",
-                    "example": "https://example.com/api/v1/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/2019-03"
+                    "example": "https://example.com/api/v1/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/YYYY-MM"
                 },
                 "self": {
                     "type": "string",
@@ -2162,26 +2190,36 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "amount": {
-                    "type": "number"
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 14.03
                 },
                 "budgetId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "55eecbd8-7c46-4b06-ada9-f287802fb05e"
                 },
                 "createdAt": {
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "date": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "1815-12-10T18:43:00.271152Z"
                 },
                 "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "destinationAccountId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "8e16b456-a719-48ce-9fec-e115cfa7cbcc"
                 },
                 "envelopeId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2649c965-7999-4873-ae16-89d5d5fa972e"
                 },
                 "id": {
                     "type": "string",
@@ -2191,13 +2229,17 @@ const docTemplate = `{
                     "$ref": "#/definitions/controllers.TransactionLinks"
                 },
                 "note": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Lunch"
                 },
                 "reconciled": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
                 },
                 "sourceAccountId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "fd81dc45-a3a2-468e-a6fa-b2618f30aa45"
                 },
                 "updatedAt": {
                     "type": "string",
@@ -2233,18 +2275,6 @@ const docTemplate = `{
                 }
             }
         },
-        "gorm.DeletedAt": {
-            "type": "object",
-            "properties": {
-                "time": {
-                    "type": "string"
-                },
-                "valid": {
-                    "description": "Valid is true if Time is not NULL",
-                    "type": "boolean"
-                }
-            }
-        },
         "httputil.HTTPError": {
             "type": "object",
             "properties": {
@@ -2263,20 +2293,22 @@ const docTemplate = `{
                 },
                 "external": {
                     "type": "boolean",
-                    "example": true
+                    "default": false,
+                    "example": false
                 },
                 "name": {
                     "type": "string",
-                    "example": "Checking"
+                    "example": "Cash"
                 },
                 "note": {
                     "type": "string",
-                    "example": "My bank account"
+                    "example": "Money in my wallet"
                 },
                 "onBudget": {
                     "description": "Always false when external: true",
                     "type": "boolean",
-                    "example": false
+                    "default": false,
+                    "example": true
                 }
             }
         },
@@ -2284,16 +2316,26 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "amount": {
-                    "type": "number"
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 22.01
                 },
                 "envelopeId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "a0909e84-e8f9-4cb6-82a5-025dff105ff2"
                 },
                 "month": {
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 12,
+                    "minimum": 1,
+                    "example": 6
                 },
                 "year": {
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 2022
                 }
             }
         },
@@ -2306,11 +2348,11 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string",
-                    "example": "My First Budget"
+                    "example": "Morre's Budget"
                 },
                 "note": {
                     "type": "string",
-                    "example": "A description so I remember what this was for"
+                    "example": "My personal expenses"
                 }
             }
         },
@@ -2324,16 +2366,19 @@ const docTemplate = `{
                     }
                 },
                 "id": {
+                    "description": "The ID of the Envelope",
                     "type": "string",
-                    "example": "23"
+                    "example": "1e777d24-3f5b-4c43-8000-04f65f895578"
                 },
                 "month": {
+                    "description": "This is always set to 00:00 UTC on the first of the month.",
                     "type": "string",
-                    "example": "2006-05-04T15:02:01.000000Z"
+                    "example": "2006-05-01T00:00:00.000000Z"
                 },
                 "name": {
+                    "description": "The name of the Envelope",
                     "type": "string",
-                    "example": "A test envelope"
+                    "example": "Groceries"
                 }
             }
         },
@@ -2341,13 +2386,16 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "budgetId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "52d967d3-33f4-4b04-9ba7-772e5ab9d0ce"
                 },
                 "name": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Saving"
                 },
                 "note": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "All envelopes for long-term saving"
                 }
             }
         },
@@ -2355,13 +2403,16 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "categoryId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "878c831f-af99-4a71-b3ca-80deb7d793c1"
                 },
                 "name": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Groceries"
                 },
                 "note": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "For stuff bought at supermarkets and drugstores"
                 }
             }
         },
@@ -2369,22 +2420,31 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "allocation": {
-                    "type": "number"
+                    "type": "number",
+                    "example": 85.44
                 },
                 "balance": {
-                    "type": "number"
+                    "type": "number",
+                    "example": 12.32
                 },
                 "id": {
-                    "type": "string"
+                    "description": "The ID of the Envelope",
+                    "type": "string",
+                    "example": "10b9705d-3356-459e-9d5a-28d42a6c4547"
                 },
                 "month": {
-                    "type": "string"
+                    "description": "This is always set to 00:00 UTC on the first of the month.",
+                    "type": "string",
+                    "example": "1969-06-01T00:00:00.000000Z"
                 },
                 "name": {
-                    "type": "string"
+                    "description": "The name of the Envelope",
+                    "type": "string",
+                    "example": "Groceries"
                 },
                 "spent": {
-                    "type": "number"
+                    "type": "number",
+                    "example": 73.12
                 }
             }
         },
@@ -2392,28 +2452,41 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "amount": {
-                    "type": "number"
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 14.03
                 },
                 "budgetId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "55eecbd8-7c46-4b06-ada9-f287802fb05e"
                 },
                 "date": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "1815-12-10T18:43:00.271152Z"
                 },
                 "destinationAccountId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "8e16b456-a719-48ce-9fec-e115cfa7cbcc"
                 },
                 "envelopeId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2649c965-7999-4873-ae16-89d5d5fa972e"
                 },
                 "note": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Lunch"
                 },
                 "reconciled": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
                 },
                 "sourceAccountId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "fd81dc45-a3a2-468e-a6fa-b2618f30aa45"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1775,7 +1775,8 @@
             "type": "object",
             "properties": {
                 "balance": {
-                    "type": "number"
+                    "type": "number",
+                    "example": 2735.17
                 },
                 "budgetId": {
                     "type": "string",
@@ -1786,11 +1787,13 @@
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "external": {
                     "type": "boolean",
-                    "example": true
+                    "default": false,
+                    "example": false
                 },
                 "id": {
                     "type": "string",
@@ -1801,19 +1804,21 @@
                 },
                 "name": {
                     "type": "string",
-                    "example": "Checking"
+                    "example": "Cash"
                 },
                 "note": {
                     "type": "string",
-                    "example": "My bank account"
+                    "example": "Money in my wallet"
                 },
                 "onBudget": {
                     "description": "Always false when external: true",
                     "type": "boolean",
-                    "example": false
+                    "default": false,
+                    "example": true
                 },
                 "reconciledBalance": {
-                    "type": "number"
+                    "type": "number",
+                    "example": 2539.57
                 },
                 "updatedAt": {
                     "type": "string",
@@ -1857,17 +1862,24 @@
             "type": "object",
             "properties": {
                 "amount": {
-                    "type": "number"
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 22.01
                 },
                 "createdAt": {
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "envelopeId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "a0909e84-e8f9-4cb6-82a5-025dff105ff2"
                 },
                 "id": {
                     "type": "string",
@@ -1877,14 +1889,18 @@
                     "$ref": "#/definitions/controllers.AllocationLinks"
                 },
                 "month": {
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 12,
+                    "minimum": 1,
+                    "example": 6
                 },
                 "updatedAt": {
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 },
                 "year": {
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 2022
                 }
             }
         },
@@ -1920,7 +1936,8 @@
             "type": "object",
             "properties": {
                 "balance": {
-                    "type": "number"
+                    "type": "number",
+                    "example": 3423.42
                 },
                 "createdAt": {
                     "type": "string",
@@ -1931,7 +1948,8 @@
                     "example": "€"
                 },
                 "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "id": {
                     "type": "string",
@@ -1942,11 +1960,11 @@
                 },
                 "name": {
                     "type": "string",
-                    "example": "My First Budget"
+                    "example": "Morre's Budget"
                 },
                 "note": {
                     "type": "string",
-                    "example": "A description so I remember what this was for"
+                    "example": "My personal expenses"
                 },
                 "updatedAt": {
                     "type": "string",
@@ -1966,8 +1984,9 @@
                     "example": "https://example.com/api/v1/categories?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"
                 },
                 "month": {
+                    "description": "This will always end in 'YYYY-MM' for clients to use replace with actual numbers.",
                     "type": "string",
-                    "example": "https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/2022-03"
+                    "example": "https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/YYYY-MM"
                 },
                 "self": {
                     "type": "string",
@@ -2010,14 +2029,16 @@
             "type": "object",
             "properties": {
                 "budgetId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "52d967d3-33f4-4b04-9ba7-772e5ab9d0ce"
                 },
                 "createdAt": {
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "id": {
                     "type": "string",
@@ -2027,10 +2048,12 @@
                     "$ref": "#/definitions/controllers.CategoryLinks"
                 },
                 "name": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Saving"
                 },
                 "note": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "All envelopes for long-term saving"
                 },
                 "updatedAt": {
                     "type": "string",
@@ -2074,14 +2097,16 @@
             "type": "object",
             "properties": {
                 "categoryId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "878c831f-af99-4a71-b3ca-80deb7d793c1"
                 },
                 "createdAt": {
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "id": {
                     "type": "string",
@@ -2091,10 +2116,12 @@
                     "$ref": "#/definitions/controllers.EnvelopeLinks"
                 },
                 "name": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Groceries"
                 },
                 "note": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "For stuff bought at supermarkets and drugstores"
                 },
                 "updatedAt": {
                     "type": "string",
@@ -2110,8 +2137,9 @@
                     "example": "https://example.com/api/v1/allocations?envelope=45b6b5b9-f746-4ae9-b77b-7688b91f8166"
                 },
                 "month": {
+                    "description": "This will always end in 'YYYY-MM' for clients to use replace with actual numbers.",
                     "type": "string",
-                    "example": "https://example.com/api/v1/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/2019-03"
+                    "example": "https://example.com/api/v1/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/YYYY-MM"
                 },
                 "self": {
                     "type": "string",
@@ -2150,26 +2178,36 @@
             "type": "object",
             "properties": {
                 "amount": {
-                    "type": "number"
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 14.03
                 },
                 "budgetId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "55eecbd8-7c46-4b06-ada9-f287802fb05e"
                 },
                 "createdAt": {
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "date": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "1815-12-10T18:43:00.271152Z"
                 },
                 "deletedAt": {
-                    "$ref": "#/definitions/gorm.DeletedAt"
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "destinationAccountId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "8e16b456-a719-48ce-9fec-e115cfa7cbcc"
                 },
                 "envelopeId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2649c965-7999-4873-ae16-89d5d5fa972e"
                 },
                 "id": {
                     "type": "string",
@@ -2179,13 +2217,17 @@
                     "$ref": "#/definitions/controllers.TransactionLinks"
                 },
                 "note": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Lunch"
                 },
                 "reconciled": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
                 },
                 "sourceAccountId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "fd81dc45-a3a2-468e-a6fa-b2618f30aa45"
                 },
                 "updatedAt": {
                     "type": "string",
@@ -2221,18 +2263,6 @@
                 }
             }
         },
-        "gorm.DeletedAt": {
-            "type": "object",
-            "properties": {
-                "time": {
-                    "type": "string"
-                },
-                "valid": {
-                    "description": "Valid is true if Time is not NULL",
-                    "type": "boolean"
-                }
-            }
-        },
         "httputil.HTTPError": {
             "type": "object",
             "properties": {
@@ -2251,20 +2281,22 @@
                 },
                 "external": {
                     "type": "boolean",
-                    "example": true
+                    "default": false,
+                    "example": false
                 },
                 "name": {
                     "type": "string",
-                    "example": "Checking"
+                    "example": "Cash"
                 },
                 "note": {
                     "type": "string",
-                    "example": "My bank account"
+                    "example": "Money in my wallet"
                 },
                 "onBudget": {
                     "description": "Always false when external: true",
                     "type": "boolean",
-                    "example": false
+                    "default": false,
+                    "example": true
                 }
             }
         },
@@ -2272,16 +2304,26 @@
             "type": "object",
             "properties": {
                 "amount": {
-                    "type": "number"
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 22.01
                 },
                 "envelopeId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "a0909e84-e8f9-4cb6-82a5-025dff105ff2"
                 },
                 "month": {
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 12,
+                    "minimum": 1,
+                    "example": 6
                 },
                 "year": {
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 2022
                 }
             }
         },
@@ -2294,11 +2336,11 @@
                 },
                 "name": {
                     "type": "string",
-                    "example": "My First Budget"
+                    "example": "Morre's Budget"
                 },
                 "note": {
                     "type": "string",
-                    "example": "A description so I remember what this was for"
+                    "example": "My personal expenses"
                 }
             }
         },
@@ -2312,16 +2354,19 @@
                     }
                 },
                 "id": {
+                    "description": "The ID of the Envelope",
                     "type": "string",
-                    "example": "23"
+                    "example": "1e777d24-3f5b-4c43-8000-04f65f895578"
                 },
                 "month": {
+                    "description": "This is always set to 00:00 UTC on the first of the month.",
                     "type": "string",
-                    "example": "2006-05-04T15:02:01.000000Z"
+                    "example": "2006-05-01T00:00:00.000000Z"
                 },
                 "name": {
+                    "description": "The name of the Envelope",
                     "type": "string",
-                    "example": "A test envelope"
+                    "example": "Groceries"
                 }
             }
         },
@@ -2329,13 +2374,16 @@
             "type": "object",
             "properties": {
                 "budgetId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "52d967d3-33f4-4b04-9ba7-772e5ab9d0ce"
                 },
                 "name": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Saving"
                 },
                 "note": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "All envelopes for long-term saving"
                 }
             }
         },
@@ -2343,13 +2391,16 @@
             "type": "object",
             "properties": {
                 "categoryId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "878c831f-af99-4a71-b3ca-80deb7d793c1"
                 },
                 "name": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Groceries"
                 },
                 "note": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "For stuff bought at supermarkets and drugstores"
                 }
             }
         },
@@ -2357,22 +2408,31 @@
             "type": "object",
             "properties": {
                 "allocation": {
-                    "type": "number"
+                    "type": "number",
+                    "example": 85.44
                 },
                 "balance": {
-                    "type": "number"
+                    "type": "number",
+                    "example": 12.32
                 },
                 "id": {
-                    "type": "string"
+                    "description": "The ID of the Envelope",
+                    "type": "string",
+                    "example": "10b9705d-3356-459e-9d5a-28d42a6c4547"
                 },
                 "month": {
-                    "type": "string"
+                    "description": "This is always set to 00:00 UTC on the first of the month.",
+                    "type": "string",
+                    "example": "1969-06-01T00:00:00.000000Z"
                 },
                 "name": {
-                    "type": "string"
+                    "description": "The name of the Envelope",
+                    "type": "string",
+                    "example": "Groceries"
                 },
                 "spent": {
-                    "type": "number"
+                    "type": "number",
+                    "example": 73.12
                 }
             }
         },
@@ -2380,28 +2440,41 @@
             "type": "object",
             "properties": {
                 "amount": {
-                    "type": "number"
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 14.03
                 },
                 "budgetId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "55eecbd8-7c46-4b06-ada9-f287802fb05e"
                 },
                 "date": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "1815-12-10T18:43:00.271152Z"
                 },
                 "destinationAccountId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "8e16b456-a719-48ce-9fec-e115cfa7cbcc"
                 },
                 "envelopeId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2649c965-7999-4873-ae16-89d5d5fa972e"
                 },
                 "note": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Lunch"
                 },
                 "reconciled": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
                 },
                 "sourceAccountId": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "fd81dc45-a3a2-468e-a6fa-b2618f30aa45"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2,6 +2,7 @@ definitions:
   controllers.Account:
     properties:
       balance:
+        example: 2735.17
         type: number
       budgetId:
         example: 550dc009-cea6-4c12-b2a5-03446eb7b7cf
@@ -10,9 +11,11 @@ definitions:
         example: "2022-04-02T19:28:44.491514Z"
         type: string
       deletedAt:
-        $ref: '#/definitions/gorm.DeletedAt'
+        example: "2022-04-22T21:01:05.058161Z"
+        type: string
       external:
-        example: true
+        default: false
+        example: false
         type: boolean
       id:
         example: 65392deb-5e92-4268-b114-297faad6cdce
@@ -20,16 +23,18 @@ definitions:
       links:
         $ref: '#/definitions/controllers.AccountLinks'
       name:
-        example: Checking
+        example: Cash
         type: string
       note:
-        example: My bank account
+        example: Money in my wallet
         type: string
       onBudget:
+        default: false
         description: 'Always false when external: true'
-        example: false
+        example: true
         type: boolean
       reconciledBalance:
+        example: 2539.57
         type: number
       updatedAt:
         example: "2022-04-17T20:14:01.048145Z"
@@ -59,13 +64,21 @@ definitions:
   controllers.Allocation:
     properties:
       amount:
+        description: The maximum value is "999999999999.99999999", swagger unfortunately
+          rounds this.
+        example: 22.01
+        maximum: 1000000000000
+        minimum: 1e-08
+        multipleOf: 1e-08
         type: number
       createdAt:
         example: "2022-04-02T19:28:44.491514Z"
         type: string
       deletedAt:
-        $ref: '#/definitions/gorm.DeletedAt'
+        example: "2022-04-22T21:01:05.058161Z"
+        type: string
       envelopeId:
+        example: a0909e84-e8f9-4cb6-82a5-025dff105ff2
         type: string
       id:
         example: 65392deb-5e92-4268-b114-297faad6cdce
@@ -73,11 +86,15 @@ definitions:
       links:
         $ref: '#/definitions/controllers.AllocationLinks'
       month:
+        example: 6
+        maximum: 12
+        minimum: 1
         type: integer
       updatedAt:
         example: "2022-04-17T20:14:01.048145Z"
         type: string
       year:
+        example: 2022
         type: integer
     type: object
   controllers.AllocationLinks:
@@ -101,6 +118,7 @@ definitions:
   controllers.Budget:
     properties:
       balance:
+        example: 3423.42
         type: number
       createdAt:
         example: "2022-04-02T19:28:44.491514Z"
@@ -109,17 +127,18 @@ definitions:
         example: €
         type: string
       deletedAt:
-        $ref: '#/definitions/gorm.DeletedAt'
+        example: "2022-04-22T21:01:05.058161Z"
+        type: string
       id:
         example: 65392deb-5e92-4268-b114-297faad6cdce
         type: string
       links:
         $ref: '#/definitions/controllers.BudgetLinks'
       name:
-        example: My First Budget
+        example: Morre's Budget
         type: string
       note:
-        example: A description so I remember what this was for
+        example: My personal expenses
         type: string
       updatedAt:
         example: "2022-04-17T20:14:01.048145Z"
@@ -134,7 +153,9 @@ definitions:
         example: https://example.com/api/v1/categories?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf
         type: string
       month:
-        example: https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/2022-03
+        description: This will always end in 'YYYY-MM' for clients to use replace
+          with actual numbers.
+        example: https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/YYYY-MM
         type: string
       self:
         example: https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf
@@ -163,20 +184,24 @@ definitions:
   controllers.Category:
     properties:
       budgetId:
+        example: 52d967d3-33f4-4b04-9ba7-772e5ab9d0ce
         type: string
       createdAt:
         example: "2022-04-02T19:28:44.491514Z"
         type: string
       deletedAt:
-        $ref: '#/definitions/gorm.DeletedAt'
+        example: "2022-04-22T21:01:05.058161Z"
+        type: string
       id:
         example: 65392deb-5e92-4268-b114-297faad6cdce
         type: string
       links:
         $ref: '#/definitions/controllers.CategoryLinks'
       name:
+        example: Saving
         type: string
       note:
+        example: All envelopes for long-term saving
         type: string
       updatedAt:
         example: "2022-04-17T20:14:01.048145Z"
@@ -206,20 +231,24 @@ definitions:
   controllers.Envelope:
     properties:
       categoryId:
+        example: 878c831f-af99-4a71-b3ca-80deb7d793c1
         type: string
       createdAt:
         example: "2022-04-02T19:28:44.491514Z"
         type: string
       deletedAt:
-        $ref: '#/definitions/gorm.DeletedAt'
+        example: "2022-04-22T21:01:05.058161Z"
+        type: string
       id:
         example: 65392deb-5e92-4268-b114-297faad6cdce
         type: string
       links:
         $ref: '#/definitions/controllers.EnvelopeLinks'
       name:
+        example: Groceries
         type: string
       note:
+        example: For stuff bought at supermarkets and drugstores
         type: string
       updatedAt:
         example: "2022-04-17T20:14:01.048145Z"
@@ -231,7 +260,9 @@ definitions:
         example: https://example.com/api/v1/allocations?envelope=45b6b5b9-f746-4ae9-b77b-7688b91f8166
         type: string
       month:
-        example: https://example.com/api/v1/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/2019-03
+        description: This will always end in 'YYYY-MM' for clients to use replace
+          with actual numbers.
+        example: https://example.com/api/v1/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/YYYY-MM
         type: string
       self:
         example: https://example.com/api/v1/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166
@@ -257,19 +288,30 @@ definitions:
   controllers.Transaction:
     properties:
       amount:
+        description: The maximum value is "999999999999.99999999", swagger unfortunately
+          rounds this.
+        example: 14.03
+        maximum: 1000000000000
+        minimum: 1e-08
+        multipleOf: 1e-08
         type: number
       budgetId:
+        example: 55eecbd8-7c46-4b06-ada9-f287802fb05e
         type: string
       createdAt:
         example: "2022-04-02T19:28:44.491514Z"
         type: string
       date:
+        example: "1815-12-10T18:43:00.271152Z"
         type: string
       deletedAt:
-        $ref: '#/definitions/gorm.DeletedAt'
+        example: "2022-04-22T21:01:05.058161Z"
+        type: string
       destinationAccountId:
+        example: 8e16b456-a719-48ce-9fec-e115cfa7cbcc
         type: string
       envelopeId:
+        example: 2649c965-7999-4873-ae16-89d5d5fa972e
         type: string
       id:
         example: 65392deb-5e92-4268-b114-297faad6cdce
@@ -277,10 +319,14 @@ definitions:
       links:
         $ref: '#/definitions/controllers.TransactionLinks'
       note:
+        example: Lunch
         type: string
       reconciled:
+        default: false
+        example: true
         type: boolean
       sourceAccountId:
+        example: fd81dc45-a3a2-468e-a6fa-b2618f30aa45
         type: string
       updatedAt:
         example: "2022-04-17T20:14:01.048145Z"
@@ -304,14 +350,6 @@ definitions:
       data:
         $ref: '#/definitions/controllers.Transaction'
     type: object
-  gorm.DeletedAt:
-    properties:
-      time:
-        type: string
-      valid:
-        description: Valid is true if Time is not NULL
-        type: boolean
-    type: object
   httputil.HTTPError:
     properties:
       error:
@@ -324,28 +362,41 @@ definitions:
         example: 550dc009-cea6-4c12-b2a5-03446eb7b7cf
         type: string
       external:
-        example: true
+        default: false
+        example: false
         type: boolean
       name:
-        example: Checking
+        example: Cash
         type: string
       note:
-        example: My bank account
+        example: Money in my wallet
         type: string
       onBudget:
+        default: false
         description: 'Always false when external: true'
-        example: false
+        example: true
         type: boolean
     type: object
   models.AllocationCreate:
     properties:
       amount:
+        description: The maximum value is "999999999999.99999999", swagger unfortunately
+          rounds this.
+        example: 22.01
+        maximum: 1000000000000
+        minimum: 1e-08
+        multipleOf: 1e-08
         type: number
       envelopeId:
+        example: a0909e84-e8f9-4cb6-82a5-025dff105ff2
         type: string
       month:
+        example: 6
+        maximum: 12
+        minimum: 1
         type: integer
       year:
+        example: 2022
         type: integer
     type: object
   models.BudgetCreate:
@@ -354,10 +405,10 @@ definitions:
         example: €
         type: string
       name:
-        example: My First Budget
+        example: Morre's Budget
         type: string
       note:
-        example: A description so I remember what this was for
+        example: My personal expenses
         type: string
     type: object
   models.BudgetMonth:
@@ -367,65 +418,97 @@ definitions:
           $ref: '#/definitions/models.EnvelopeMonth'
         type: array
       id:
-        example: "23"
+        description: The ID of the Envelope
+        example: 1e777d24-3f5b-4c43-8000-04f65f895578
         type: string
       month:
-        example: "2006-05-04T15:02:01.000000Z"
+        description: This is always set to 00:00 UTC on the first of the month.
+        example: "2006-05-01T00:00:00.000000Z"
         type: string
       name:
-        example: A test envelope
+        description: The name of the Envelope
+        example: Groceries
         type: string
     type: object
   models.CategoryCreate:
     properties:
       budgetId:
+        example: 52d967d3-33f4-4b04-9ba7-772e5ab9d0ce
         type: string
       name:
+        example: Saving
         type: string
       note:
+        example: All envelopes for long-term saving
         type: string
     type: object
   models.EnvelopeCreate:
     properties:
       categoryId:
+        example: 878c831f-af99-4a71-b3ca-80deb7d793c1
         type: string
       name:
+        example: Groceries
         type: string
       note:
+        example: For stuff bought at supermarkets and drugstores
         type: string
     type: object
   models.EnvelopeMonth:
     properties:
       allocation:
+        example: 85.44
         type: number
       balance:
+        example: 12.32
         type: number
       id:
+        description: The ID of the Envelope
+        example: 10b9705d-3356-459e-9d5a-28d42a6c4547
         type: string
       month:
+        description: This is always set to 00:00 UTC on the first of the month.
+        example: "1969-06-01T00:00:00.000000Z"
         type: string
       name:
+        description: The name of the Envelope
+        example: Groceries
         type: string
       spent:
+        example: 73.12
         type: number
     type: object
   models.TransactionCreate:
     properties:
       amount:
+        description: The maximum value is "999999999999.99999999", swagger unfortunately
+          rounds this.
+        example: 14.03
+        maximum: 1000000000000
+        minimum: 1e-08
+        multipleOf: 1e-08
         type: number
       budgetId:
+        example: 55eecbd8-7c46-4b06-ada9-f287802fb05e
         type: string
       date:
+        example: "1815-12-10T18:43:00.271152Z"
         type: string
       destinationAccountId:
+        example: 8e16b456-a719-48ce-9fec-e115cfa7cbcc
         type: string
       envelopeId:
+        example: 2649c965-7999-4873-ae16-89d5d5fa972e
         type: string
       note:
+        example: Lunch
         type: string
       reconciled:
+        default: false
+        example: true
         type: boolean
       sourceAccountId:
+        example: fd81dc45-a3a2-468e-a6fa-b2618f30aa45
         type: string
     type: object
   router.RootLinks:

--- a/pkg/controllers/budget.go
+++ b/pkg/controllers/budget.go
@@ -31,7 +31,7 @@ type BudgetLinks struct {
 	Accounts     string `json:"accounts" example:"https://example.com/api/v1/accounts?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"`
 	Categories   string `json:"categories" example:"https://example.com/api/v1/categories?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"`
 	Transactions string `json:"transactions" example:"https://example.com/api/v1/transactions?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"`
-	Month        string `json:"month" example:"https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/2022-03"`
+	Month        string `json:"month" example:"https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/YYYY-MM"` // This will always end in 'YYYY-MM' for clients to use replace with actual numbers.
 }
 
 type BudgetMonthResponse struct {

--- a/pkg/controllers/envelope.go
+++ b/pkg/controllers/envelope.go
@@ -32,7 +32,7 @@ type EnvelopeMonthResponse struct {
 type EnvelopeLinks struct {
 	Self        string `json:"self" example:"https://example.com/api/v1/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166"`
 	Allocations string `json:"allocations" example:"https://example.com/api/v1/allocations?envelope=45b6b5b9-f746-4ae9-b77b-7688b91f8166"`
-	Month       string `json:"month" example:"https://example.com/api/v1/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/2019-03"`
+	Month       string `json:"month" example:"https://example.com/api/v1/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/YYYY-MM"` // This will always end in 'YYYY-MM' for clients to use replace with actual numbers.
 }
 
 // RegisterEnvelopeRoutes registers the routes for envelopes with

--- a/pkg/models/account.go
+++ b/pkg/models/account.go
@@ -12,16 +12,16 @@ type Account struct {
 	Model
 	AccountCreate
 	Budget            Budget          `json:"-"`
-	Balance           decimal.Decimal `json:"balance" gorm:"-"`
-	ReconciledBalance decimal.Decimal `json:"reconciledBalance" gorm:"-"`
+	Balance           decimal.Decimal `json:"balance" gorm:"-" example:"2735.17"`
+	ReconciledBalance decimal.Decimal `json:"reconciledBalance" gorm:"-" example:"2539.57"`
 }
 
 type AccountCreate struct {
-	Name     string    `json:"name,omitempty" example:"Checking"`
-	Note     string    `json:"note,omitempty" example:"My bank account"`
+	Name     string    `json:"name,omitempty" example:"Cash" default:""`
+	Note     string    `json:"note,omitempty" example:"Money in my wallet" default:""`
 	BudgetID uuid.UUID `json:"budgetId" example:"550dc009-cea6-4c12-b2a5-03446eb7b7cf"`
-	OnBudget bool      `json:"onBudget" example:"false"` // Always false when external: true
-	External bool      `json:"external" example:"true"`
+	OnBudget bool      `json:"onBudget" example:"true" default:"false"` // Always false when external: true
+	External bool      `json:"external" example:"false" default:"false"`
 }
 
 func (a Account) WithCalculations() Account {

--- a/pkg/models/allocation.go
+++ b/pkg/models/allocation.go
@@ -13,8 +13,8 @@ type Allocation struct {
 }
 
 type AllocationCreate struct {
-	Month      uint8           `json:"month" gorm:"uniqueIndex:year_month;check:month_valid,month >= 1 AND month <= 12"`
-	Year       uint            `json:"year" gorm:"uniqueIndex:year_month"`
-	Amount     decimal.Decimal `json:"amount" gorm:"type:DECIMAL(20,8)"`
-	EnvelopeID uuid.UUID       `json:"envelopeId,omitempty"`
+	Month      uint8           `json:"month" gorm:"uniqueIndex:year_month;check:month_valid,month >= 1 AND month <= 12" minimum:"1" maximum:"12" example:"6"`
+	Year       uint            `json:"year" gorm:"uniqueIndex:year_month" example:"2022"`
+	Amount     decimal.Decimal `json:"amount" gorm:"type:DECIMAL(20,8)" example:"22.01" minimum:"0.00000001" maximum:"999999999999.99999999" multipleOf:"0.00000001"` // The maximum value is "999999999999.99999999", swagger unfortunately rounds this.
+	EnvelopeID uuid.UUID       `json:"envelopeId,omitempty" example:"a0909e84-e8f9-4cb6-82a5-025dff105ff2"`
 }

--- a/pkg/models/budget.go
+++ b/pkg/models/budget.go
@@ -14,18 +14,18 @@ import (
 type Budget struct {
 	Model
 	BudgetCreate
-	Balance decimal.Decimal `json:"balance" gorm:"-"`
+	Balance decimal.Decimal `json:"balance" gorm:"-" example:"3423.42"`
 }
 
 type BudgetCreate struct {
-	Name     string `json:"name,omitempty" example:"My First Budget"`
-	Note     string `json:"note,omitempty" example:"A description so I remember what this was for"`
-	Currency string `json:"currency,omitempty" example:"€"`
+	Name     string `json:"name,omitempty" example:"Morre's Budget" default:""`
+	Note     string `json:"note,omitempty" example:"My personal expenses" default:""`
+	Currency string `json:"currency,omitempty" example:"€" default:""`
 }
 
 type BudgetMonth struct {
-	ID        uuid.UUID       `json:"id" example:"23"`
-	Name      string          `json:"name" example:"A test envelope"`
-	Month     time.Time       `json:"month" example:"2006-05-04T15:02:01.000000Z"`
+	ID        uuid.UUID       `json:"id" example:"1e777d24-3f5b-4c43-8000-04f65f895578"` // The ID of the Envelope
+	Name      string          `json:"name" example:"Groceries"`                          // The name of the Envelope
+	Month     time.Time       `json:"month" example:"2006-05-01T00:00:00.000000Z"`       // This is always set to 00:00 UTC on the first of the month.
 	Envelopes []EnvelopeMonth `json:"envelopes,omitempty"`
 }

--- a/pkg/models/category.go
+++ b/pkg/models/category.go
@@ -10,7 +10,7 @@ type Category struct {
 }
 
 type CategoryCreate struct {
-	Name     string    `json:"name,omitempty"`
-	BudgetID uuid.UUID `json:"budgetId"`
-	Note     string    `json:"note,omitempty"`
+	Name     string    `json:"name,omitempty" example:"Saving" default:""`
+	BudgetID uuid.UUID `json:"budgetId" example:"52d967d3-33f4-4b04-9ba7-772e5ab9d0ce"`
+	Note     string    `json:"note,omitempty" example:"All envelopes for long-term saving" default:""`
 }

--- a/pkg/models/envelope.go
+++ b/pkg/models/envelope.go
@@ -16,19 +16,19 @@ type Envelope struct {
 }
 
 type EnvelopeCreate struct {
-	Name       string    `json:"name,omitempty"`
-	CategoryID uuid.UUID `json:"categoryId"`
-	Note       string    `json:"note,omitempty"`
+	Name       string    `json:"name,omitempty" example:"Groceries" default:""`
+	CategoryID uuid.UUID `json:"categoryId" example:"878c831f-af99-4a71-b3ca-80deb7d793c1"`
+	Note       string    `json:"note,omitempty" example:"For stuff bought at supermarkets and drugstores" default:""`
 }
 
 // EnvelopeMonth contains data about an Envelope for a specific month.
 type EnvelopeMonth struct {
-	ID         uuid.UUID       `json:"id"`
-	Name       string          `json:"name"`
-	Month      time.Time       `json:"month"`
-	Spent      decimal.Decimal `json:"spent"`
-	Balance    decimal.Decimal `json:"balance"`
-	Allocation decimal.Decimal `json:"allocation"`
+	ID         uuid.UUID       `json:"id" example:"10b9705d-3356-459e-9d5a-28d42a6c4547"` // The ID of the Envelope
+	Name       string          `json:"name" example:"Groceries"`                          // The name of the Envelope
+	Month      time.Time       `json:"month" example:"1969-06-01T00:00:00.000000Z"`       // This is always set to 00:00 UTC on the first of the month.
+	Spent      decimal.Decimal `json:"spent" example:"73.12"`
+	Balance    decimal.Decimal `json:"balance" example:"12.32"`
+	Allocation decimal.Decimal `json:"allocation" example:"85.44"`
 }
 
 // Spent returns the amount spent for the month the time.Time instance is in.

--- a/pkg/models/model.go
+++ b/pkg/models/model.go
@@ -12,7 +12,7 @@ type Model struct {
 	ID        uuid.UUID       `json:"id" example:"65392deb-5e92-4268-b114-297faad6cdce"`
 	CreatedAt time.Time       `json:"createdAt" example:"2022-04-02T19:28:44.491514Z"`
 	UpdatedAt time.Time       `json:"updatedAt" example:"2022-04-17T20:14:01.048145Z"`
-	DeletedAt *gorm.DeletedAt `json:"deletedAt,omitempty" gorm:"index"`
+	DeletedAt *gorm.DeletedAt `json:"deletedAt,omitempty" gorm:"index" example:"2022-04-22T21:01:05.058161Z" swaggertype:"primitive,string"`
 }
 
 // AfterFind updates the timestamps to use UTC as

--- a/pkg/models/transaction.go
+++ b/pkg/models/transaction.go
@@ -19,14 +19,14 @@ type Transaction struct {
 }
 
 type TransactionCreate struct {
-	Date                 time.Time       `json:"date,omitempty"`
-	Amount               decimal.Decimal `json:"amount" gorm:"type:DECIMAL(20,8)"`
-	Note                 string          `json:"note,omitempty"`
-	BudgetID             uuid.UUID       `json:"budgetId,omitempty"`
-	SourceAccountID      uuid.UUID       `json:"sourceAccountId,omitempty"`
-	DestinationAccountID uuid.UUID       `json:"destinationAccountId,omitempty"`
-	EnvelopeID           uuid.UUID       `json:"envelopeId,omitempty"`
-	Reconciled           bool            `json:"reconciled"`
+	Date                 time.Time       `json:"date,omitempty" example:"1815-12-10T18:43:00.271152Z"`
+	Amount               decimal.Decimal `json:"amount" gorm:"type:DECIMAL(20,8)" example:"14.03" minimum:"0.00000001" maximum:"999999999999.99999999" multipleOf:"0.00000001"` // The maximum value is "999999999999.99999999", swagger unfortunately rounds this.
+	Note                 string          `json:"note,omitempty" example:"Lunch" default:""`
+	BudgetID             uuid.UUID       `json:"budgetId,omitempty" example:"55eecbd8-7c46-4b06-ada9-f287802fb05e"`
+	SourceAccountID      uuid.UUID       `json:"sourceAccountId,omitempty" example:"fd81dc45-a3a2-468e-a6fa-b2618f30aa45"`
+	DestinationAccountID uuid.UUID       `json:"destinationAccountId,omitempty" example:"8e16b456-a719-48ce-9fec-e115cfa7cbcc"`
+	EnvelopeID           uuid.UUID       `json:"envelopeId,omitempty" example:"2649c965-7999-4873-ae16-89d5d5fa972e"`
+	Reconciled           bool            `json:"reconciled" example:"true" default:"false"`
 }
 
 // AfterFind updates the timestamps to use UTC as


### PR DESCRIPTION
Adds examples to all values, defaults to non-required values an descriptions to complex values.
