### PR TITLE
fix: goreleaser did not set the version correctly on builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,7 @@ builds:
       - windows
       - darwin
     ldflags:
-      - -X github.com/envelope-zero/backend/pkg/controllers.version={{.Version}}
+      - -X github.com/envelope-zero/backend/internal/router.version=${VERSION}
 archives:
   - replacements:
       darwin: Darwin


### PR DESCRIPTION
With this PR, goreleaser will again correctly set the version with a linker flag
