### PR TITLE
fix: bad copy paste

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,7 @@ builds:
       - windows
       - darwin
     ldflags:
-      - -X github.com/envelope-zero/backend/internal/router.version=${VERSION}
+      - -X github.com/envelope-zero/backend/internal/router.version={{.Version}}
 archives:
   - replacements:
       darwin: Darwin


### PR DESCRIPTION
Fixes a copy-pasting error when fixing goreleaser setting the version with a linker flag
