### PR TITLE
fix: use baseURL instead of requestURL for /v1 endpoint

### DIFF
--- a/internal/router/middleware.go
+++ b/internal/router/middleware.go
@@ -26,7 +26,6 @@ func URLMiddleware() gin.HandlerFunc {
 		}
 
 		c.Set("baseURL", url.String())
-		c.Set("requestURL", url.String()+c.Request.URL.Path)
 		c.Next()
 	}
 }

--- a/internal/router/middleware_test.go
+++ b/internal/router/middleware_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/envelope-zero/backend/internal/router"
-	"github.com/envelope-zero/backend/pkg/test"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
@@ -19,27 +18,15 @@ func TestURLMiddlewareContextSet(t *testing.T) {
 	os.Setenv("API_URL", "https://ez.example.com:8081/api")
 
 	r.GET("/envelopes", func(ctx *gin.Context) {
-		urlMiddleware := router.URLMiddleware()
-		urlMiddleware(c)
-
-		c.JSON(http.StatusOK, map[string]string{
-			"baseURL":    c.GetString("baseURL"),
-			"requestURL": c.GetString("requestURL"),
-		})
+		router.URLMiddleware()(c)
+		c.String(http.StatusOK, c.GetString("baseURL"))
 	})
-
-	urls := struct {
-		BaseURL    string `json:"baseURL"`
-		RequestURL string `json:"requestURL"`
-	}{}
 
 	// Make and decode repsonse
 	c.Request, _ = http.NewRequest(http.MethodGet, "https://example.com/envelopes", nil)
 	r.ServeHTTP(w, c.Request)
-	test.DecodeResponse(t, w, &urls)
 
-	assert.Equal(t, "https://ez.example.com:8081/api", urls.BaseURL)
-	assert.Equal(t, "https://ez.example.com:8081/api/envelopes", urls.RequestURL)
+	assert.Equal(t, "https://ez.example.com:8081/api", w.Body.String())
 
 	os.Unsetenv("API_URL")
 }
@@ -51,27 +38,15 @@ func TestURLMiddlewareNotAnURL(t *testing.T) {
 	os.Setenv("API_URL", "https://ez.examp\\?le.com:8081/api")
 
 	r.GET("/envelopes", func(ctx *gin.Context) {
-		urlMiddleware := router.URLMiddleware()
-		urlMiddleware(c)
-
-		c.JSON(http.StatusOK, map[string]string{
-			"baseURL":    c.GetString("baseURL"),
-			"requestURL": c.GetString("requestURL"),
-		})
+		router.URLMiddleware()(c)
+		c.String(http.StatusOK, c.GetString("baseURL"))
 	})
-
-	urls := struct {
-		BaseURL    string `json:"baseURL"`
-		RequestURL string `json:"requestURL"`
-	}{}
 
 	// Make and decode repsonse
 	c.Request, _ = http.NewRequest(http.MethodGet, "https://example.com/envelopes", nil)
 	r.ServeHTTP(w, c.Request)
-	test.DecodeResponse(t, w, &urls)
 
-	assert.Equal(t, "", urls.BaseURL)
-	assert.Equal(t, "", urls.RequestURL)
+	assert.Equal(t, "", w.Body.String())
 
 	os.Unsetenv("API_URL")
 }
@@ -84,22 +59,12 @@ func TestURLMiddlewareEnvNotSet(t *testing.T) {
 		urlMiddleware := router.URLMiddleware()
 		urlMiddleware(c)
 
-		c.JSON(http.StatusOK, map[string]string{
-			"baseURL":    c.GetString("baseURL"),
-			"requestURL": c.GetString("requestURL"),
-		})
+		c.String(http.StatusOK, c.GetString("baseURL"))
 	})
-
-	urls := struct {
-		BaseURL    string `json:"baseURL"`
-		RequestURL string `json:"requestURL"`
-	}{}
 
 	// Make and decode repsonse
 	c.Request, _ = http.NewRequest(http.MethodGet, "https://example.com/envelopes", nil)
 	r.ServeHTTP(w, c.Request)
-	test.DecodeResponse(t, w, &urls)
 
-	assert.Equal(t, "", urls.BaseURL)
-	assert.Equal(t, "", urls.RequestURL)
+	assert.Equal(t, "", w.Body.String())
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -210,12 +210,12 @@ type V1Links struct {
 func GetV1(c *gin.Context) {
 	c.JSON(http.StatusOK, V1Response{
 		Links: V1Links{
-			Budgets:      c.GetString("requestURL") + "/v1/budgets",
-			Accounts:     c.GetString("requestURL") + "/v1/accounts",
-			Categories:   c.GetString("requestURL") + "/v1/categories",
-			Transactions: c.GetString("requestURL") + "/v1/transactions",
-			Envelopes:    c.GetString("requestURL") + "/v1/envelopes",
-			Allocations:  c.GetString("requestURL") + "/v1/allocations",
+			Budgets:      c.GetString("baseURL") + "/v1/budgets",
+			Accounts:     c.GetString("baseURL") + "/v1/accounts",
+			Categories:   c.GetString("baseURL") + "/v1/categories",
+			Transactions: c.GetString("baseURL") + "/v1/transactions",
+			Envelopes:    c.GetString("baseURL") + "/v1/envelopes",
+			Allocations:  c.GetString("baseURL") + "/v1/allocations",
 		},
 	})
 }


### PR DESCRIPTION
With this, requestURL is unused and therefore removed.
