### PR TITLE
chore: upgrade go version everywhere at once

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as builder
+FROM golang:1.18.4-alpine as builder
 
 RUN apk add --no-cache make
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "rangeStrategy": "pin",
   "rebaseWhen": "behind-base-branch",
   "semanticCommits": "enabled",
+  "platformAutomerge": true,
   "postUpdateOptions": ["gomodTidy"],
   "regexManagers": [
     {
@@ -35,10 +36,21 @@
   ],
   "packageRules": [
     {
+      "description": "The golang CI language version only uses major.minor",
+      "matchFiles": [".golangci.yml"],
+      "matchPackageNames": ["go"],
+      "extractVersion": "^(?<version>\\d+\\.\\d+)"
+    },
+    {
       "description": "Automatically merge minor updates for GitHub actions and go dependencies",
       "matchManagers": ["github-actions", "gomod"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
+    },
+    {
+      "description": "Group go upgrades",
+      "matchPackageNames": ["go", "golang"],
+      "groupName": "go"
     }
   ]
 }


### PR DESCRIPTION
With this PR, renovate will upgrade the version of go in one PR for all occurences.
