### PR TITLE
chore: remove unneeded spaces for gofumpt, go.mod go version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,13 +15,11 @@
       "description": "Upgrade go version",
       "fileMatch": [
         "(^workflow-templates|\\.github/workflows)/[^/]+\\.ya?ml$",
-        ".golangci.yml",
-        "go.mod"
+        "^\\.golangci\\.yml"
       ],
       "matchStrings": [
         "# renovate: go-version\\s*go-version:\\s*\"?(?<currentValue>.*)\"?",
-        "^\\s*lang-version: \"(?<currentValue>.*)\"$",
-        "^go (?<currentValue>.*)$"
+        "lang-version: \"(?<currentValue>.*)\""
       ],
       "datasourceTemplate": "golang-version",
       "depNameTemplate": "go"


### PR DESCRIPTION
This cleans up the renovate configuration a bit.
