### PR TITLE
chore: add golangci go version to go group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,8 @@
       "description": "The golang CI language version only uses major.minor",
       "matchFiles": [".golangci.yml"],
       "matchPackageNames": ["go"],
-      "extractVersion": "^(?<version>\\d+\\.\\d+)"
+      "extractVersion": "^(?<version>\\d+\\.\\d+)",
+      "groupName": "go"
     },
     {
       "description": "Automatically merge minor updates for GitHub actions and go dependencies",


### PR DESCRIPTION
This adds the language-version in .golangci.yml to the go group so that go is upgraded at once.
