### PR TITLE
chore: remove extractVersion for .golangci.yml

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,6 @@
       "description": "The golang CI language version only uses major.minor",
       "matchFiles": [".golangci.yml"],
       "matchPackageNames": ["go"],
-      "extractVersion": "^(?<version>\\d+\\.\\d+)",
       "groupName": "go"
     },
     {


### PR DESCRIPTION
Removes the extractVersion for .golangci.yml as this can apparently be autodetected.
