### PR TITLE
feat: allow transactions to be created without an Envelope

### DIFF
--- a/pkg/controllers/transaction.go
+++ b/pkg/controllers/transaction.go
@@ -102,27 +102,20 @@ func CreateTransaction(c *gin.Context) {
 	}
 
 	// Check the source account
-	sourceAccount, err := getAccountResource(c, transaction.SourceAccountID)
+	_, err = getAccountResource(c, transaction.SourceAccountID)
 	if err != nil {
 		return
 	}
 
 	// Check the destination account
-	destinationAccount, err := getAccountResource(c, transaction.DestinationAccountID)
+	_, err = getAccountResource(c, transaction.DestinationAccountID)
 	if err != nil {
 		return
 	}
 
-	// Check if the transaction is a transfer. If yes, the envelope can be empty.
-	//
-	// Check that the Envelope ID is set for incoming and outgoing transactions
-	if sourceAccount.External || destinationAccount.External && transaction.EnvelopeID == nil {
-		httputil.NewError(c, http.StatusBadRequest, errors.New("For incoming and outgoing transactions, an envelope is required"))
-		return
-
-		// Check the envelope ID only if it is set. (This will always evaluate to true for incoming and outgoing transactions,
-		// but for transfers, can evaluate to false
-	} else if transaction.EnvelopeID != nil {
+	// Check the envelope ID only if it is set. (This will always evaluate to true for incoming and outgoing transactions,
+	// but for transfers, can evaluate to false
+	if transaction.EnvelopeID != nil {
 		_, err = getEnvelopeResource(c, *transaction.EnvelopeID)
 		if err != nil {
 			return

--- a/pkg/controllers/transaction_test.go
+++ b/pkg/controllers/transaction_test.go
@@ -228,10 +228,7 @@ func (suite *TestSuiteEnv) TestCreateNoEnvelopeTransactionOutgoing() {
 	}
 
 	recorder := test.Request(suite.T(), http.MethodPost, "http://example.com/v1/transactions", c)
-	test.AssertHTTPStatus(suite.T(), http.StatusBadRequest, &recorder)
-
-	err := test.DecodeError(suite.T(), recorder.Body.Bytes())
-	assert.Equal(suite.T(), "For incoming and outgoing transactions, an envelope is required", err)
+	test.AssertHTTPStatus(suite.T(), http.StatusCreated, &recorder)
 }
 
 func (suite *TestSuiteEnv) TestCreateNonExistingEnvelopeTransactionTransfer() {


### PR DESCRIPTION
This removes the requirement for Incoming and Outgoing transactions to have an Envelope.
With this, “Income” transactions that make money available for budgeting are possible.

At the same time, if a tracking error occurs, reconciling transactions are now possible.
Those either remove money from the budget that does not exist or add money that was not
tracked before (same as an income transaction).

Neither of those two types logically requires an Envelope.
