### PR TITLE
feat!: allocations now use RFC3339 timestamps instead of a Month and a Year (u)int

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1901,18 +1901,13 @@ const docTemplate = `{
                     "$ref": "#/definitions/controllers.AllocationLinks"
                 },
                 "month": {
-                    "type": "integer",
-                    "maximum": 12,
-                    "minimum": 1,
-                    "example": 6
+                    "description": "Only year and month of this timestamp are used, everything else is ignored. This will always be set to 00:00 UTC on the first of the specified month",
+                    "type": "string",
+                    "example": "2021-12-01T00:00:00.000000Z"
                 },
                 "updatedAt": {
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
-                },
-                "year": {
-                    "type": "integer",
-                    "example": 2022
                 }
             }
         },
@@ -2342,14 +2337,9 @@ const docTemplate = `{
                     "example": "a0909e84-e8f9-4cb6-82a5-025dff105ff2"
                 },
                 "month": {
-                    "type": "integer",
-                    "maximum": 12,
-                    "minimum": 1,
-                    "example": 6
-                },
-                "year": {
-                    "type": "integer",
-                    "example": 2022
+                    "description": "Only year and month of this timestamp are used, everything else is ignored. This will always be set to 00:00 UTC on the first of the specified month",
+                    "type": "string",
+                    "example": "2021-12-01T00:00:00.000000Z"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1889,18 +1889,13 @@
                     "$ref": "#/definitions/controllers.AllocationLinks"
                 },
                 "month": {
-                    "type": "integer",
-                    "maximum": 12,
-                    "minimum": 1,
-                    "example": 6
+                    "description": "Only year and month of this timestamp are used, everything else is ignored. This will always be set to 00:00 UTC on the first of the specified month",
+                    "type": "string",
+                    "example": "2021-12-01T00:00:00.000000Z"
                 },
                 "updatedAt": {
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
-                },
-                "year": {
-                    "type": "integer",
-                    "example": 2022
                 }
             }
         },
@@ -2330,14 +2325,9 @@
                     "example": "a0909e84-e8f9-4cb6-82a5-025dff105ff2"
                 },
                 "month": {
-                    "type": "integer",
-                    "maximum": 12,
-                    "minimum": 1,
-                    "example": 6
-                },
-                "year": {
-                    "type": "integer",
-                    "example": 2022
+                    "description": "Only year and month of this timestamp are used, everything else is ignored. This will always be set to 00:00 UTC on the first of the specified month",
+                    "type": "string",
+                    "example": "2021-12-01T00:00:00.000000Z"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -86,16 +86,14 @@ definitions:
       links:
         $ref: '#/definitions/controllers.AllocationLinks'
       month:
-        example: 6
-        maximum: 12
-        minimum: 1
-        type: integer
+        description: Only year and month of this timestamp are used, everything else
+          is ignored. This will always be set to 00:00 UTC on the first of the specified
+          month
+        example: "2021-12-01T00:00:00.000000Z"
+        type: string
       updatedAt:
         example: "2022-04-17T20:14:01.048145Z"
         type: string
-      year:
-        example: 2022
-        type: integer
     type: object
   controllers.AllocationLinks:
     properties:
@@ -401,13 +399,11 @@ definitions:
         example: a0909e84-e8f9-4cb6-82a5-025dff105ff2
         type: string
       month:
-        example: 6
-        maximum: 12
-        minimum: 1
-        type: integer
-      year:
-        example: 2022
-        type: integer
+        description: Only year and month of this timestamp are used, everything else
+          is ignored. This will always be set to 00:00 UTC on the first of the specified
+          month
+        example: "2021-12-01T00:00:00.000000Z"
+        type: string
     type: object
   models.BudgetCreate:
     properties:

--- a/main.go
+++ b/main.go
@@ -52,6 +52,13 @@ func main() {
 		log.Fatal().Msg(err.Error())
 	}
 
+	// Drop unused constraint in https://github.com/envelope-zero/backend/pull/274
+	// Can be removed after the 1.0.0 release (we will require everyone to upgrade to 1.0.0 and then to further releases).
+	err = database.DB.Migrator().DropConstraint(&models.Allocation{}, "month_valid")
+	if err != nil {
+		log.Debug().Err(err).Msg("Could not drop month_valid constraint on allocations")
+	}
+
 	// Migrate all models so that the schema is correct
 	err = database.DB.AutoMigrate(models.Budget{}, models.Account{}, models.Category{}, models.Envelope{}, models.Transaction{}, models.Allocation{})
 	if err != nil {

--- a/pkg/controllers/allocation.go
+++ b/pkg/controllers/allocation.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -95,6 +96,9 @@ func CreateAllocation(c *gin.Context) {
 	if err != nil {
 		return
 	}
+
+	// Ignore every field that is not Year or Month
+	allocation.Month = time.Date(allocation.Month.Year(), allocation.Month.Month(), 1, 0, 0, 0, 0, time.UTC)
 
 	_, err = getEnvelopeResource(c, allocation.EnvelopeID)
 	if err != nil {
@@ -196,6 +200,9 @@ func UpdateAllocation(c *gin.Context) {
 	if err := httputil.BindData(c, &data); err != nil {
 		return
 	}
+
+	// Ignore every field that is not Year or Month
+	allocation.Month = time.Date(allocation.Month.Year(), allocation.Month.Month(), 1, 0, 0, 0, 0, time.UTC)
 
 	err = database.DB.Model(&allocation).Select("", updateFields...).Updates(data).Error
 	if err != nil {

--- a/pkg/controllers/budget_test.go
+++ b/pkg/controllers/budget_test.go
@@ -176,22 +176,19 @@ func (suite *TestSuiteEnv) TestBudgetMonth() {
 
 	_ = createTestAllocation(suite.T(), models.AllocationCreate{
 		EnvelopeID: envelope.Data.ID,
-		Month:      1,
-		Year:       2022,
+		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(20.99),
 	})
 
 	_ = createTestAllocation(suite.T(), models.AllocationCreate{
 		EnvelopeID: envelope.Data.ID,
-		Month:      2,
-		Year:       2022,
+		Month:      time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(47.12),
 	})
 
 	_ = createTestAllocation(suite.T(), models.AllocationCreate{
 		EnvelopeID: envelope.Data.ID,
-		Month:      3,
-		Year:       2022,
+		Month:      time.Date(2022, 3, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(31.17),
 	})
 

--- a/pkg/controllers/envelope_test.go
+++ b/pkg/controllers/envelope_test.go
@@ -141,22 +141,19 @@ func (suite *TestSuiteEnv) TestEnvelopeMonth() {
 
 	_ = createTestAllocation(suite.T(), models.AllocationCreate{
 		EnvelopeID: envelope.Data.ID,
-		Month:      1,
-		Year:       2022,
+		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(20.99),
 	})
 
 	_ = createTestAllocation(suite.T(), models.AllocationCreate{
 		EnvelopeID: envelope.Data.ID,
-		Month:      2,
-		Year:       2022,
+		Month:      time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(47.12),
 	})
 
 	_ = createTestAllocation(suite.T(), models.AllocationCreate{
 		EnvelopeID: envelope.Data.ID,
-		Month:      3,
-		Year:       2022,
+		Month:      time.Date(2022, 3, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(31.17),
 	})
 
@@ -235,11 +232,11 @@ func (suite *TestSuiteEnv) TestEnvelopeMonth() {
 		test.AssertHTTPStatus(suite.T(), http.StatusOK, &r)
 
 		test.DecodeResponse(suite.T(), &r, &envelopeMonth)
-		assert.Equal(suite.T(), envelopeMonth.Data.Name, tt.envelopeMonth.Name)
-		assert.Equal(suite.T(), envelopeMonth.Data.Month, tt.envelopeMonth.Month)
-		assert.True(suite.T(), envelopeMonth.Data.Spent.Equal(tt.envelopeMonth.Spent), "Monthly spent calculation for %v is wrong: should be %v, but is %v: %#v", envelopeMonth.Data.Month, tt.envelopeMonth.Spent, envelopeMonth.Data.Spent, envelopeMonth.Data)
-		assert.True(suite.T(), envelopeMonth.Data.Balance.Equal(tt.envelopeMonth.Balance), "Monthly balance calculation for %v is wrong: should be %v, but is %v: %#v", envelopeMonth.Data.Month, tt.envelopeMonth.Balance, envelopeMonth.Data.Balance, envelopeMonth.Data)
-		assert.True(suite.T(), envelopeMonth.Data.Allocation.Equal(tt.envelopeMonth.Allocation), "Monthly allocation fetch for %v is wrong: should be %v, but is %v: %#v", envelopeMonth.Data.Month, tt.envelopeMonth.Allocation, envelopeMonth.Data.Allocation, envelopeMonth.Data)
+		assert.Equal(suite.T(), tt.envelopeMonth.Name, envelopeMonth.Data.Name)
+		assert.Equal(suite.T(), time.Date(tt.envelopeMonth.Month.Year(), tt.envelopeMonth.Month.Month(), 1, 0, 0, 0, 0, time.UTC), envelopeMonth.Data.Month)
+		assert.True(suite.T(), envelopeMonth.Data.Spent.Equal(tt.envelopeMonth.Spent), "Monthly spent calculation for %v is wrong: should be %v, but is %v: %#v", envelopeMonth.Data.Month.Month(), tt.envelopeMonth.Spent, envelopeMonth.Data.Spent, envelopeMonth.Data)
+		assert.True(suite.T(), envelopeMonth.Data.Balance.Equal(tt.envelopeMonth.Balance), "Monthly balance calculation for %v is wrong: should be %v, but is %v: %#v", envelopeMonth.Data.Month.Month(), tt.envelopeMonth.Balance, envelopeMonth.Data.Balance, envelopeMonth.Data)
+		assert.True(suite.T(), envelopeMonth.Data.Allocation.Equal(tt.envelopeMonth.Allocation), "Monthly allocation fetch for %v is wrong: should be %v, but is %v: %#v", envelopeMonth.Data.Month.Month(), tt.envelopeMonth.Allocation, envelopeMonth.Data.Allocation, envelopeMonth.Data)
 	}
 }
 

--- a/pkg/httputil/error.go
+++ b/pkg/httputil/error.go
@@ -31,7 +31,7 @@ func ErrorHandler(c *gin.Context, err error) {
 			NewError(c, http.StatusBadRequest, errors.New("Source and destination accounts for a transaction must be different"))
 		} else if strings.Contains(err.Error(), "CHECK constraint failed: month_valid") {
 			NewError(c, http.StatusBadRequest, errors.New("The month must be between 1 and 12"))
-		} else if strings.Contains(err.Error(), "UNIQUE constraint failed: allocations.month, allocations.year") {
+		} else if strings.Contains(err.Error(), "UNIQUE constraint failed: allocations.month") {
 			NewError(c, http.StatusBadRequest, errors.New("You can not create multiple allocations for the same month"))
 		} else {
 			log.Error().Str("request-id", requestid.Get(c)).Msgf("%T: %v", err, err.Error())

--- a/pkg/models/allocation.go
+++ b/pkg/models/allocation.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 )
@@ -13,8 +15,7 @@ type Allocation struct {
 }
 
 type AllocationCreate struct {
-	Month      uint8           `json:"month" gorm:"uniqueIndex:year_month;check:month_valid,month >= 1 AND month <= 12" minimum:"1" maximum:"12" example:"6"`
-	Year       uint            `json:"year" gorm:"uniqueIndex:year_month" example:"2022"`
+	Month      time.Time       `json:"month" gorm:"uniqueIndex:allocation_month" example:"2021-12-01T00:00:00.000000Z"`                                               // Only year and month of this timestamp are used, everything else is ignored. This will always be set to 00:00 UTC on the first of the specified month
 	Amount     decimal.Decimal `json:"amount" gorm:"type:DECIMAL(20,8)" example:"22.01" minimum:"0.00000001" maximum:"999999999999.99999999" multipleOf:"0.00000001"` // The maximum value is "999999999999.99999999", swagger unfortunately rounds this.
 	EnvelopeID uuid.UUID       `json:"envelopeId" example:"a0909e84-e8f9-4cb6-82a5-025dff105ff2"`
 }

--- a/pkg/models/envelope.go
+++ b/pkg/models/envelope.go
@@ -71,8 +71,7 @@ func (e Envelope) Month(t time.Time) EnvelopeMonth {
 	var allocation Allocation
 	database.DB.First(&allocation, &Allocation{
 		AllocationCreate: AllocationCreate{
-			Month: uint8(t.UTC().Month()),
-			Year:  uint(t.UTC().Year()),
+			Month: time.Date(t.UTC().Year(), t.UTC().Month(), 1, 0, 0, 0, 0, time.UTC),
 		},
 	})
 
@@ -81,7 +80,7 @@ func (e Envelope) Month(t time.Time) EnvelopeMonth {
 	return EnvelopeMonth{
 		ID:         e.ID,
 		Name:       e.Name,
-		Month:      time.Date(t.UTC().Year(), t.UTC().Month(), 1, 0, 0, 0, 0, time.UTC),
+		Month:      allocation.Month,
 		Spent:      spent,
 		Balance:    balance,
 		Allocation: allocation.Amount,


### PR DESCRIPTION
BREAKING CHANGE: With this, allocations use RFC3339 timestamps like all other
resources in the Envelope Zero backend already do.

Resolves #85.
