### PR TITLE
fix: allocations need to be uniqe for (month, envelope), not only the month

### DIFF
--- a/pkg/controllers/allocation_test.go
+++ b/pkg/controllers/allocation_test.go
@@ -138,6 +138,21 @@ func (suite *TestSuiteEnv) TestCreateDuplicateAllocation() {
 	test.AssertHTTPStatus(suite.T(), http.StatusBadRequest, &recorder)
 }
 
+func (suite *TestSuiteEnv) TestCreateNonDuplicateAllocationSameMonth() {
+	e1 := createTestEnvelope(suite.T(), models.EnvelopeCreate{})
+	e2 := createTestEnvelope(suite.T(), models.EnvelopeCreate{})
+
+	_ = createTestAllocation(suite.T(), models.AllocationCreate{
+		Month:      time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC),
+		EnvelopeID: e1.Data.ID,
+	})
+
+	_ = createTestAllocation(suite.T(), models.AllocationCreate{
+		Month:      time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC),
+		EnvelopeID: e2.Data.ID,
+	})
+}
+
 func (suite *TestSuiteEnv) TestCreateAllocationNoBody() {
 	recorder := test.Request(suite.T(), http.MethodPost, "http://example.com/v1/allocations", "")
 	test.AssertHTTPStatus(suite.T(), http.StatusBadRequest, &recorder)

--- a/pkg/models/allocation.go
+++ b/pkg/models/allocation.go
@@ -15,7 +15,7 @@ type Allocation struct {
 }
 
 type AllocationCreate struct {
-	Month      time.Time       `json:"month" gorm:"uniqueIndex:allocation_month" example:"2021-12-01T00:00:00.000000Z"`                                               // Only year and month of this timestamp are used, everything else is ignored. This will always be set to 00:00 UTC on the first of the specified month
+	Month      time.Time       `json:"month" gorm:"uniqueIndex:allocation_month_envelope" example:"2021-12-01T00:00:00.000000Z"`                                      // Only year and month of this timestamp are used, everything else is ignored. This will always be set to 00:00 UTC on the first of the specified month
 	Amount     decimal.Decimal `json:"amount" gorm:"type:DECIMAL(20,8)" example:"22.01" minimum:"0.00000001" maximum:"999999999999.99999999" multipleOf:"0.00000001"` // The maximum value is "999999999999.99999999", swagger unfortunately rounds this.
-	EnvelopeID uuid.UUID       `json:"envelopeId" example:"a0909e84-e8f9-4cb6-82a5-025dff105ff2"`
+	EnvelopeID uuid.UUID       `json:"envelopeId" gorm:"uniqueIndex:allocation_month_envelope" example:"a0909e84-e8f9-4cb6-82a5-025dff105ff2"`
 }


### PR DESCRIPTION
This fixes a bug where you could not create an allocation for the same month, even when they referenced different Envelopes.