### PR TITLE
feat: add graceful shutdown

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -121,8 +121,6 @@ func Router() (*gin.Engine, error) {
 	controllers.RegisterEnvelopeRoutes(v1.Group("/envelopes"))
 	controllers.RegisterAllocationRoutes(v1.Group("/allocations"))
 
-	log.Info().Msg("backend startup complete")
-
 	return r, nil
 }
 


### PR DESCRIPTION
With this commit, the backend will stop accepting new connections on SIGINT or SIGTERM,
but allow existing requests to finish. This graceful shutdown has a timeout of
25 seconds.

Additionally, this removes the double timestamp from the production log format.

Resolves #69.
