### PR TITLE
feat: add cleanup for all resources

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -49,7 +49,7 @@ const docTemplate = `{
             "get": {
                 "description": "Returns general information about the v1 API",
                 "tags": [
-                    "General"
+                    "v1"
                 ],
                 "summary": "v1 API",
                 "responses": {
@@ -61,10 +61,28 @@ const docTemplate = `{
                     }
                 }
             },
+            "delete": {
+                "description": "Permanently deletes all resources",
+                "tags": [
+                    "v1"
+                ],
+                "summary": "Delete everything",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
             "options": {
                 "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
                 "tags": [
-                    "General"
+                    "v1"
                 ],
                 "summary": "Allowed HTTP verbs",
                 "responses": {
@@ -2831,7 +2849,7 @@ const docTemplate = `{
                 },
                 "allocations": {
                     "type": "string",
-                    "example": "https://example.com/api/v1/allocations3"
+                    "example": "https://example.com/api/v1/allocations"
                 },
                 "budgets": {
                     "type": "string",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -37,7 +37,7 @@
             "get": {
                 "description": "Returns general information about the v1 API",
                 "tags": [
-                    "General"
+                    "v1"
                 ],
                 "summary": "v1 API",
                 "responses": {
@@ -49,10 +49,28 @@
                     }
                 }
             },
+            "delete": {
+                "description": "Permanently deletes all resources",
+                "tags": [
+                    "v1"
+                ],
+                "summary": "Delete everything",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
             "options": {
                 "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
                 "tags": [
-                    "General"
+                    "v1"
                 ],
                 "summary": "Allowed HTTP verbs",
                 "responses": {
@@ -2819,7 +2837,7 @@
                 },
                 "allocations": {
                     "type": "string",
-                    "example": "https://example.com/api/v1/allocations3"
+                    "example": "https://example.com/api/v1/allocations"
                 },
                 "budgets": {
                     "type": "string",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -557,7 +557,7 @@ definitions:
         example: https://example.com/api/v1/accounts
         type: string
       allocations:
-        example: https://example.com/api/v1/allocations3
+        example: https://example.com/api/v1/allocations
         type: string
       budgets:
         example: https://example.com/api/v1/budgets
@@ -612,6 +612,18 @@ paths:
       tags:
       - General
   /v1:
+    delete:
+      description: Permanently deletes all resources
+      responses:
+        "204":
+          description: No Content
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Delete everything
+      tags:
+      - v1
     get:
       description: Returns general information about the v1 API
       responses:
@@ -621,7 +633,7 @@ paths:
             $ref: '#/definitions/router.V1Response'
       summary: v1 API
       tags:
-      - General
+      - v1
     options:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
@@ -630,7 +642,7 @@ paths:
           description: No Content
       summary: Allowed HTTP verbs
       tags:
-      - General
+      - v1
   /v1/accounts:
     get:
       description: Returns a list of accounts

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -111,6 +111,7 @@ func Router() (*gin.Engine, error) {
 	v1 := r.Group("/v1")
 	{
 		v1.GET("", GetV1)
+		v1.DELETE("", controllers.DeleteAll)
 		v1.OPTIONS("", OptionsV1)
 	}
 
@@ -197,12 +198,12 @@ type V1Links struct {
 	Categories   string `json:"categories" example:"https://example.com/api/v1/categories"`
 	Transactions string `json:"transactions" example:"https://example.com/api/v1/transactions"`
 	Envelopes    string `json:"envelopes" example:"https://example.com/api/v1/envelopes"`
-	Allocations  string `json:"allocations" example:"https://example.com/api/v1/allocations3"`
+	Allocations  string `json:"allocations" example:"https://example.com/api/v1/allocations"`
 }
 
 // @Summary     v1 API
 // @Description Returns general information about the v1 API
-// @Tags        General
+// @Tags        v1
 // @Success     200 {object} V1Response
 // @Router      /v1 [get]
 func GetV1(c *gin.Context) {
@@ -220,9 +221,9 @@ func GetV1(c *gin.Context) {
 
 // @Summary     Allowed HTTP verbs
 // @Description Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
-// @Tags        General
+// @Tags        v1
 // @Success     204
 // @Router      /v1 [options]
 func OptionsV1(c *gin.Context) {
-	httputil.OptionsGet(c)
+	httputil.OptionsGetDelete(c)
 }

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -142,12 +142,13 @@ func TestOptions(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		path string
-		f    func(*gin.Context)
+		path     string
+		f        func(*gin.Context)
+		expected string
 	}{
-		{"/", router.OptionsRoot},
-		{"/version", router.OptionsVersion},
-		{"/v1", router.OptionsV1},
+		{"/", router.OptionsRoot, "GET"},
+		{"/version", router.OptionsVersion, "GET"},
+		{"/v1", router.OptionsV1, "GET, DELETE"},
 	}
 
 	for _, tt := range tests {
@@ -164,7 +165,7 @@ func TestOptions(t *testing.T) {
 			r.ServeHTTP(w, c.Request)
 
 			assert.Equal(t, http.StatusNoContent, w.Code)
-			assert.Equal(t, http.MethodGet, w.Header().Get("allow"))
+			assert.Equal(t, tt.expected, w.Header().Get("allow"))
 		})
 	}
 }

--- a/pkg/controllers/cleanup.go
+++ b/pkg/controllers/cleanup.go
@@ -1,0 +1,56 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/envelope-zero/backend/internal/database"
+	"github.com/envelope-zero/backend/pkg/httperrors"
+	"github.com/envelope-zero/backend/pkg/models"
+	"github.com/gin-gonic/gin"
+)
+
+// @Summary     Delete everything
+// @Description Permanently deletes all resources
+// @Tags        v1
+// @Success     204
+// @Failure     500 {object} httperrors.HTTPError
+// @Router      /v1 [delete]
+func DeleteAll(c *gin.Context) {
+	err := database.DB.Unscoped().Where("true").Delete(&models.Transaction{}).Error
+	if err != nil {
+		httperrors.Handler(c, err)
+		return
+	}
+
+	err = database.DB.Unscoped().Where("true").Delete(&models.Allocation{}).Error
+	if err != nil {
+		httperrors.Handler(c, err)
+		return
+	}
+
+	err = database.DB.Unscoped().Where("true").Delete(&models.Envelope{}).Error
+	if err != nil {
+		httperrors.Handler(c, err)
+		return
+	}
+
+	err = database.DB.Unscoped().Where("true").Delete(&models.Category{}).Error
+	if err != nil {
+		httperrors.Handler(c, err)
+		return
+	}
+
+	err = database.DB.Unscoped().Where("true").Delete(&models.Account{}).Error
+	if err != nil {
+		httperrors.Handler(c, err)
+		return
+	}
+
+	err = database.DB.Unscoped().Where("true").Delete(&models.Budget{}).Error
+	if err != nil {
+		httperrors.Handler(c, err)
+		return
+	}
+
+	c.JSON(http.StatusNoContent, gin.H{})
+}

--- a/pkg/controllers/cleanup_test.go
+++ b/pkg/controllers/cleanup_test.go
@@ -1,0 +1,46 @@
+package controllers_test
+
+import (
+	"net/http"
+
+	"github.com/envelope-zero/backend/pkg/models"
+	"github.com/envelope-zero/backend/pkg/test"
+	"github.com/shopspring/decimal"
+)
+
+func (suite *TestSuiteEnv) TestCleanup() {
+	_ = createTestBudget(suite.T(), models.BudgetCreate{})
+	_ = createTestAccount(suite.T(), models.AccountCreate{})
+	_ = createTestCategory(suite.T(), models.CategoryCreate{})
+	_ = createTestEnvelope(suite.T(), models.EnvelopeCreate{})
+	_ = createTestAllocation(suite.T(), models.AllocationCreate{})
+	_ = createTestTransaction(suite.T(), models.TransactionCreate{Amount: decimal.NewFromFloat(17.32)})
+
+	tests := []string{
+		"http://example.com/v1/budgets",
+		"http://example.com/v1/accounts",
+		"http://example.com/v1/categories",
+		"http://example.com/v1/transactions",
+		"http://example.com/v1/envelopes",
+		"http://example.com/v1/allocations",
+	}
+
+	// Delete
+	recorder := test.Request(suite.T(), http.MethodDelete, "http://example.com/v1", "")
+	test.AssertHTTPStatus(suite.T(), http.StatusNoContent, &recorder)
+
+	// Verify
+	for _, tt := range tests {
+		suite.Run(tt, func() {
+			recorder := test.Request(suite.T(), http.MethodGet, tt, "")
+			test.AssertHTTPStatus(suite.T(), http.StatusOK, &recorder)
+
+			var response struct {
+				Data []any `json:"data"`
+			}
+
+			test.DecodeResponse(suite.T(), &recorder, &response)
+			suite.Assert().Len(response.Data, 0, "There are resources left for type %s", tt)
+		})
+	}
+}

--- a/pkg/controllers/main_list_test.go
+++ b/pkg/controllers/main_list_test.go
@@ -13,7 +13,6 @@ var methodNotAllowedTests = []struct {
 	{"/", http.MethodPost},
 	{"/", http.MethodDelete},
 	{"http://example.com/v1", http.MethodPost},
-	{"http://example.com/v1", http.MethodDelete},
 	{"http://example.com/v1/budgets", "HEAD"},
 	{"http://example.com/v1/budgets", "PUT"},
 }

--- a/pkg/controllers/main_options_test.go
+++ b/pkg/controllers/main_options_test.go
@@ -7,21 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (suite *TestSuiteEnv) TestOptionsHeaderGeneral() {
-	optionsHeaderTests := []string{
-		"/",
-		"/version",
-		"http://example.com/v1",
-	}
-
-	for _, path := range optionsHeaderTests {
-		recorder := test.Request(suite.T(), http.MethodOptions, path, "")
-
-		assert.Equal(suite.T(), http.StatusNoContent, recorder.Code)
-		assert.Equal(suite.T(), recorder.Header().Get("allow"), "GET")
-	}
-}
-
 func (suite *TestSuiteEnv) TestOptionsHeaderResources() {
 	optionsHeaderTests := []string{
 		"http://example.com/v1/budgets",

--- a/pkg/httputil/options.go
+++ b/pkg/httputil/options.go
@@ -17,6 +17,11 @@ func OptionsGetPost(c *gin.Context) {
 	c.Render(http.StatusNoContent, render.JSON{})
 }
 
+func OptionsGetDelete(c *gin.Context) {
+	c.Header("allow", "GET, DELETE")
+	c.Render(http.StatusNoContent, render.JSON{})
+}
+
 func OptionsGetPatchDelete(c *gin.Context) {
 	c.Header("allow", "GET, PATCH, DELETE")
 	c.Render(http.StatusNoContent, render.JSON{})

--- a/pkg/httputil/options_test.go
+++ b/pkg/httputil/options_test.go
@@ -52,6 +52,20 @@ func TestOptionsGetPatchDelete(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, w.Code)
 }
 
+func TestOptionsGetDelete(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", httputil.OptionsGetDelete)
+
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Host = "example.com"
+	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, "GET, DELETE", w.Header().Get("allow"))
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
 func TestOptionsDelete(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, r := gin.CreateTestContext(w)


### PR DESCRIPTION
This endpoint allows you to delete all resources permanently.
It can be used to reset an instance to “factory defaults“
