### PR TITLE
fix: only calculate with transactions for the budget

### DIFF
--- a/pkg/models/budget.go
+++ b/pkg/models/budget.go
@@ -67,6 +67,11 @@ func (b Budget) Income(t time.Time) (decimal.Decimal, error) {
 		Where("transactions.envelope_id IS NULL").
 		Where("strftime('%m', transactions.date) = ?", fmt.Sprintf("%02d", t.Month())).
 		Where("strftime('%Y', transactions.date) = ?", fmt.Sprintf("%d", t.Year())).
+		Where(&Transaction{
+			TransactionCreate: TransactionCreate{
+				BudgetID: b.ID,
+			},
+		}).
 		Table("transactions").
 		Find(&income).
 		Error
@@ -92,6 +97,11 @@ func (b Budget) TotalIncome() (decimal.Decimal, error) {
 		Where("source_account.external = 1").
 		Where("destination_account.external = 0").
 		Where("transactions.envelope_id IS NULL").
+		Where(&Transaction{
+			TransactionCreate: TransactionCreate{
+				BudgetID: b.ID,
+			},
+		}).
 		Table("transactions").
 		Find(&income).
 		Error

--- a/pkg/models/budget_test.go
+++ b/pkg/models/budget_test.go
@@ -18,6 +18,12 @@ func (suite *TestSuiteEnv) TestBudgetCalculations() {
 		suite.Assert().Fail("Resource could not be saved", err)
 	}
 
+	emptyBudget := models.Budget{}
+	err = database.DB.Save(&emptyBudget).Error
+	if err != nil {
+		suite.Assert().Fail("Resource could not be saved", err)
+	}
+
 	bankAccount := models.Account{
 		AccountCreate: models.AccountCreate{
 			BudgetID: budget.ID,
@@ -149,15 +155,27 @@ func (suite *TestSuiteEnv) TestBudgetCalculations() {
 	shouldBalance := decimal.NewFromFloat(5489.38)
 	assert.True(suite.T(), budget.Balance.Equal(shouldBalance), "Balance for budget is not correct. Should be %s, is %s", shouldBalance, budget.Balance)
 
+	// Verify income for used budget in March
 	shouldIncome := decimal.NewFromFloat(2800)
 	income, err := budget.Income(marchFifteenthTwentyTwentyTwo)
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), income.Equal(shouldIncome), "Income is %s, should be %s", income, shouldIncome)
 
+	// Verify total income for used budget
 	shouldIncomeTotal := decimal.NewFromFloat(5600)
 	income, err = budget.TotalIncome()
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), income.Equal(shouldIncomeTotal), "Income is %s, should be %s", income, shouldIncomeTotal)
+
+	// Verify income for empty budget in March
+	income, err = emptyBudget.Income(marchFifteenthTwentyTwentyTwo)
+	assert.Nil(suite.T(), err)
+	assert.True(suite.T(), income.IsZero(), "Income is %s, should be 0", income)
+
+	// Verify total income for empty budget
+	income, err = emptyBudget.TotalIncome()
+	assert.Nil(suite.T(), err)
+	assert.True(suite.T(), income.IsZero(), "Income is %s, should be 0", income)
 }
 
 func (suite *TestSuiteEnv) TestMonthIncomeNoTransactions() {


### PR DESCRIPTION
When calculating sums over transactions for a budget, the query
should filter transactions by the budget.
