### PR TITLE
fix: budget balance not double the actual balance anymore

### DIFF
--- a/pkg/controllers/budget.go
+++ b/pkg/controllers/budget.go
@@ -616,7 +616,7 @@ func getBudgetObject(c *gin.Context, id uuid.UUID) (Budget, error) {
 	}
 
 	return Budget{
-		resource.WithCalculations(),
+		resource,
 		getBudgetLinks(c, resource.ID),
 	}, nil
 }

--- a/pkg/models/budget.go
+++ b/pkg/models/budget.go
@@ -36,6 +36,8 @@ type BudgetMonth struct {
 
 // WithCalculations computes all the calculated values.
 func (b Budget) WithCalculations() Budget {
+	b.Balance = decimal.Zero
+
 	// Get all OnBudget accounts for the budget
 	var accounts []Account
 	_ = database.DB.Where(&Account{
@@ -47,7 +49,6 @@ func (b Budget) WithCalculations() Budget {
 
 	// Add all their balances to the budget's balance
 	for _, account := range accounts {
-		fmt.Println(account.WithCalculations().Balance)
 		b.Balance = b.Balance.Add(account.WithCalculations().Balance)
 	}
 


### PR DESCRIPTION
Fixes a bug where the Balance of a budget was summed up twice and added.
