### PR TITLE
test: make codecov status informational

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -7,10 +7,10 @@ coverage:
       default:
         target: auto
         threshold: 3%
-        if_ci_failed: error
-        only_pulls: false
+        informational: true
 
     patch:
       default:
         target: auto
         threshold: 25%
+        informational: true


### PR DESCRIPTION
With this, the checks will always succeed, even if the coverage is
outside of thresholds.
