### PR TITLE
refactor: move database init to function, reduce gocyclo limit

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,14 @@
 issues:
   fix: true
 
+  # Relax rules for tests
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gocyclo
+        - errcheck
+        - dupl
+
 linters:
   enable:
     - gocyclo
@@ -16,6 +24,8 @@ linters-settings:
   gofumpt:
     lang-version: "1.18"
     extra-rules: true
+  gocyclo:
+    min-complexity: 15
 
   godot:
     exclude:


### PR DESCRIPTION
This reduces the cyclomatic complexity of the main function and makes golang-ci lint fail when it goes above 15.
