### PR TITLE
refactor: remove old code

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -2,6 +2,10 @@
 
 If upgrades between versions require manual actions, those are described here.
 
+## to any version > v1.0.0
+
+If you are running a version below `v0.35.0`, you _must_ upgrade to `v1.0.0` before you upgrade any further.
+
 ## v0.32.0 to v0.33.0
 
 [v0.33.0](https://github.com/envelope-zero/backend/releases/tag/v0.33.0) removes support for postgresql.

--- a/main.go
+++ b/main.go
@@ -105,13 +105,6 @@ func databaseInit() {
 		log.Fatal().Msg(err.Error())
 	}
 
-	// Drop unused constraint in https://github.com/envelope-zero/backend/pull/274
-	// Can be removed after the 1.0.0 release (we will require everyone to upgrade to 1.0.0 and then to further releases).
-	err = database.DB.Migrator().DropConstraint(&models.Allocation{}, "month_valid")
-	if err != nil {
-		log.Debug().Err(err).Msg("Could not drop month_valid constraint on allocations")
-	}
-
 	// Migrate all models so that the schema is correct
 	err = database.DB.AutoMigrate(models.Budget{}, models.Account{}, models.Category{}, models.Envelope{}, models.Transaction{}, models.Allocation{})
 	if err != nil {


### PR DESCRIPTION
Cleans up migration code that is not needed after v1.0.0
