### PR TITLE
chore(renovate): fix versioning for golangci-lint language version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,7 +30,8 @@
       "fileMatch": ["^\\.golangci\\.yml"],
       "matchStrings": ["lang-version: \"(?<currentValue>.*)\""],
       "datasourceTemplate": "github-tags",
-      "depNameTemplate": "golang/go"
+      "depNameTemplate": "golang/go",
+      "versioningTemplate": "docker"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
Uses docker versioning for golangci-lint go version as we need only major.minor
