### PR TITLE
refactor: break up router setup into multiple functions

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,10 +54,13 @@ func main() {
 		log.Fatal().Msg(err.Error())
 	}
 
-	r, err := router.Router()
+	r, err := router.Config()
 	if err != nil {
 		log.Fatal().Msg(err.Error())
 	}
+
+	// Attach the routes to the root URL
+	router.AttachRoutes(r.Group("/"))
 
 	// Set the port to the env variable, default to 8080
 	port := os.Getenv("PORT")

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -17,7 +17,8 @@ func TestGinMode(t *testing.T) {
 	os.Setenv("GIN_MODE", "debug")
 	os.Setenv("API_URL", "http://example.com")
 
-	_, err := router.Router()
+	r, err := router.Config()
+	router.AttachRoutes(r.Group("/"))
 
 	assert.Nil(t, err, "%T: %v", err, err)
 	assert.True(t, gin.IsDebugging())
@@ -27,14 +28,14 @@ func TestGinMode(t *testing.T) {
 }
 
 func TestEnvUnset(t *testing.T) {
-	_, err := router.Router()
+	_, err := router.Config()
 
 	assert.NotNil(t, err, "API_URL is unset, this must lead to an error")
 }
 
 func TestEnvNoURL(t *testing.T) {
 	os.Setenv("API_URL", "\\:veryMuchNotAURL")
-	_, err := router.Router()
+	_, err := router.Config()
 
 	assert.NotNil(t, err, "API_URL is not an URL, this must lead to an error")
 }
@@ -45,7 +46,7 @@ func TestCorsSetting(t *testing.T) {
 	os.Setenv("CORS_ALLOW_ORIGINS", "http://localhost:3000 https://example.com")
 	os.Setenv("API_URL", "http://example.com")
 
-	_, err := router.Router()
+	_, err := router.Config()
 
 	assert.Nil(t, err)
 	os.Unsetenv("CORS_ALLOW_ORIGINS")

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -41,10 +41,11 @@ func Request(t *testing.T, method, url string, body any, headers ...map[string]s
 		}
 	}
 
-	router, err := router.Router()
+	r, err := router.Config()
 	if err != nil {
 		assert.FailNow(t, "Router could not be initialized")
 	}
+	router.AttachRoutes(r.Group("/"))
 
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest(method, url, bytes.NewBuffer(byteStr))
@@ -55,7 +56,7 @@ func Request(t *testing.T, method, url string, body any, headers ...map[string]s
 		}
 	}
 
-	router.ServeHTTP(recorder, req)
+	r.ServeHTTP(recorder, req)
 
 	return *recorder
 }


### PR DESCRIPTION
This breaks up the router configuration in multiple functions, allowing for better reusability.
