### PR TITLE
feat: add grouped month endpoint

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -934,7 +934,7 @@ const docTemplate = `{
         },
         "/v1/budgets/{budgetId}/{month}": {
             "get": {
-                "description": "Returns data about a budget for a for a specific month",
+                "description": "Returns data about a budget for a for a specific month. **Use GET /month endpoint with month and budgetId query parameters instead.**",
                 "produces": [
                     "application/json"
                 ],
@@ -942,6 +942,7 @@ const docTemplate = `{
                     "Budgets"
                 ],
                 "summary": "Get Budget month data",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -983,11 +984,12 @@ const docTemplate = `{
                 }
             },
             "options": {
-                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs. **Use GET /month endpoint with month and budgetId query parameters instead.**",
                 "tags": [
                     "Budgets"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1712,7 +1714,7 @@ const docTemplate = `{
         },
         "/v1/envelopes/{envelopeId}/{month}": {
             "get": {
-                "description": "Returns data about an envelope for a for a specific month",
+                "description": "Returns data about an envelope for a for a specific month. **Use GET /month endpoint with month and budgetId query parameters instead.**",
                 "produces": [
                     "application/json"
                 ],
@@ -1720,6 +1722,7 @@ const docTemplate = `{
                     "Envelopes"
                 ],
                 "summary": "Get Envelope month data",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1757,6 +1760,69 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/httperrors.HTTPError"
                         }
+                    }
+                }
+            }
+        },
+        "/v1/months": {
+            "get": {
+                "description": "Returns data about a specific month.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Months"
+                ],
+                "summary": "Get data about a month",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID formatted as string",
+                        "name": "budget",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The month in YYYY-MM format",
+                        "name": "month",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.MonthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs.",
+                "tags": [
+                    "Months"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
                     }
                 }
             }
@@ -2302,6 +2368,11 @@ const docTemplate = `{
                     "type": "string",
                     "example": "https://example.com/api/v1/envelopes?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"
                 },
+                "groupedMonth": {
+                    "description": "This 'YYYY-MM' for clients to replace with the actual year and month.",
+                    "type": "string",
+                    "example": "https://example.com/api/v1/month?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf\u0026month=YYYY-MM"
+                },
                 "month": {
                     "description": "This 'YYYY-MM' for clients to replace with the actual year and month.",
                     "type": "string",
@@ -2508,6 +2579,14 @@ const docTemplate = `{
                 }
             }
         },
+        "controllers.MonthResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.Month"
+                }
+            }
+        },
         "controllers.Transaction": {
             "type": "object",
             "properties": {
@@ -2691,7 +2770,7 @@ const docTemplate = `{
                     }
                 },
                 "id": {
-                    "description": "The ID of the Envelope",
+                    "description": "The ID of the Budget",
                     "type": "string",
                     "example": "1e777d24-3f5b-4c43-8000-04f65f895578"
                 },
@@ -2705,7 +2784,7 @@ const docTemplate = `{
                     "example": "2006-05-01T00:00:00.000000Z"
                 },
                 "name": {
-                    "description": "The name of the Envelope",
+                    "description": "The name of the Budget",
                     "type": "string",
                     "example": "Groceries"
                 }
@@ -2725,6 +2804,25 @@ const docTemplate = `{
                 "note": {
                     "type": "string",
                     "example": "All envelopes for long-term saving"
+                }
+            }
+        },
+        "models.CategoryEnvelopes": {
+            "type": "object",
+            "properties": {
+                "envelopes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.EnvelopeMonth"
+                    }
+                },
+                "id": {
+                    "type": "string",
+                    "example": "dafd9a74-6aeb-46b9-9f5a-cfca624fea85"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Rainy Day Funds"
                 }
             }
         },
@@ -2762,7 +2860,7 @@ const docTemplate = `{
                     "example": "10b9705d-3356-459e-9d5a-28d42a6c4547"
                 },
                 "month": {
-                    "description": "This is always set to 00:00 UTC on the first of the month.",
+                    "description": "This is always set to 00:00 UTC on the first of the month. **This field is deprecated and will be removed in v2**",
                     "type": "string",
                     "example": "1969-06-01T00:00:00.000000Z"
                 },
@@ -2774,6 +2872,44 @@ const docTemplate = `{
                 "spent": {
                     "type": "number",
                     "example": 73.12
+                }
+            }
+        },
+        "models.Month": {
+            "type": "object",
+            "properties": {
+                "available": {
+                    "type": "number",
+                    "example": 217.34
+                },
+                "budgeted": {
+                    "type": "number",
+                    "example": 2100
+                },
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.CategoryEnvelopes"
+                    }
+                },
+                "id": {
+                    "description": "The ID of the Budget",
+                    "type": "string",
+                    "example": "1e777d24-3f5b-4c43-8000-04f65f895578"
+                },
+                "income": {
+                    "type": "number",
+                    "example": 2317.34
+                },
+                "month": {
+                    "description": "This is always set to 00:00 UTC on the first of the month.",
+                    "type": "string",
+                    "example": "2006-05-01T00:00:00.000000Z"
+                },
+                "name": {
+                    "description": "The name of the Budget",
+                    "type": "string",
+                    "example": "Zero budget"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -922,7 +922,7 @@
         },
         "/v1/budgets/{budgetId}/{month}": {
             "get": {
-                "description": "Returns data about a budget for a for a specific month",
+                "description": "Returns data about a budget for a for a specific month. **Use GET /month endpoint with month and budgetId query parameters instead.**",
                 "produces": [
                     "application/json"
                 ],
@@ -930,6 +930,7 @@
                     "Budgets"
                 ],
                 "summary": "Get Budget month data",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -971,11 +972,12 @@
                 }
             },
             "options": {
-                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs. **Use GET /month endpoint with month and budgetId query parameters instead.**",
                 "tags": [
                     "Budgets"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1700,7 +1702,7 @@
         },
         "/v1/envelopes/{envelopeId}/{month}": {
             "get": {
-                "description": "Returns data about an envelope for a for a specific month",
+                "description": "Returns data about an envelope for a for a specific month. **Use GET /month endpoint with month and budgetId query parameters instead.**",
                 "produces": [
                     "application/json"
                 ],
@@ -1708,6 +1710,7 @@
                     "Envelopes"
                 ],
                 "summary": "Get Envelope month data",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1745,6 +1748,69 @@
                         "schema": {
                             "$ref": "#/definitions/httperrors.HTTPError"
                         }
+                    }
+                }
+            }
+        },
+        "/v1/months": {
+            "get": {
+                "description": "Returns data about a specific month.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Months"
+                ],
+                "summary": "Get data about a month",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID formatted as string",
+                        "name": "budget",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The month in YYYY-MM format",
+                        "name": "month",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.MonthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs.",
+                "tags": [
+                    "Months"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
                     }
                 }
             }
@@ -2290,6 +2356,11 @@
                     "type": "string",
                     "example": "https://example.com/api/v1/envelopes?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"
                 },
+                "groupedMonth": {
+                    "description": "This 'YYYY-MM' for clients to replace with the actual year and month.",
+                    "type": "string",
+                    "example": "https://example.com/api/v1/month?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf\u0026month=YYYY-MM"
+                },
                 "month": {
                     "description": "This 'YYYY-MM' for clients to replace with the actual year and month.",
                     "type": "string",
@@ -2496,6 +2567,14 @@
                 }
             }
         },
+        "controllers.MonthResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.Month"
+                }
+            }
+        },
         "controllers.Transaction": {
             "type": "object",
             "properties": {
@@ -2679,7 +2758,7 @@
                     }
                 },
                 "id": {
-                    "description": "The ID of the Envelope",
+                    "description": "The ID of the Budget",
                     "type": "string",
                     "example": "1e777d24-3f5b-4c43-8000-04f65f895578"
                 },
@@ -2693,7 +2772,7 @@
                     "example": "2006-05-01T00:00:00.000000Z"
                 },
                 "name": {
-                    "description": "The name of the Envelope",
+                    "description": "The name of the Budget",
                     "type": "string",
                     "example": "Groceries"
                 }
@@ -2713,6 +2792,25 @@
                 "note": {
                     "type": "string",
                     "example": "All envelopes for long-term saving"
+                }
+            }
+        },
+        "models.CategoryEnvelopes": {
+            "type": "object",
+            "properties": {
+                "envelopes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.EnvelopeMonth"
+                    }
+                },
+                "id": {
+                    "type": "string",
+                    "example": "dafd9a74-6aeb-46b9-9f5a-cfca624fea85"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Rainy Day Funds"
                 }
             }
         },
@@ -2750,7 +2848,7 @@
                     "example": "10b9705d-3356-459e-9d5a-28d42a6c4547"
                 },
                 "month": {
-                    "description": "This is always set to 00:00 UTC on the first of the month.",
+                    "description": "This is always set to 00:00 UTC on the first of the month. **This field is deprecated and will be removed in v2**",
                     "type": "string",
                     "example": "1969-06-01T00:00:00.000000Z"
                 },
@@ -2762,6 +2860,44 @@
                 "spent": {
                     "type": "number",
                     "example": 73.12
+                }
+            }
+        },
+        "models.Month": {
+            "type": "object",
+            "properties": {
+                "available": {
+                    "type": "number",
+                    "example": 217.34
+                },
+                "budgeted": {
+                    "type": "number",
+                    "example": 2100
+                },
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.CategoryEnvelopes"
+                    }
+                },
+                "id": {
+                    "description": "The ID of the Budget",
+                    "type": "string",
+                    "example": "1e777d24-3f5b-4c43-8000-04f65f895578"
+                },
+                "income": {
+                    "type": "number",
+                    "example": 2317.34
+                },
+                "month": {
+                    "description": "This is always set to 00:00 UTC on the first of the month.",
+                    "type": "string",
+                    "example": "2006-05-01T00:00:00.000000Z"
+                },
+                "name": {
+                    "description": "The name of the Budget",
+                    "type": "string",
+                    "example": "Zero budget"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -159,6 +159,11 @@ definitions:
       envelopes:
         example: https://example.com/api/v1/envelopes?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf
         type: string
+      groupedMonth:
+        description: This 'YYYY-MM' for clients to replace with the actual year and
+          month.
+        example: https://example.com/api/v1/month?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf&month=YYYY-MM
+        type: string
       month:
         description: This 'YYYY-MM' for clients to replace with the actual year and
           month.
@@ -304,6 +309,11 @@ definitions:
       data:
         $ref: '#/definitions/controllers.Envelope'
     type: object
+  controllers.MonthResponse:
+    properties:
+      data:
+        $ref: '#/definitions/models.Month'
+    type: object
   controllers.Transaction:
     properties:
       amount:
@@ -441,7 +451,7 @@ definitions:
           $ref: '#/definitions/models.EnvelopeMonth'
         type: array
       id:
-        description: The ID of the Envelope
+        description: The ID of the Budget
         example: 1e777d24-3f5b-4c43-8000-04f65f895578
         type: string
       income:
@@ -452,7 +462,7 @@ definitions:
         example: "2006-05-01T00:00:00.000000Z"
         type: string
       name:
-        description: The name of the Envelope
+        description: The name of the Budget
         example: Groceries
         type: string
     type: object
@@ -466,6 +476,19 @@ definitions:
         type: string
       note:
         example: All envelopes for long-term saving
+        type: string
+    type: object
+  models.CategoryEnvelopes:
+    properties:
+      envelopes:
+        items:
+          $ref: '#/definitions/models.EnvelopeMonth'
+        type: array
+      id:
+        example: dafd9a74-6aeb-46b9-9f5a-cfca624fea85
+        type: string
+      name:
+        example: Rainy Day Funds
         type: string
     type: object
   models.EnvelopeCreate:
@@ -493,7 +516,8 @@ definitions:
         example: 10b9705d-3356-459e-9d5a-28d42a6c4547
         type: string
       month:
-        description: This is always set to 00:00 UTC on the first of the month.
+        description: This is always set to 00:00 UTC on the first of the month. **This
+          field is deprecated and will be removed in v2**
         example: "1969-06-01T00:00:00.000000Z"
         type: string
       name:
@@ -503,6 +527,34 @@ definitions:
       spent:
         example: 73.12
         type: number
+    type: object
+  models.Month:
+    properties:
+      available:
+        example: 217.34
+        type: number
+      budgeted:
+        example: 2100
+        type: number
+      categories:
+        items:
+          $ref: '#/definitions/models.CategoryEnvelopes'
+        type: array
+      id:
+        description: The ID of the Budget
+        example: 1e777d24-3f5b-4c43-8000-04f65f895578
+        type: string
+      income:
+        example: 2317.34
+        type: number
+      month:
+        description: This is always set to 00:00 UTC on the first of the month.
+        example: "2006-05-01T00:00:00.000000Z"
+        type: string
+      name:
+        description: The name of the Budget
+        example: Zero budget
+        type: string
     type: object
   models.TransactionCreate:
     properties:
@@ -1212,7 +1264,9 @@ paths:
       - Budgets
   /v1/budgets/{budgetId}/{month}:
     get:
-      description: Returns data about a budget for a for a specific month
+      deprecated: true
+      description: Returns data about a budget for a for a specific month. **Use GET
+        /month endpoint with month and budgetId query parameters instead.**
       parameters:
       - description: ID formatted as string
         in: path
@@ -1245,8 +1299,10 @@ paths:
       tags:
       - Budgets
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
-        allowed HTTP verbs
+        allowed HTTP verbs. **Use GET /month endpoint with month and budgetId query
+        parameters instead.**
       parameters:
       - description: ID formatted as string
         in: path
@@ -1738,7 +1794,9 @@ paths:
       - Envelopes
   /v1/envelopes/{envelopeId}/{month}:
     get:
-      description: Returns data about an envelope for a for a specific month
+      deprecated: true
+      description: Returns data about an envelope for a for a specific month. **Use
+        GET /month endpoint with month and budgetId query parameters instead.**
       parameters:
       - description: ID formatted as string
         in: path
@@ -1770,6 +1828,49 @@ paths:
       summary: Get Envelope month data
       tags:
       - Envelopes
+  /v1/months:
+    get:
+      description: Returns data about a specific month.
+      parameters:
+      - description: ID formatted as string
+        in: query
+        name: budget
+        required: true
+        type: string
+      - description: The month in YYYY-MM format
+        in: query
+        name: month
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.MonthResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Get data about a month
+      tags:
+      - Months
+    options:
+      description: Returns an empty response with the HTTP Header "allow" set to the
+        allowed HTTP verbs.
+      responses:
+        "204":
+          description: No Content
+      summary: Allowed HTTP verbs
+      tags:
+      - Months
   /v1/transactions:
     get:
       description: Returns a list of transactions

--- a/pkg/controllers/budget.go
+++ b/pkg/controllers/budget.go
@@ -33,6 +33,7 @@ type BudgetLinks struct {
 	Envelopes        string `json:"envelopes" example:"https://example.com/api/v1/envelopes?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"`
 	Transactions     string `json:"transactions" example:"https://example.com/api/v1/transactions?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"`
 	Month            string `json:"month" example:"https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/YYYY-MM"`                        // This 'YYYY-MM' for clients to replace with the actual year and month.
+	GroupedMonth     string `json:"groupedMonth" example:"https://example.com/api/v1/month?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf&month=YYYY-MM"`      // This 'YYYY-MM' for clients to replace with the actual year and month.
 	MonthAllocations string `json:"monthAllocations" example:"https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/YYYY-MM/allocations"` // This uses 'YYYY-MM' for clients to replace with the actual year and month.
 }
 
@@ -116,7 +117,7 @@ func (co Controller) OptionsBudgetDetail(c *gin.Context) {
 }
 
 // @Summary     Allowed HTTP verbs
-// @Description Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
+// @Description Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs. **Use GET /month endpoint with month and budgetId query parameters instead.**
 // @Tags        Budgets
 // @Success     204
 // @Failure     400 {object} httperrors.HTTPError
@@ -125,6 +126,7 @@ func (co Controller) OptionsBudgetDetail(c *gin.Context) {
 // @Param       budgetId path     string true "ID formatted as string"
 // @Param       month    path     string true "The month in YYYY-MM format"
 // @Router      /v1/budgets/{budgetId}/{month} [options]
+// @Deprecated  true
 func (co Controller) OptionsBudgetMonth(c *gin.Context) {
 	p, err := uuid.Parse(c.Param("budgetId"))
 	if err != nil {
@@ -276,7 +278,7 @@ func (co Controller) GetBudget(c *gin.Context) {
 }
 
 // @Summary     Get Budget month data
-// @Description Returns data about a budget for a for a specific month
+// @Description Returns data about a budget for a for a specific month. **Use GET /month endpoint with month and budgetId query parameters instead.**
 // @Tags        Budgets
 // @Produce     json
 // @Success     200 {object} BudgetMonthResponse
@@ -286,6 +288,7 @@ func (co Controller) GetBudget(c *gin.Context) {
 // @Param       budgetId path     string true "ID formatted as string"
 // @Param       month    path     string true "The month in YYYY-MM format"
 // @Router      /v1/budgets/{budgetId}/{month} [get]
+// @Deprecated  true
 func (co Controller) GetBudgetMonth(c *gin.Context) {
 	p, err := uuid.Parse(c.Param("budgetId"))
 	if err != nil {
@@ -642,6 +645,7 @@ func (co Controller) getBudgetObject(c *gin.Context, id uuid.UUID) (Budget, bool
 			Envelopes:        fmt.Sprintf("%s/v1/envelopes?budget=%s", c.GetString("baseURL"), resource.ID),
 			Transactions:     fmt.Sprintf("%s/v1/transactions?budget=%s", c.GetString("baseURL"), resource.ID),
 			Month:            url + "/YYYY-MM",
+			GroupedMonth:     fmt.Sprintf("%s/v1/months?budget=%s&month=YYYY-MM", c.GetString("baseURL"), resource.ID),
 			MonthAllocations: url + "/YYYY-MM/allocations",
 		},
 	}, true

--- a/pkg/controllers/envelope.go
+++ b/pkg/controllers/envelope.go
@@ -207,7 +207,7 @@ func (co Controller) GetEnvelope(c *gin.Context) {
 }
 
 // @Summary     Get Envelope month data
-// @Description Returns data about an envelope for a for a specific month
+// @Description Returns data about an envelope for a for a specific month. **Use GET /month endpoint with month and budgetId query parameters instead.**
 // @Tags        Envelopes
 // @Produce     json
 // @Success     200 {object} EnvelopeMonthResponse
@@ -217,6 +217,7 @@ func (co Controller) GetEnvelope(c *gin.Context) {
 // @Param       envelopeId path     string true "ID formatted as string"
 // @Param       month      path     string true "The month in YYYY-MM format"
 // @Router      /v1/envelopes/{envelopeId}/{month} [get]
+// @Deprecated  true
 func (co Controller) GetEnvelopeMonth(c *gin.Context) {
 	p, err := uuid.Parse(c.Param("envelopeId"))
 	if err != nil {

--- a/pkg/controllers/month.go
+++ b/pkg/controllers/month.go
@@ -1,0 +1,149 @@
+package controllers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/envelope-zero/backend/pkg/httperrors"
+	"github.com/envelope-zero/backend/pkg/httputil"
+	"github.com/envelope-zero/backend/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+type MonthResponse struct {
+	Data models.Month `json:"data"`
+}
+
+type MonthQuery struct {
+	Month    time.Time `form:"month" time_format:"2006-01" time_utc:"1" example:"2022-07"`
+	BudgetID string    `form:"budget" example:"81b0c9ce-6fd3-4e1e-becc-106055898a2a"`
+}
+
+// RegisterMonthRoutes registers the routes for months with
+// the RouterGroup that is passed.
+func (co Controller) RegisterMonthRoutes(r *gin.RouterGroup) {
+	{
+		r.OPTIONS("", co.OptionsMonth)
+		r.GET("", co.GetMonth)
+	}
+}
+
+// @Summary     Allowed HTTP verbs
+// @Description Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs.
+// @Tags        Months
+// @Success     204
+// @Router      /v1/months [options]
+func (co Controller) OptionsMonth(c *gin.Context) {
+	httputil.OptionsGet(c)
+}
+
+// @Summary     Get data about a month
+// @Description Returns data about a specific month.
+// @Tags        Months
+// @Produce     json
+// @Success     200 {object} MonthResponse
+// @Failure     400 {object} httperrors.HTTPError
+// @Failure     404
+// @Failure     500    {object} httperrors.HTTPError
+// @Param       budget query    string true "ID formatted as string"
+// @Param       month  query    string true "The month in YYYY-MM format"
+// @Router      /v1/months [get]
+func (co Controller) GetMonth(c *gin.Context) {
+	var query MonthQuery
+	if err := c.Bind(&query); err != nil {
+		httperrors.Handler(c, err)
+		return
+	}
+
+	budgetID, err := uuid.Parse(query.BudgetID)
+	if err != nil {
+		httperrors.InvalidUUID(c)
+		return
+	}
+
+	budget, ok := co.getBudgetResource(c, budgetID)
+	if !ok {
+		return
+	}
+
+	if query.Month.IsZero() {
+		httperrors.New(c, http.StatusBadRequest, "You cannot request data for no month")
+		return
+	}
+	// Set the month to the first of the month at midnight
+	query.Month = time.Date(query.Month.Year(), query.Month.Month(), 1, 0, 0, 0, 0, time.UTC)
+
+	// Initialize the response object
+	month := models.Month{
+		ID:    budget.ID,
+		Name:  budget.Name,
+		Month: query.Month,
+	}
+
+	// Add budgeted sum to response
+	budgeted, err := budget.Budgeted(co.DB, month.Month)
+	if err != nil {
+		httperrors.Handler(c, err)
+		return
+	}
+	month.Budgeted = budgeted
+
+	// Add income to response
+	income, err := budget.Income(co.DB, month.Month)
+	if err != nil {
+		httperrors.Handler(c, err)
+		return
+	}
+	month.Income = income
+
+	// Add available sum to response
+	available, err := budget.Available(co.DB, month.Month)
+	if err != nil {
+		httperrors.Handler(c, err)
+		return
+	}
+	month.Available = available
+
+	// Get all categories to iterate over
+	categories, ok := co.getCategoryResources(c, budget.ID)
+	if !ok {
+		return
+	}
+
+	month.Categories = make([]models.CategoryEnvelopes, 0)
+
+	// Get envelopes for all categories
+	for _, category := range categories {
+		var categoryEnvelopes models.CategoryEnvelopes
+
+		// Set the basic category values
+		categoryEnvelopes.ID = category.ID
+		categoryEnvelopes.Name = category.Name
+		categoryEnvelopes.Envelopes = make([]models.EnvelopeMonth, 0)
+
+		var envelopes []models.Envelope
+
+		if !queryWithRetry(c, co.DB.Where(&models.Envelope{
+			EnvelopeCreate: models.EnvelopeCreate{
+				CategoryID: category.ID,
+			},
+		}).Find(&envelopes)) {
+			return
+		}
+
+		for _, envelope := range envelopes {
+			envelopeMonth, err := envelope.Month(co.DB, month.Month)
+			if err != nil {
+				httperrors.Handler(c, err)
+				return
+			}
+
+			categoryEnvelopes.Envelopes = append(categoryEnvelopes.Envelopes, envelopeMonth)
+		}
+
+		month.Categories = append(month.Categories, categoryEnvelopes)
+	}
+
+	c.JSON(http.StatusOK, MonthResponse{Data: month})
+}

--- a/pkg/controllers/month_test.go
+++ b/pkg/controllers/month_test.go
@@ -1,0 +1,242 @@
+package controllers_test
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/envelope-zero/backend/pkg/controllers"
+	"github.com/envelope-zero/backend/pkg/models"
+	"github.com/envelope-zero/backend/test"
+	"github.com/shopspring/decimal"
+)
+
+func (suite *TestSuiteStandard) TestOptionsMonth() {
+	recorder := test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/months", "")
+	suite.Assert().Equal(http.StatusNoContent, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
+	suite.Assert().Equal(recorder.Header().Get("allow"), "GET")
+}
+
+// TestBudgetMonth verifies that the monthly calculations are correct.
+func (suite *TestSuiteStandard) TestMonth() {
+	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
+	category := suite.createTestCategory(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID, Name: "Upkeep"})
+	envelope := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID, Name: "Utilities"})
+	account := suite.createTestAccount(suite.T(), models.AccountCreate{BudgetID: budget.Data.ID})
+	externalAccount := suite.createTestAccount(suite.T(), models.AccountCreate{BudgetID: budget.Data.ID, External: true})
+
+	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+		EnvelopeID: envelope.Data.ID,
+		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+		Amount:     decimal.NewFromFloat(20.99),
+	})
+
+	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+		EnvelopeID: envelope.Data.ID,
+		Month:      time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC),
+		Amount:     decimal.NewFromFloat(47.12),
+	})
+
+	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+		EnvelopeID: envelope.Data.ID,
+		Month:      time.Date(2022, 3, 1, 0, 0, 0, 0, time.UTC),
+		Amount:     decimal.NewFromFloat(31.17),
+	})
+
+	_ = suite.createTestTransaction(suite.T(), models.TransactionCreate{
+		Date:                 time.Date(2022, 1, 15, 0, 0, 0, 0, time.UTC),
+		Amount:               decimal.NewFromFloat(10.0),
+		Note:                 "Water bill for January",
+		BudgetID:             budget.Data.ID,
+		SourceAccountID:      account.Data.ID,
+		DestinationAccountID: externalAccount.Data.ID,
+		EnvelopeID:           &envelope.Data.ID,
+		Reconciled:           true,
+	})
+
+	_ = suite.createTestTransaction(suite.T(), models.TransactionCreate{
+		Date:                 time.Date(2022, 2, 15, 0, 0, 0, 0, time.UTC),
+		Amount:               decimal.NewFromFloat(5.0),
+		Note:                 "Water bill for February",
+		BudgetID:             budget.Data.ID,
+		SourceAccountID:      account.Data.ID,
+		DestinationAccountID: externalAccount.Data.ID,
+		EnvelopeID:           &envelope.Data.ID,
+		Reconciled:           true,
+	})
+
+	_ = suite.createTestTransaction(suite.T(), models.TransactionCreate{
+		Date:                 time.Date(2022, 3, 15, 0, 0, 0, 0, time.UTC),
+		Amount:               decimal.NewFromFloat(15.0),
+		Note:                 "Water bill for March",
+		BudgetID:             budget.Data.ID,
+		SourceAccountID:      account.Data.ID,
+		DestinationAccountID: externalAccount.Data.ID,
+		EnvelopeID:           &envelope.Data.ID,
+		Reconciled:           true,
+	})
+
+	_ = suite.createTestTransaction(suite.T(), models.TransactionCreate{
+		Date:                 time.Date(2022, 3, 1, 7, 38, 17, 0, time.UTC),
+		Amount:               decimal.NewFromFloat(1500),
+		Note:                 "Income for march",
+		BudgetID:             budget.Data.ID,
+		SourceAccountID:      externalAccount.Data.ID,
+		DestinationAccountID: account.Data.ID,
+		EnvelopeID:           nil,
+	})
+
+	tests := []struct {
+		path     string
+		response controllers.MonthResponse
+	}{
+		{
+			strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-01", -1),
+			controllers.MonthResponse{
+				Data: models.Month{
+					Month:  time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+					Income: decimal.NewFromFloat(0),
+
+					Categories: []models.CategoryEnvelopes{
+						{
+							Name: category.Data.Name,
+							ID:   category.Data.ID,
+							Envelopes: []models.EnvelopeMonth{
+								{
+									Name:       "Utilities",
+									Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+									Spent:      decimal.NewFromFloat(10),
+									Balance:    decimal.NewFromFloat(10.99),
+									Allocation: decimal.NewFromFloat(20.99),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-02", -1),
+			controllers.MonthResponse{
+				Data: models.Month{
+					Month:  time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC),
+					Income: decimal.NewFromFloat(0),
+					Categories: []models.CategoryEnvelopes{
+						{
+							Name: category.Data.Name,
+							ID:   category.Data.ID,
+							Envelopes: []models.EnvelopeMonth{
+								{
+									Name:       "Utilities",
+									Month:      time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC),
+									Balance:    decimal.NewFromFloat(53.11),
+									Spent:      decimal.NewFromFloat(5),
+									Allocation: decimal.NewFromFloat(47.12),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-03", -1),
+			controllers.MonthResponse{
+				Data: models.Month{
+					Month:  time.Date(2022, 3, 1, 0, 0, 0, 0, time.UTC),
+					Income: decimal.NewFromFloat(1500),
+					Categories: []models.CategoryEnvelopes{
+						{
+							Name: category.Data.Name,
+							ID:   category.Data.ID,
+							Envelopes: []models.EnvelopeMonth{
+								{
+									Name:       "Utilities",
+									Month:      time.Date(2022, 3, 1, 0, 0, 0, 0, time.UTC),
+									Balance:    decimal.NewFromFloat(69.28),
+									Spent:      decimal.NewFromFloat(15),
+									Allocation: decimal.NewFromFloat(31.17),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var month controllers.MonthResponse
+	for _, tt := range tests {
+		r := test.Request(suite.controller, suite.T(), http.MethodGet, tt.path, "")
+		test.AssertHTTPStatus(suite.T(), &r, http.StatusOK)
+		test.DecodeResponse(suite.T(), &r, &month)
+
+		// Verify income calculation
+		suite.Assert().True(month.Data.Income.Equal(tt.response.Data.Income))
+
+		if !suite.Assert().Len(month.Data.Categories, 1) {
+			suite.Assert().FailNow("Response category length does not match!", "Category list does not have exactly 1 item, it has %d, Request ID: %s", len(month.Data.Categories), r.Header().Get("x-request-id"))
+		}
+
+		if !suite.Assert().Len(month.Data.Categories[0].Envelopes, 1) {
+			suite.Assert().FailNow("Response envelope length does not match!", "Envelope list does not have exactly 1 item, it has %d, Request ID: %s", len(month.Data.Categories[0].Envelopes), r.Header().Get("x-request-id"))
+		}
+
+		expected := tt.response.Data.Categories[0].Envelopes[0]
+		envelope := month.Data.Categories[0].Envelopes[0]
+		suite.Assert().True(envelope.Spent.Equal(expected.Spent), "Monthly spent calculation for %v is wrong: should be %v, but is %v: %#v", month.Data.Month, expected.Spent, envelope.Spent, month.Data)
+		suite.Assert().True(envelope.Balance.Equal(expected.Balance), "Monthly balance calculation for %v is wrong: should be %v, but is %v: %#v", month.Data.Month, expected.Balance, envelope.Balance, month.Data)
+		suite.Assert().True(envelope.Allocation.Equal(expected.Allocation), "Monthly allocation fetch for %v is wrong: should be %v, but is %v: %#v", month.Data.Month, expected.Allocation, envelope.Allocation, month.Data)
+	}
+}
+
+// TestBudgetMonth verifies that the monthly calculations are correct.
+func (suite *TestSuiteStandard) TestMonthNotNil() {
+	var month controllers.MonthResponse
+
+	// Verify that the categories list is empty, not nil
+	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
+
+	r := test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-01", 1), "")
+	test.AssertHTTPStatus(suite.T(), &r, http.StatusOK)
+	test.DecodeResponse(suite.T(), &r, &month)
+	if !suite.Assert().NotNil(month.Data.Categories) {
+		suite.Assert().FailNow("Categories field is nil, cannot continue")
+	}
+	suite.Assert().Empty(month.Data.Categories)
+
+	// Verify that the envelopes list is empty, not nil
+	_ = suite.createTestCategory(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
+
+	r = test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-01", 1), "")
+	test.AssertHTTPStatus(suite.T(), &r, http.StatusOK)
+	test.DecodeResponse(suite.T(), &r, &month)
+	suite.Assert().NotNil(month.Data.Categories[0].Envelopes)
+	suite.Assert().Empty(month.Data.Categories[0].Envelopes)
+}
+
+func (suite *TestSuiteStandard) TestMonthInvalidRequest() {
+	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/months?month=-56", "")
+	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+
+	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/months?budget=noUUID", "")
+	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+
+	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
+	r = test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "0001-01", 1), "")
+	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.Assert().Equal("You cannot request data for no month", test.DecodeError(suite.T(), r.Body.Bytes()))
+
+	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/months?budget=6a463cc8-1938-474a-8aeb-0482b82ffb6f", "")
+	test.AssertHTTPStatus(suite.T(), &r, http.StatusNotFound)
+	suite.Assert().Equal("No budget found for the specified ID", test.DecodeError(suite.T(), r.Body.Bytes()))
+}
+
+func (suite *TestSuiteStandard) TestMonthDBFail() {
+	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
+
+	suite.CloseDB()
+
+	r := test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-01", 1), "")
+	test.AssertHTTPStatus(suite.T(), &r, http.StatusInternalServerError)
+}

--- a/pkg/models/budget_test.go
+++ b/pkg/models/budget_test.go
@@ -261,8 +261,18 @@ func (suite *TestSuiteStandard) TestBudgetCalculations() {
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), budgeted.Equal(decimal.NewFromFloat(67)), "Budgeted is %s, should be 67", budgeted)
 
+	// Verify budgeted for used budget
+	budgeted, err = budget.Budgeted(suite.db, marchFifteenthTwentyTwentyTwo)
+	assert.Nil(suite.T(), err)
+	assert.True(suite.T(), budgeted.Equal(decimal.NewFromFloat(25)), "Budgeted is %s, should be 25", budgeted)
+
 	// Verify total budgeted for empty budget
 	budgeted, err = emptyBudget.TotalBudgeted(suite.db, marchFifteenthTwentyTwentyTwo)
+	assert.Nil(suite.T(), err)
+	assert.True(suite.T(), budgeted.IsZero(), "Budgeted is %s, should be 0", budgeted)
+
+	// Verify budgeted for empty budget
+	budgeted, err = emptyBudget.Budgeted(suite.db, marchFifteenthTwentyTwentyTwo)
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), budgeted.IsZero(), "Budgeted is %s, should be 0", budgeted)
 
@@ -315,4 +325,94 @@ func (suite *TestSuiteStandard) TestTotalBudgetedNoTransactions() {
 	budgeted, err := budget.TotalBudgeted(suite.db, time.Date(1913, 8, 3, 0, 0, 0, 0, time.UTC))
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), budgeted.IsZero(), "Income is %s, should be 0", budgeted)
+}
+
+func (suite *TestSuiteStandard) TestBudgetAvailableDBFail() {
+	budget := models.Budget{}
+
+	err := suite.db.Save(&budget).Error
+	if err != nil {
+		suite.Assert().Fail("Resource could not be saved", err)
+	}
+
+	suite.CloseDB()
+
+	_, err = budget.Available(suite.db, time.Now())
+	suite.Assert().NotNil(err)
+	suite.Assert().Equal("sql: database is closed", err.Error())
+}
+
+func (suite *TestSuiteStandard) TestBudgetIncomeDBFail() {
+	budget := models.Budget{}
+
+	err := suite.db.Save(&budget).Error
+	if err != nil {
+		suite.Assert().Fail("Resource could not be saved", err)
+	}
+
+	suite.CloseDB()
+
+	_, err = budget.Income(suite.db, time.Now())
+	suite.Assert().NotNil(err)
+	suite.Assert().Equal("sql: database is closed", err.Error())
+}
+
+func (suite *TestSuiteStandard) TestBudgetBudgetedDBFail() {
+	budget := models.Budget{}
+
+	err := suite.db.Save(&budget).Error
+	if err != nil {
+		suite.Assert().Fail("Resource could not be saved", err)
+	}
+
+	suite.CloseDB()
+
+	_, err = budget.Budgeted(suite.db, time.Now())
+	suite.Assert().NotNil(err)
+	suite.Assert().Equal("sql: database is closed", err.Error())
+}
+
+func (suite *TestSuiteStandard) TestBudgetTotalBudgetedDBFail() {
+	budget := models.Budget{}
+
+	err := suite.db.Save(&budget).Error
+	if err != nil {
+		suite.Assert().Fail("Resource could not be saved", err)
+	}
+
+	suite.CloseDB()
+
+	_, err = budget.TotalBudgeted(suite.db, time.Now())
+	suite.Assert().NotNil(err)
+	suite.Assert().Equal("sql: database is closed", err.Error())
+}
+
+func (suite *TestSuiteStandard) TestBudgetTotalIncomeDBFail() {
+	budget := models.Budget{}
+
+	err := suite.db.Save(&budget).Error
+	if err != nil {
+		suite.Assert().Fail("Resource could not be saved", err)
+	}
+
+	suite.CloseDB()
+
+	_, err = budget.TotalIncome(suite.db, time.Now())
+	suite.Assert().NotNil(err)
+	suite.Assert().Equal("sql: database is closed", err.Error())
+}
+
+func (suite *TestSuiteStandard) TestBudgetOverspentDBFail() {
+	budget := models.Budget{}
+
+	err := suite.db.Save(&budget).Error
+	if err != nil {
+		suite.Assert().Fail("Resource could not be saved", err)
+	}
+
+	suite.CloseDB()
+
+	_, err = budget.Overspent(suite.db, time.Now())
+	suite.Assert().NotNil(err)
+	suite.Assert().Equal("sql: database is closed", err.Error())
 }

--- a/pkg/models/database_test.go
+++ b/pkg/models/database_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (suite *TestSuiteStandard) TestMigrate() {
-	suite.DisconnectDB()
+	suite.CloseDB()
 	err := models.Migrate(suite.db)
 	suite.Assert().NotNil(err)
 	suite.Assert().Contains(err.Error(), "error during DB migration")

--- a/pkg/models/envelope.go
+++ b/pkg/models/envelope.go
@@ -23,9 +23,9 @@ type EnvelopeCreate struct {
 
 // EnvelopeMonth contains data about an Envelope for a specific month.
 type EnvelopeMonth struct {
-	ID         uuid.UUID       `json:"id" example:"10b9705d-3356-459e-9d5a-28d42a6c4547"` // The ID of the Envelope
-	Name       string          `json:"name" example:"Groceries"`                          // The name of the Envelope
-	Month      time.Time       `json:"month" example:"1969-06-01T00:00:00.000000Z"`       // This is always set to 00:00 UTC on the first of the month.
+	ID         uuid.UUID       `json:"id" example:"10b9705d-3356-459e-9d5a-28d42a6c4547"`               // The ID of the Envelope
+	Name       string          `json:"name" example:"Groceries"`                                        // The name of the Envelope
+	Month      time.Time       `json:"month" example:"1969-06-01T00:00:00.000000Z" hidden:"deprecated"` // This is always set to 00:00 UTC on the first of the month. **This field is deprecated and will be removed in v2**
 	Spent      decimal.Decimal `json:"spent" example:"73.12"`
 	Balance    decimal.Decimal `json:"balance" example:"12.32"`
 	Allocation decimal.Decimal `json:"allocation" example:"85.44"`

--- a/pkg/models/month.go
+++ b/pkg/models/month.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+type CategoryEnvelopes struct {
+	ID        uuid.UUID       `json:"id" example:"dafd9a74-6aeb-46b9-9f5a-cfca624fea85"`
+	Name      string          `json:"name" example:"Rainy Day Funds" default:""`
+	Envelopes []EnvelopeMonth `json:"envelopes"`
+}
+
+type Month struct {
+	ID         uuid.UUID           `json:"id" example:"1e777d24-3f5b-4c43-8000-04f65f895578"` // The ID of the Budget
+	Name       string              `json:"name" example:"Zero budget"`                        // The name of the Budget
+	Month      time.Time           `json:"month" example:"2006-05-01T00:00:00.000000Z"`       // This is always set to 00:00 UTC on the first of the month.
+	Budgeted   decimal.Decimal     `json:"budgeted" example:"2100"`
+	Income     decimal.Decimal     `json:"income" example:"2317.34"`
+	Available  decimal.Decimal     `json:"available" example:"217.34"`
+	Categories []CategoryEnvelopes `json:"categories"`
+}

--- a/pkg/models/test_suite_test.go
+++ b/pkg/models/test_suite_test.go
@@ -48,9 +48,9 @@ func (suite *TestSuiteStandard) SetupTest() {
 	suite.db = db
 }
 
-// DisconnectDB closes the database connection. This enables testing the handling
+// CloseDB closes the database connection. This enables testing the handling
 // of database errors.
-func (suite *TestSuiteStandard) DisconnectDB() {
+func (suite *TestSuiteStandard) CloseDB() {
 	sqlDB, err := suite.db.DB()
 	if err != nil {
 		suite.Assert().FailNowf("Failed to get database resource for teardown: %v", err.Error())

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -121,6 +121,7 @@ func AttachRoutes(co controllers.Controller, group *gin.RouterGroup) {
 	co.RegisterCategoryRoutes(v1.Group("/categories"))
 	co.RegisterEnvelopeRoutes(v1.Group("/envelopes"))
 	co.RegisterAllocationRoutes(v1.Group("/allocations"))
+	co.RegisterMonthRoutes(v1.Group("/months"))
 }
 
 type RootResponse struct {


### PR DESCRIPTION
This is part of #358. 

It adds a new `/v1/months?budget={budgetId}&month={month}` endpoint that replaces the existing `/v1/budgets/{budgetId}/{month}`, which is deprecated with this PR.
