### PR TITLE
fix: missing links to months endpoint

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3003,6 +3003,10 @@ const docTemplate = `{
                     "type": "string",
                     "example": "https://example.com/api/v1/envelopes"
                 },
+                "months": {
+                    "type": "string",
+                    "example": "https://example.com/api/v1/months"
+                },
                 "transactions": {
                     "type": "string",
                     "example": "https://example.com/api/v1/transactions"

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2991,6 +2991,10 @@
                     "type": "string",
                     "example": "https://example.com/api/v1/envelopes"
                 },
+                "months": {
+                    "type": "string",
+                    "example": "https://example.com/api/v1/months"
+                },
                 "transactions": {
                     "type": "string",
                     "example": "https://example.com/api/v1/transactions"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -623,6 +623,9 @@ definitions:
       envelopes:
         example: https://example.com/api/v1/envelopes
         type: string
+      months:
+        example: https://example.com/api/v1/months
+        type: string
       transactions:
         example: https://example.com/api/v1/transactions
         type: string

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -198,6 +198,7 @@ type V1Links struct {
 	Transactions string `json:"transactions" example:"https://example.com/api/v1/transactions"`
 	Envelopes    string `json:"envelopes" example:"https://example.com/api/v1/envelopes"`
 	Allocations  string `json:"allocations" example:"https://example.com/api/v1/allocations"`
+	Months       string `json:"months" example:"https://example.com/api/v1/months"`
 }
 
 // @Summary     v1 API
@@ -214,6 +215,7 @@ func GetV1(c *gin.Context) {
 			Transactions: c.GetString("baseURL") + "/v1/transactions",
 			Envelopes:    c.GetString("baseURL") + "/v1/envelopes",
 			Allocations:  c.GetString("baseURL") + "/v1/allocations",
+			Months:       c.GetString("baseURL") + "/v1/months",
 		},
 	})
 }

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -108,6 +108,7 @@ func TestGetV1(t *testing.T) {
 			Categories:   "/v1/categories",
 			Envelopes:    "/v1/envelopes",
 			Allocations:  "/v1/allocations",
+			Months:       "/v1/months",
 		},
 	}
 


### PR DESCRIPTION
Adds the missing link to the `months` endpoint.
