### PR TITLE
feat: add envelope balance sum to month response

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2879,14 +2879,22 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "available": {
+                    "description": "The amount available to budget",
                     "type": "number",
                     "example": 217.34
                 },
+                "balance": {
+                    "description": "The sum of all envelope balances",
+                    "type": "number",
+                    "example": 5231.37
+                },
                 "budgeted": {
+                    "description": "The sum of all allocations for the month",
                     "type": "number",
                     "example": 2100
                 },
                 "categories": {
+                    "description": "A list of envelope month calculations grouped by category",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/models.CategoryEnvelopes"
@@ -2898,6 +2906,7 @@ const docTemplate = `{
                     "example": "1e777d24-3f5b-4c43-8000-04f65f895578"
                 },
                 "income": {
+                    "description": "The total income for the month (sum of all incoming transactions without an Envelope)",
                     "type": "number",
                     "example": 2317.34
                 },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2867,14 +2867,22 @@
             "type": "object",
             "properties": {
                 "available": {
+                    "description": "The amount available to budget",
                     "type": "number",
                     "example": 217.34
                 },
+                "balance": {
+                    "description": "The sum of all envelope balances",
+                    "type": "number",
+                    "example": 5231.37
+                },
                 "budgeted": {
+                    "description": "The sum of all allocations for the month",
                     "type": "number",
                     "example": 2100
                 },
                 "categories": {
+                    "description": "A list of envelope month calculations grouped by category",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/models.CategoryEnvelopes"
@@ -2886,6 +2894,7 @@
                     "example": "1e777d24-3f5b-4c43-8000-04f65f895578"
                 },
                 "income": {
+                    "description": "The total income for the month (sum of all incoming transactions without an Envelope)",
                     "type": "number",
                     "example": 2317.34
                 },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -531,12 +531,19 @@ definitions:
   models.Month:
     properties:
       available:
+        description: The amount available to budget
         example: 217.34
         type: number
+      balance:
+        description: The sum of all envelope balances
+        example: 5231.37
+        type: number
       budgeted:
+        description: The sum of all allocations for the month
         example: 2100
         type: number
       categories:
+        description: A list of envelope month calculations grouped by category
         items:
           $ref: '#/definitions/models.CategoryEnvelopes'
         type: array
@@ -545,6 +552,8 @@ definitions:
         example: 1e777d24-3f5b-4c43-8000-04f65f895578
         type: string
       income:
+        description: The total income for the month (sum of all incoming transactions
+          without an Envelope)
         example: 2317.34
         type: number
       month:

--- a/pkg/controllers/month.go
+++ b/pkg/controllers/month.go
@@ -9,6 +9,7 @@ import (
 	"github.com/envelope-zero/backend/pkg/models"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 )
 
 type MonthResponse struct {
@@ -112,6 +113,7 @@ func (co Controller) GetMonth(c *gin.Context) {
 	}
 
 	month.Categories = make([]models.CategoryEnvelopes, 0)
+	month.Balance = decimal.Zero
 
 	// Get envelopes for all categories
 	for _, category := range categories {
@@ -134,6 +136,7 @@ func (co Controller) GetMonth(c *gin.Context) {
 
 		for _, envelope := range envelopes {
 			envelopeMonth, err := envelope.Month(co.DB, month.Month)
+			month.Balance = month.Balance.Add(envelopeMonth.Balance)
 			if err != nil {
 				httperrors.Handler(c, err)
 				return

--- a/pkg/controllers/month_test.go
+++ b/pkg/controllers/month_test.go
@@ -94,9 +94,9 @@ func (suite *TestSuiteStandard) TestMonth() {
 			strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-01", -1),
 			controllers.MonthResponse{
 				Data: models.Month{
-					Month:  time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
-					Income: decimal.NewFromFloat(0),
-
+					Month:   time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+					Income:  decimal.NewFromFloat(0),
+					Balance: decimal.NewFromFloat(10.99),
 					Categories: []models.CategoryEnvelopes{
 						{
 							Name: category.Data.Name,
@@ -119,8 +119,9 @@ func (suite *TestSuiteStandard) TestMonth() {
 			strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-02", -1),
 			controllers.MonthResponse{
 				Data: models.Month{
-					Month:  time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC),
-					Income: decimal.NewFromFloat(0),
+					Month:   time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC),
+					Income:  decimal.NewFromFloat(0),
+					Balance: decimal.NewFromFloat(53.11),
 					Categories: []models.CategoryEnvelopes{
 						{
 							Name: category.Data.Name,
@@ -143,8 +144,9 @@ func (suite *TestSuiteStandard) TestMonth() {
 			strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-03", -1),
 			controllers.MonthResponse{
 				Data: models.Month{
-					Month:  time.Date(2022, 3, 1, 0, 0, 0, 0, time.UTC),
-					Income: decimal.NewFromFloat(1500),
+					Month:   time.Date(2022, 3, 1, 0, 0, 0, 0, time.UTC),
+					Income:  decimal.NewFromFloat(1500),
+					Balance: decimal.NewFromFloat(69.28),
 					Categories: []models.CategoryEnvelopes{
 						{
 							Name: category.Data.Name,
@@ -173,6 +175,9 @@ func (suite *TestSuiteStandard) TestMonth() {
 
 		// Verify income calculation
 		suite.Assert().True(month.Data.Income.Equal(tt.response.Data.Income))
+
+		// Verify month balance calculation
+		suite.Assert().True(month.Data.Balance.Equal(tt.response.Data.Balance), "Month balance calculation for %v is wrong: should be %v, but is %v: %#v", month.Data.Month, tt.response.Data.Balance, month.Data.Balance, month.Data)
 
 		if !suite.Assert().Len(month.Data.Categories, 1) {
 			suite.Assert().FailNow("Response category length does not match!", "Category list does not have exactly 1 item, it has %d, Request ID: %s", len(month.Data.Categories), r.Header().Get("x-request-id"))

--- a/pkg/models/month.go
+++ b/pkg/models/month.go
@@ -17,8 +17,9 @@ type Month struct {
 	ID         uuid.UUID           `json:"id" example:"1e777d24-3f5b-4c43-8000-04f65f895578"` // The ID of the Budget
 	Name       string              `json:"name" example:"Zero budget"`                        // The name of the Budget
 	Month      time.Time           `json:"month" example:"2006-05-01T00:00:00.000000Z"`       // This is always set to 00:00 UTC on the first of the month.
-	Budgeted   decimal.Decimal     `json:"budgeted" example:"2100"`
-	Income     decimal.Decimal     `json:"income" example:"2317.34"`
-	Available  decimal.Decimal     `json:"available" example:"217.34"`
-	Categories []CategoryEnvelopes `json:"categories"`
+	Budgeted   decimal.Decimal     `json:"budgeted" example:"2100"`                           // The sum of all allocations for the month
+	Income     decimal.Decimal     `json:"income" example:"2317.34"`                          // The total income for the month (sum of all incoming transactions without an Envelope)
+	Available  decimal.Decimal     `json:"available" example:"217.34"`                        // The amount available to budget
+	Balance    decimal.Decimal     `json:"balance" example:"5231.37"`                         // The sum of all envelope balances
+	Categories []CategoryEnvelopes `json:"categories"`                                        // A list of envelope month calculations grouped by category
 }


### PR DESCRIPTION
Adds a `balance` field with the sum of all envelopes.
