### PR TITLE
feat: add allocation link to month responses

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2859,6 +2859,9 @@ const docTemplate = `{
                     "type": "string",
                     "example": "10b9705d-3356-459e-9d5a-28d42a6c4547"
                 },
+                "links": {
+                    "$ref": "#/definitions/models.EnvelopeMonthLinks"
+                },
                 "month": {
                     "description": "This is always set to 00:00 UTC on the first of the month. **This field is deprecated and will be removed in v2**",
                     "type": "string",
@@ -2872,6 +2875,16 @@ const docTemplate = `{
                 "spent": {
                     "type": "number",
                     "example": 73.12
+                }
+            }
+        },
+        "models.EnvelopeMonthLinks": {
+            "type": "object",
+            "properties": {
+                "allocation": {
+                    "description": "This is an empty string when no allocation exists",
+                    "type": "string",
+                    "example": "https://example.com/api/v1/allocations/772d6956-ecba-485b-8a27-46a506c5a2a3"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2847,6 +2847,9 @@
                     "type": "string",
                     "example": "10b9705d-3356-459e-9d5a-28d42a6c4547"
                 },
+                "links": {
+                    "$ref": "#/definitions/models.EnvelopeMonthLinks"
+                },
                 "month": {
                     "description": "This is always set to 00:00 UTC on the first of the month. **This field is deprecated and will be removed in v2**",
                     "type": "string",
@@ -2860,6 +2863,16 @@
                 "spent": {
                     "type": "number",
                     "example": 73.12
+                }
+            }
+        },
+        "models.EnvelopeMonthLinks": {
+            "type": "object",
+            "properties": {
+                "allocation": {
+                    "description": "This is an empty string when no allocation exists",
+                    "type": "string",
+                    "example": "https://example.com/api/v1/allocations/772d6956-ecba-485b-8a27-46a506c5a2a3"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -515,6 +515,8 @@ definitions:
         description: The ID of the Envelope
         example: 10b9705d-3356-459e-9d5a-28d42a6c4547
         type: string
+      links:
+        $ref: '#/definitions/models.EnvelopeMonthLinks'
       month:
         description: This is always set to 00:00 UTC on the first of the month. **This
           field is deprecated and will be removed in v2**
@@ -527,6 +529,13 @@ definitions:
       spent:
         example: 73.12
         type: number
+    type: object
+  models.EnvelopeMonthLinks:
+    properties:
+      allocation:
+        description: This is an empty string when no allocation exists
+        example: https://example.com/api/v1/allocations/772d6956-ecba-485b-8a27-46a506c5a2a3
+        type: string
     type: object
   models.Month:
     properties:

--- a/pkg/controllers/budget.go
+++ b/pkg/controllers/budget.go
@@ -335,7 +335,7 @@ func (co Controller) GetBudgetMonth(c *gin.Context) {
 
 	var envelopeMonths []models.EnvelopeMonth
 	for _, envelope := range envelopes {
-		envelopeMonth, err := envelope.Month(co.DB, month.Month)
+		envelopeMonth, _, err := envelope.Month(co.DB, month.Month)
 		if err != nil {
 			httperrors.Handler(c, err)
 			return

--- a/pkg/controllers/envelope.go
+++ b/pkg/controllers/envelope.go
@@ -242,7 +242,7 @@ func (co Controller) GetEnvelopeMonth(c *gin.Context) {
 		return
 	}
 
-	envelopeMonth, err := envelope.Month(co.DB, month.Month)
+	envelopeMonth, _, err := envelope.Month(co.DB, month.Month)
 	if err != nil {
 		httperrors.Handler(c, err)
 		return

--- a/pkg/controllers/month.go
+++ b/pkg/controllers/month.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -135,11 +136,17 @@ func (co Controller) GetMonth(c *gin.Context) {
 		}
 
 		for _, envelope := range envelopes {
-			envelopeMonth, err := envelope.Month(co.DB, month.Month)
-			month.Balance = month.Balance.Add(envelopeMonth.Balance)
+			envelopeMonth, allocationID, err := envelope.Month(co.DB, month.Month)
 			if err != nil {
 				httperrors.Handler(c, err)
 				return
+			}
+
+			// Update the month's balance
+			month.Balance = month.Balance.Add(envelopeMonth.Balance)
+			// Set the allocation link if it is not empty.
+			if allocationID != uuid.Nil {
+				envelopeMonth.Links.Allocation = fmt.Sprintf("%s/v1/allocations/%s", c.GetString("baseURL"), allocationID)
 			}
 
 			categoryEnvelopes.Envelopes = append(categoryEnvelopes.Envelopes, envelopeMonth)

--- a/pkg/controllers/month_test.go
+++ b/pkg/controllers/month_test.go
@@ -1,6 +1,7 @@
 package controllers_test
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -25,19 +26,19 @@ func (suite *TestSuiteStandard) TestMonth() {
 	account := suite.createTestAccount(suite.T(), models.AccountCreate{BudgetID: budget.Data.ID})
 	externalAccount := suite.createTestAccount(suite.T(), models.AccountCreate{BudgetID: budget.Data.ID, External: true})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	allocationJanuary := suite.createTestAllocation(suite.T(), models.AllocationCreate{
 		EnvelopeID: envelope.Data.ID,
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(20.99),
 	})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	allocationFebruary := suite.createTestAllocation(suite.T(), models.AllocationCreate{
 		EnvelopeID: envelope.Data.ID,
 		Month:      time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(47.12),
 	})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	allocationMarch := suite.createTestAllocation(suite.T(), models.AllocationCreate{
 		EnvelopeID: envelope.Data.ID,
 		Month:      time.Date(2022, 3, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(31.17),
@@ -108,6 +109,9 @@ func (suite *TestSuiteStandard) TestMonth() {
 									Spent:      decimal.NewFromFloat(10),
 									Balance:    decimal.NewFromFloat(10.99),
 									Allocation: decimal.NewFromFloat(20.99),
+									Links: models.EnvelopeMonthLinks{
+										Allocation: fmt.Sprintf("http://example.com/v1/allocations/%s", allocationJanuary.Data.ID),
+									},
 								},
 							},
 						},
@@ -133,6 +137,9 @@ func (suite *TestSuiteStandard) TestMonth() {
 									Balance:    decimal.NewFromFloat(53.11),
 									Spent:      decimal.NewFromFloat(5),
 									Allocation: decimal.NewFromFloat(47.12),
+									Links: models.EnvelopeMonthLinks{
+										Allocation: fmt.Sprintf("http://example.com/v1/allocations/%s", allocationFebruary.Data.ID),
+									},
 								},
 							},
 						},
@@ -158,6 +165,9 @@ func (suite *TestSuiteStandard) TestMonth() {
 									Balance:    decimal.NewFromFloat(69.28),
 									Spent:      decimal.NewFromFloat(15),
 									Allocation: decimal.NewFromFloat(31.17),
+									Links: models.EnvelopeMonthLinks{
+										Allocation: fmt.Sprintf("http://example.com/v1/allocations/%s", allocationMarch.Data.ID),
+									},
 								},
 							},
 						},
@@ -192,6 +202,8 @@ func (suite *TestSuiteStandard) TestMonth() {
 		suite.Assert().True(envelope.Spent.Equal(expected.Spent), "Monthly spent calculation for %v is wrong: should be %v, but is %v: %#v", month.Data.Month, expected.Spent, envelope.Spent, month.Data)
 		suite.Assert().True(envelope.Balance.Equal(expected.Balance), "Monthly balance calculation for %v is wrong: should be %v, but is %v: %#v", month.Data.Month, expected.Balance, envelope.Balance, month.Data)
 		suite.Assert().True(envelope.Allocation.Equal(expected.Allocation), "Monthly allocation fetch for %v is wrong: should be %v, but is %v: %#v", month.Data.Month, expected.Allocation, envelope.Allocation, month.Data)
+
+		suite.Assert().Equal(expected.Links.Allocation, envelope.Links.Allocation)
 	}
 }
 

--- a/pkg/models/envelope_test.go
+++ b/pkg/models/envelope_test.go
@@ -92,11 +92,11 @@ func (suite *TestSuiteStandard) TestEnvelopeMonthSum() {
 		suite.Assert().Fail("Resource could not be saved", err)
 	}
 
-	envelopeMonth, err := envelope.Month(suite.db, january)
+	envelopeMonth, _, err := envelope.Month(suite.db, january)
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), envelopeMonth.Spent.Equal(spent), "Month calculation for 2022-01 is wrong: should be %v, but is %v", spent, envelopeMonth.Spent)
 
-	envelopeMonth, err = envelope.Month(suite.db, january.AddDate(0, 1, 0))
+	envelopeMonth, _, err = envelope.Month(suite.db, january.AddDate(0, 1, 0))
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), envelopeMonth.Spent.Equal(spent), "Month calculation for 2022-02 is wrong: should be %v, but is %v", spent, envelopeMonth.Spent)
 
@@ -105,7 +105,7 @@ func (suite *TestSuiteStandard) TestEnvelopeMonthSum() {
 		suite.Assert().Fail("Resource could not be deleted", err)
 	}
 
-	envelopeMonth, err = envelope.Month(suite.db, january)
+	envelopeMonth, _, err = envelope.Month(suite.db, january)
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), envelopeMonth.Spent.Equal(decimal.NewFromFloat(0)), "Month calculation for 2022-01 is wrong: should be %v, but is %v", decimal.NewFromFloat(0), envelopeMonth.Spent)
 }
@@ -284,23 +284,23 @@ func (suite *TestSuiteStandard) TestEnvelopeMonthBalance() {
 	}
 
 	shouldBalance := decimal.NewFromFloat(35)
-	envelopeMonth, err := envelope.Month(suite.db, january)
+	envelopeMonth, _, err := envelope.Month(suite.db, january)
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), envelopeMonth.Balance.Equal(shouldBalance), "Balance calculation for 2022-01 is wrong: should be %v, but is %v", shouldBalance, envelopeMonth.Balance)
 
 	shouldBalance = decimal.NewFromFloat(45)
-	envelopeMonth, err = envelope.Month(suite.db, january.AddDate(0, 1, 0))
+	envelopeMonth, _, err = envelope.Month(suite.db, january.AddDate(0, 1, 0))
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), envelopeMonth.Balance.Equal(shouldBalance), "Balance calculation for 2022-02 is wrong: should be %v, but is %v", shouldBalance, envelopeMonth.Balance)
 
 	// Verify balance for December (regression test for using AddDate(0, 1, 0) with the month instead of the whole date)
 	shouldBalance = decimal.NewFromFloat(45)
-	envelopeMonth, err = envelope.Month(suite.db, time.Date(january.Year(), 12, 1, 0, 0, 0, 0, time.UTC))
+	envelopeMonth, _, err = envelope.Month(suite.db, time.Date(january.Year(), 12, 1, 0, 0, 0, 0, time.UTC))
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), envelopeMonth.Balance.Equal(shouldBalance), "Balance calculation for 2022-02 is wrong: should be %v, but is %v", shouldBalance, envelopeMonth.Balance)
 
 	shouldBalance = decimal.NewFromFloat(0)
-	envelopeMonth, err = envelope2.Month(suite.db, january.AddDate(0, 1, 0))
+	envelopeMonth, _, err = envelope2.Month(suite.db, january.AddDate(0, 1, 0))
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), envelopeMonth.Balance.Equal(shouldBalance), "Balance calculation for 2022-02 is wrong: should be %v, but is %v", shouldBalance, envelopeMonth.Balance)
 }


### PR DESCRIPTION
This allows clients to easily modify the existing allocation if one exists or determine that they need to create a new one.
