### PR TITLE
fix: allocation link for envelope month calculation

### DIFF
--- a/pkg/controllers/month.go
+++ b/pkg/controllers/month.go
@@ -144,9 +144,13 @@ func (co Controller) GetMonth(c *gin.Context) {
 
 			// Update the month's balance
 			month.Balance = month.Balance.Add(envelopeMonth.Balance)
-			// Set the allocation link if it is not empty.
+
+			// Set the allocation link. If there is no allocation, we send the collection endpoint.
+			// With this, any client will be able to see that the "Budgeted" amount is 0 and therefore
+			// send a HTTP POST for creation instead of a patch.
+			envelopeMonth.Links.Allocation = fmt.Sprintf("%s/v1/allocations", c.GetString("baseURL"))
 			if allocationID != uuid.Nil {
-				envelopeMonth.Links.Allocation = fmt.Sprintf("%s/v1/allocations/%s", c.GetString("baseURL"), allocationID)
+				envelopeMonth.Links.Allocation = fmt.Sprintf("%s/%s", envelopeMonth.Links.Allocation, allocationID)
 			}
 
 			categoryEnvelopes.Envelopes = append(categoryEnvelopes.Envelopes, envelopeMonth)


### PR DESCRIPTION
With this commit, the allocation link for a month without an allocation
points to the collection endpoint. This enables clients to send a POST
request to that endpoint, creating a new allocation, whenever the
budgeted amount for that month is 0.

Before, clients needed to have the URL hardcoded or request it from
the API root, which is not good API design.
