### PR TITLE
feat: add import for YNAB 4 budgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ coverage.out
 /backend
 dist/
 __debug_bin
+.DS_Store
 
 # Created in the workflows but need to be ignored
 node_modules/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,11 @@ issues:
         - gocyclo
         - errcheck
         - dupl
+      # Parsing logic has high cyclomatic complexity. This is okay.
+    - path: pkg/importer/parser/ynab4/parse.go
+      linters:
+        - gocyclo
+      text: "func `parseTransactions`"
 
 linters:
   enable:

--- a/api/docs.go
+++ b/api/docs.go
@@ -1764,6 +1764,71 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/import": {
+            "post": {
+                "description": "Imports data from other sources. Resources with the same name are ignored. Accepts CSV files in the following formats: YNAB Import (use [YNAP](https://ynap.leolabs.org/) to convert your bank statement), YNAB 4 Register export, and YNAB 4 Budget export.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Import"
+                ],
+                "summary": "Import",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "File to import",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Name of the Budget to create for a YNAB 4 import. Ignored for all other imports",
+                        "name": "budgetName",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "tags": [
+                    "Import"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/months": {
             "get": {
                 "description": "Returns data about a specific month.",
@@ -3064,6 +3129,10 @@ const docTemplate = `{
                 "envelopes": {
                     "type": "string",
                     "example": "https://example.com/api/v1/envelopes"
+                },
+                "import": {
+                    "type": "string",
+                    "example": "https://example.com/api/v1/import"
                 },
                 "months": {
                     "type": "string",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1752,6 +1752,71 @@
                 }
             }
         },
+        "/v1/import": {
+            "post": {
+                "description": "Imports data from other sources. Resources with the same name are ignored. Accepts CSV files in the following formats: YNAB Import (use [YNAP](https://ynap.leolabs.org/) to convert your bank statement), YNAB 4 Register export, and YNAB 4 Budget export.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Import"
+                ],
+                "summary": "Import",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "File to import",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Name of the Budget to create for a YNAB 4 import. Ignored for all other imports",
+                        "name": "budgetName",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "tags": [
+                    "Import"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/months": {
             "get": {
                 "description": "Returns data about a specific month.",
@@ -3052,6 +3117,10 @@
                 "envelopes": {
                     "type": "string",
                     "example": "https://example.com/api/v1/envelopes"
+                },
+                "import": {
+                    "type": "string",
+                    "example": "https://example.com/api/v1/import"
                 },
                 "months": {
                     "type": "string",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -673,6 +673,9 @@ definitions:
       envelopes:
         example: https://example.com/api/v1/envelopes
         type: string
+      import:
+        example: https://example.com/api/v1/import
+        type: string
       months:
         example: https://example.com/api/v1/months
         type: string
@@ -1881,6 +1884,54 @@ paths:
       summary: Get Envelope month data
       tags:
       - Envelopes
+  /v1/import:
+    options:
+      description: Returns an empty response with the HTTP Header "allow" set to the
+        allowed HTTP verbs
+      responses:
+        "204":
+          description: No Content
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Allowed HTTP verbs
+      tags:
+      - Import
+    post:
+      consumes:
+      - multipart/form-data
+      description: 'Imports data from other sources. Resources with the same name
+        are ignored. Accepts CSV files in the following formats: YNAB Import (use
+        [YNAP](https://ynap.leolabs.org/) to convert your bank statement), YNAB 4
+        Register export, and YNAB 4 Budget export.'
+      parameters:
+      - description: File to import
+        in: formData
+        name: file
+        required: true
+        type: file
+      - description: Name of the Budget to create for a YNAB 4 import. Ignored for
+          all other imports
+        in: query
+        name: budgetName
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Import
+      tags:
+      - Import
   /v1/months:
     get:
       description: Returns data about a specific month.

--- a/docs/import.md
+++ b/docs/import.md
@@ -1,0 +1,37 @@
+# Import
+
+You can import data from various sources.
+
+## YNAB 4
+
+You can import a YNAB 4 budget directly into Envelope Zero. Please read this whole section carefully before you do so.
+
+### Notable differences
+
+The following is **not yet supported** in Envelope Zero and will therefore be ignored:
+
+- Recurring transactions. They will be implemented with [milestone #5](https://github.com/envelope-zero/backend/milestone/5) and import supported with https://github.com/envelope-zero/backend/issues/379.
+- Payee rename rules are not yet supported in Envelope Zero (https://github.com/envelope-zero/backend/issues/373)
+- Different handling of overspend. In Envelope Zero, overspend is always carried over to the next months budget for the category (https://github.com/envelope-zero/backend/issues/327)
+
+The following **work differently** on Envelope Zero:
+
+- Date formatting. While YNAB 4 does date formatting per Budget, in Envelope Zero, the formatting is decided by the browser (https://github.com/envelope-zero/frontend/issues/145) or by the users configuration (https://github.com/envelope-zero/backend/issues/33)
+- Transactions always need to have a source and destination. Transactions that do not have a Payee set in YNAB 4 will be imported with the opposing account as „YNAB 4 Import - No Payee“. If an account or Payee named „YNAB 4 Import - No Payee“ already exists in your budget, it will be used for those transactions.
+- Transactions can not have an amount of 0 - if no money was moved, no transaction is needed. Any transaction with an amount of 0 will be ignored during the import.
+
+### How to import
+
+YNAB 4 saves all data in a file that can be imported directly to Envelope Zero. The file has the name `Budget.yfull`, you can find it by doing the following:
+
+1. Go to the directory where your YNAB 4 budget file is saved. This file is actually a directory, but it claims to be a file. You can enter this directory with
+1. On MacOS: Right click -> Show package content
+1. On Windows: ?
+1. Open the `Budget.ymeta` file with any text editor. This file tells us which directory to look into next. Check the `relativeDataFolderName` string. Open this directory
+1. In the directory, you will find another directory with a UUID as name, for example `F90E864E-8D96-4E0E-A723-776CEEB1C2F0`. Open this directory, too.
+1. In there, you will find a Budget.yfull file. This is the one you need, copy it to e.g. your Desktop.
+1. Navigate to http://example.com/api/docs/index.html#/Import/post_v1_import. Replace `example.com` with the URL of your Envelope Zero instance.
+1. Click the "Try it out" button on the top right
+1. Select your file and a Budget Name (it must be a name that does not exist yet), then click "Execute".
+1. Check the "Server response" section that appeared below. It should have a "Code" of 204. If it does not, check the box at the right for the error message.
+1. All done!

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/swaggo/gin-swagger v1.5.3
 	github.com/swaggo/swag v1.8.6
 	github.com/wei840222/gorm-zerolog v0.0.0-20210303025759-235c42bb33fa
+	golang.org/x/text v0.3.7
 	gorm.io/gorm v1.23.10
 )
 
@@ -32,7 +33,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-playground/validator/v10 v10.11.0 // indirect
 	github.com/goccy/go-json v0.9.8 // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -48,10 +48,10 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
-	golang.org/x/net v0.0.0-20220706163947-c90051bbdb60 // indirect
+	golang.org/x/exp v0.0.0-20220927162542-c76eaa363f9d
+	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
-	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/tools v0.1.11 // indirect
+	golang.org/x/tools v0.1.12 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,7 +59,6 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
-github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -164,6 +163,8 @@ golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/exp v0.0.0-20220927162542-c76eaa363f9d h1:3wgmvnqHUJ8SxiNWwea5NCzTwAVfhTtuV+0ClVFlClc=
+golang.org/x/exp v0.0.0-20220927162542-c76eaa363f9d/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
@@ -176,8 +177,8 @@ golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220706163947-c90051bbdb60 h1:8NSylCMxLW4JvserAndSgFL7aPli6A68yf0bYFTcWCM=
-golang.org/x/net v0.0.0-20220706163947-c90051bbdb60/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgkU2rGHdKlKowJSMN9h0=
+golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -210,8 +211,8 @@ golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20201124115921-2c860bdd6e78/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
-golang.org/x/tools v0.1.11 h1:loJ25fNOEhSXfHrpoGj91eCUThwdNX6u24rO1xnNteY=
-golang.org/x/tools v0.1.11/go.mod h1:SgwaegtQh8clINPpECJMqnxLv9I09HLqnW3RMqW0CA4=
+golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
+golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/controllers/budget_test.go
+++ b/pkg/controllers/budget_test.go
@@ -61,7 +61,7 @@ func (suite *TestSuiteStandard) TestOptionsBudgetMonth() {
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodOptions, strings.Replace(budgetLink, "YYYY-MM", "1970-01", 1), "")
 	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
-	assert.Equal(suite.T(), recorder.Header().Get("allow"), "GET")
+	assert.Equal(suite.T(), recorder.Header().Get("allow"), "OPTIONS, GET")
 
 	// Bad Request for invalid UUID
 	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/budgets/nouuid/2022-01", "")
@@ -81,7 +81,7 @@ func (suite *TestSuiteStandard) TestOptionsBudgetMonthAllocations() {
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodOptions, strings.Replace(budgetAllocationsLink, "YYYY-MM", "1970-01", 1), "")
 	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
-	assert.Equal(suite.T(), recorder.Header().Get("allow"), "DELETE")
+	assert.Equal(suite.T(), recorder.Header().Get("allow"), "OPTIONS, DELETE")
 
 	// Bad Request for invalid UUID
 	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/budgets/nouuid/2022-01/allocations", "")

--- a/pkg/controllers/import.go
+++ b/pkg/controllers/import.go
@@ -1,0 +1,112 @@
+package controllers
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/envelope-zero/backend/pkg/httperrors"
+	"github.com/envelope-zero/backend/pkg/httputil"
+	"github.com/envelope-zero/backend/pkg/importer"
+	"github.com/envelope-zero/backend/pkg/importer/parser/ynab4"
+	"github.com/envelope-zero/backend/pkg/models"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+type ImportQuery struct {
+	BudgetName string `form:"budgetName" binding:"required"`
+}
+
+// RegisterImportRoutes registers the routes for imports.
+func (co Controller) RegisterImportRoutes(r *gin.RouterGroup) {
+	// Root group
+	{
+		r.OPTIONS("", co.OptionsImport)
+		r.POST("", co.Import)
+	}
+}
+
+// @Summary     Allowed HTTP verbs
+// @Description Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
+// @Tags        Import
+// @Success     204
+// @Failure     500 {object} httperrors.HTTPError
+// @Router      /v1/import [options]
+func (co Controller) OptionsImport(c *gin.Context) {
+	httputil.OptionsPost(c)
+}
+
+// @Summary     Import
+// @Description Imports data from other sources. Resources with the same name are ignored. Accepts CSV files in the following formats: YNAB Import (use [YNAP](https://ynap.leolabs.org/) to convert your bank statement), YNAB 4 Register export, and YNAB 4 Budget export.
+// @Tags        Import
+// @Accept      multipart/form-data
+// @Produce     json
+// @Success     204
+// @Failure     400        {object} httperrors.HTTPError
+// @Failure     500        {object} httperrors.HTTPError
+// @Param       file       formData file   true  "File to import"
+// @Param       budgetName query    string false "Name of the Budget to create for a YNAB 4 import. Ignored for all other imports"
+// @Router      /v1/import [post]
+func (co Controller) Import(c *gin.Context) {
+	var query ImportQuery
+	if err := c.BindQuery(&query); err != nil {
+		httperrors.New(c, http.StatusBadRequest, "The budgetName parameter must be set")
+		return
+	}
+
+	// Verify if the budget does already exist. If yes, return an error
+	// as we only allow imports to new budgets
+	var budget models.Budget
+	err := co.DB.Where(&models.Budget{
+		BudgetCreate: models.BudgetCreate{
+			Name: query.BudgetName,
+		},
+	}).First(&budget).Error
+
+	if err == nil {
+		httperrors.New(c, http.StatusBadRequest, "This budget name is already in use. Imports from YNAB 4 create a new budget, therefore the name needs to be unique.")
+		return
+	} else if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		httperrors.Handler(c, err)
+		return
+	}
+
+	formFile, err := c.FormFile("file")
+	if formFile == nil {
+		httperrors.New(c, http.StatusBadRequest, "You must send a file to this endpoint")
+		return
+	} else if err != nil && err.Error() == "unexpected EOF" {
+		httperrors.New(c, http.StatusBadRequest, "The file you uploaded is empty. Did the file get deleted before you uploaded it?")
+		return
+	} else if err != nil {
+		httperrors.Handler(c, err)
+		return
+	}
+
+	if !strings.HasSuffix(formFile.Filename, ".yfull") {
+		httperrors.New(c, http.StatusBadRequest, "Import currently only supports YNAB 4 budgets. If you tried to upload a YNAB 4 budget, make sure its file name ends with .yfull")
+		return
+	}
+
+	f, err := formFile.Open()
+	if err != nil {
+		httperrors.Handler(c, err)
+		return
+	}
+
+	// Parse the Budget.yfull
+	resources, err := ynab4.Parse(f)
+	if err != nil {
+		httperrors.New(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	err = importer.Create(co.DB, query.BudgetName, resources)
+	if err != nil {
+		httperrors.Handler(c, err)
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+}

--- a/pkg/controllers/import_test.go
+++ b/pkg/controllers/import_test.go
@@ -1,0 +1,87 @@
+package controllers_test
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path"
+
+	"github.com/envelope-zero/backend/pkg/models"
+	"github.com/envelope-zero/backend/test"
+)
+
+func (suite *TestSuiteStandard) loadTestFile(filePath string) (*bytes.Buffer, map[string]string) {
+	path := path.Join("../../testdata", filePath)
+	body := new(bytes.Buffer)
+
+	mw := multipart.NewWriter(body)
+
+	file, err := os.Open(path)
+	if err != nil {
+		suite.Assert().Fail(err.Error())
+	}
+
+	w, err := mw.CreateFormFile("file", filePath)
+	if err != nil {
+		suite.Assert().Fail(err.Error())
+	}
+
+	if _, err := io.Copy(w, file); err != nil {
+		suite.Assert().Fail(err.Error())
+	}
+
+	mw.Close()
+
+	return body, map[string]string{"Content-Type": mw.FormDataContentType()}
+}
+
+func (suite *TestSuiteStandard) TestOptionsImport() {
+	recorder := test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/import", "")
+	suite.Assert().Equal(http.StatusNoContent, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
+	suite.Assert().Equal(recorder.Header().Get("allow"), "OPTIONS, POST")
+}
+
+func (suite *TestSuiteStandard) TestImportFails() {
+	// Budget name not set
+	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/import", "")
+	suite.Assert().Equal(http.StatusBadRequest, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
+	suite.Assert().Contains(test.DecodeError(suite.T(), recorder.Body.Bytes()), "The budgetName parameter must be set")
+
+	// No file sent
+	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/import?budgetName=same", "")
+	suite.Assert().Equal(http.StatusBadRequest, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
+	suite.Assert().Contains(test.DecodeError(suite.T(), recorder.Body.Bytes()), "You must send a file to this endpoint")
+
+	// Wrong file name
+	body, headers := suite.loadTestFile("wrong-name.json")
+	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/import?budgetName=same", body, headers)
+	suite.Assert().Equal(http.StatusBadRequest, recorder.Code, "Request ID %s, response %s", recorder.Header().Get("x-request-id"), recorder.Body.String())
+	suite.Assert().Contains(test.DecodeError(suite.T(), recorder.Body.Bytes()), "If you tried to upload a YNAB 4 budget, make sure its file name ends with .yfull")
+
+	// Empty file
+	body, headers = suite.loadTestFile("EmptyFile.yfull")
+	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/import?budgetName=same", body, headers)
+	suite.Assert().Equal(http.StatusBadRequest, recorder.Code, "Request ID %s, response %s", recorder.Header().Get("x-request-id"), recorder.Body.String())
+	suite.Assert().Contains(test.DecodeError(suite.T(), recorder.Body.Bytes()), "not a valid YNAB4 Budget.yfull file: unexpected end of JSON input")
+
+	// Budget with name already exists
+	_ = suite.createTestBudget(suite.T(), models.BudgetCreate{Name: "Import Test"})
+	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/import?budgetName=Import Test", "")
+	suite.Assert().Equal(http.StatusBadRequest, recorder.Code, "Request ID %s, response %s", recorder.Header().Get("x-request-id"), recorder.Body.String())
+	suite.Assert().Contains(test.DecodeError(suite.T(), recorder.Body.Bytes()), "This budget name is already in use")
+
+	// Database error. This test must be the last one.
+	suite.CloseDB()
+	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/import?budgetName=Import Test", "")
+	suite.Assert().Equal(http.StatusInternalServerError, recorder.Code, "Request ID %s, response %s", recorder.Header().Get("x-request-id"), recorder.Body.String())
+	suite.Assert().Contains(test.DecodeError(suite.T(), recorder.Body.Bytes()), "There is a problem with the database connection")
+}
+
+func (suite *TestSuiteStandard) TestImport() {
+	// Import one
+	body, headers := suite.loadTestFile("Budget.yfull")
+	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/import?budgetName=Test Budget", body, headers)
+	suite.Assert().Equal(http.StatusNoContent, recorder.Code, "Request ID %s, response %s", recorder.Header().Get("x-request-id"), recorder.Body.String())
+}

--- a/pkg/controllers/month_test.go
+++ b/pkg/controllers/month_test.go
@@ -15,7 +15,7 @@ import (
 func (suite *TestSuiteStandard) TestOptionsMonth() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/months", "")
 	suite.Assert().Equal(http.StatusNoContent, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
-	suite.Assert().Equal(recorder.Header().Get("allow"), "GET")
+	suite.Assert().Equal(recorder.Header().Get("allow"), "OPTIONS, GET")
 }
 
 // TestBudgetMonth verifies that the monthly calculations are correct.

--- a/pkg/controllers/test_options_test.go
+++ b/pkg/controllers/test_options_test.go
@@ -21,6 +21,6 @@ func (suite *TestSuiteStandard) TestOptionsHeaderResources() {
 		recorder := test.Request(suite.controller, suite.T(), http.MethodOptions, path, "")
 
 		assert.Equal(suite.T(), http.StatusNoContent, recorder.Code)
-		assert.Equal(suite.T(), recorder.Header().Get("allow"), "GET, POST")
+		assert.Equal(suite.T(), recorder.Header().Get("allow"), "OPTIONS, GET, POST")
 	}
 }

--- a/pkg/httputil/options.go
+++ b/pkg/httputil/options.go
@@ -8,26 +8,26 @@ import (
 )
 
 func OptionsGet(c *gin.Context) {
-	c.Header("allow", "GET")
+	c.Header("allow", "OPTIONS, GET")
 	c.Render(http.StatusNoContent, render.JSON{})
 }
 
 func OptionsGetPost(c *gin.Context) {
-	c.Header("allow", "GET, POST")
+	c.Header("allow", "OPTIONS, GET, POST")
 	c.Render(http.StatusNoContent, render.JSON{})
 }
 
 func OptionsGetDelete(c *gin.Context) {
-	c.Header("allow", "GET, DELETE")
+	c.Header("allow", "OPTIONS, GET, DELETE")
 	c.Render(http.StatusNoContent, render.JSON{})
 }
 
 func OptionsGetPatchDelete(c *gin.Context) {
-	c.Header("allow", "GET, PATCH, DELETE")
+	c.Header("allow", "OPTIONS, GET, PATCH, DELETE")
 	c.Render(http.StatusNoContent, render.JSON{})
 }
 
 func OptionsDelete(c *gin.Context) {
-	c.Header("allow", "DELETE")
+	c.Header("allow", "OPTIONS, DELETE")
 	c.Render(http.StatusNoContent, render.JSON{})
 }

--- a/pkg/httputil/options.go
+++ b/pkg/httputil/options.go
@@ -12,6 +12,11 @@ func OptionsGet(c *gin.Context) {
 	c.Render(http.StatusNoContent, render.JSON{})
 }
 
+func OptionsPost(c *gin.Context) {
+	c.Header("allow", "OPTIONS, POST")
+	c.Render(http.StatusNoContent, render.JSON{})
+}
+
 func OptionsGetPost(c *gin.Context) {
 	c.Header("allow", "OPTIONS, GET, POST")
 	c.Render(http.StatusNoContent, render.JSON{})

--- a/pkg/httputil/options_test.go
+++ b/pkg/httputil/options_test.go
@@ -24,7 +24,7 @@ func TestOptionsGet(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, w.Code)
 }
 
-func TestOptionsPost(t *testing.T) {
+func TestOptionsGetPost(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, r := gin.CreateTestContext(w)
 
@@ -35,6 +35,20 @@ func TestOptionsPost(t *testing.T) {
 	r.ServeHTTP(w, c.Request)
 
 	assert.Equal(t, "OPTIONS, GET, POST", w.Header().Get("allow"))
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestOptionsPost(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", httputil.OptionsPost)
+
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Host = "example.com"
+	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, "OPTIONS, POST", w.Header().Get("allow"))
 	assert.Equal(t, http.StatusNoContent, w.Code)
 }
 

--- a/pkg/httputil/options_test.go
+++ b/pkg/httputil/options_test.go
@@ -20,7 +20,7 @@ func TestOptionsGet(t *testing.T) {
 	c.Request.Host = "example.com"
 	r.ServeHTTP(w, c.Request)
 
-	assert.Equal(t, http.MethodGet, w.Header().Get("allow"))
+	assert.Equal(t, "OPTIONS, GET", w.Header().Get("allow"))
 	assert.Equal(t, http.StatusNoContent, w.Code)
 }
 
@@ -34,7 +34,7 @@ func TestOptionsPost(t *testing.T) {
 	c.Request.Host = "example.com"
 	r.ServeHTTP(w, c.Request)
 
-	assert.Equal(t, "GET, POST", w.Header().Get("allow"))
+	assert.Equal(t, "OPTIONS, GET, POST", w.Header().Get("allow"))
 	assert.Equal(t, http.StatusNoContent, w.Code)
 }
 
@@ -48,7 +48,7 @@ func TestOptionsGetPatchDelete(t *testing.T) {
 	c.Request.Host = "example.com"
 	r.ServeHTTP(w, c.Request)
 
-	assert.Equal(t, "GET, PATCH, DELETE", w.Header().Get("allow"))
+	assert.Equal(t, "OPTIONS, GET, PATCH, DELETE", w.Header().Get("allow"))
 	assert.Equal(t, http.StatusNoContent, w.Code)
 }
 
@@ -62,7 +62,7 @@ func TestOptionsGetDelete(t *testing.T) {
 	c.Request.Host = "example.com"
 	r.ServeHTTP(w, c.Request)
 
-	assert.Equal(t, "GET, DELETE", w.Header().Get("allow"))
+	assert.Equal(t, "OPTIONS, GET, DELETE", w.Header().Get("allow"))
 	assert.Equal(t, http.StatusNoContent, w.Code)
 }
 
@@ -76,6 +76,6 @@ func TestOptionsDelete(t *testing.T) {
 	c.Request.Host = "example.com"
 	r.ServeHTTP(w, c.Request)
 
-	assert.Equal(t, "DELETE", w.Header().Get("allow"))
+	assert.Equal(t, "OPTIONS, DELETE", w.Header().Get("allow"))
 	assert.Equal(t, http.StatusNoContent, w.Code)
 }

--- a/pkg/importer/creator.go
+++ b/pkg/importer/creator.go
@@ -1,0 +1,95 @@
+package importer
+
+import (
+	"github.com/envelope-zero/backend/pkg/importer/types"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+func Create(db *gorm.DB, budgetName string, resources types.ParsedResources) error {
+	// Start a transaction so we can roll back all created resources if an error occurs
+	tx := db.Begin()
+
+	// Create the budget
+	budget := resources.Budget
+	budget.BudgetCreate.Name = budgetName
+	err := tx.Create(&budget).Error
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	// Create accounts
+	for name, r := range resources.Accounts {
+		// Set the Account ID & name and create the account
+		account := r.Model
+		account.AccountCreate.BudgetID = budget.ID
+		account.AccountCreate.Name = name
+		err := tx.Create(&account).Error
+		if err != nil {
+			tx.Rollback()
+			return err
+		}
+
+		// Update the account in the resources struct so that it also contains the ID
+		r.Model = account
+		resources.Accounts[name] = r
+	}
+
+	for cName, category := range resources.Categories {
+		category.Model.BudgetID = budget.ID
+
+		err := tx.Create(&category.Model).Error
+		if err != nil {
+			tx.Rollback()
+			return err
+		}
+		resources.Categories[cName] = category
+
+		// Add all envelopes
+		for eName, envelope := range category.Envelopes {
+			envelope.Model.CategoryID = category.Model.ID
+
+			err := tx.Create(&envelope.Model).Error
+			if err != nil {
+				tx.Rollback()
+				return err
+			}
+			resources.Categories[category.Model.Name].Envelopes[eName] = envelope
+		}
+	}
+
+	// Create transactions
+	for _, r := range resources.Transactions {
+		transaction := r.Model
+		transaction.BudgetID = budget.ID
+		transaction.SourceAccountID = resources.Accounts[r.SourceAccount].Model.ID
+		transaction.DestinationAccountID = resources.Accounts[r.DestinationAccount].Model.ID
+
+		envelopeID := resources.Categories[r.Category].Envelopes[r.Envelope].Model.ID
+		if envelopeID != uuid.Nil {
+			transaction.EnvelopeID = &envelopeID
+		}
+
+		err := tx.Create(&transaction).Error
+		if err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+
+	for _, a := range resources.Allocations {
+		allocation := a.Model
+		allocation.AllocationCreate.EnvelopeID = resources.Categories[a.Category].Envelopes[a.Envelope].Model.ID
+
+		err := tx.Create(&allocation).Error
+		if err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+
+	// No errors happened, commit the transaction
+	tx.Commit()
+	return nil
+}

--- a/pkg/importer/parser/ynab4/parse.go
+++ b/pkg/importer/parser/ynab4/parse.go
@@ -1,0 +1,369 @@
+package ynab4
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/envelope-zero/backend/pkg/importer/types"
+	"github.com/envelope-zero/backend/pkg/models"
+	"golang.org/x/exp/maps"
+	"golang.org/x/text/currency"
+)
+
+// This function parses the comdirect CSV files.
+func Parse(f io.Reader) (types.ParsedResources, error) {
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return types.ParsedResources{}, fmt.Errorf("could not read data from file: %w", err)
+	}
+
+	var budget Budget
+	err = json.Unmarshal(content, &budget)
+	if err != nil {
+		return types.ParsedResources{}, fmt.Errorf("not a valid YNAB4 Budget.yfull file: %w", err)
+	}
+
+	var resources types.ParsedResources
+
+	// Set options for the budget
+	cur, _ := currency.FromTag(budget.BudgetMetaData.CurrencyLocale)
+	resources.Budget = models.Budget{
+		BudgetCreate: models.BudgetCreate{
+			Currency: fmt.Sprintf("%s", currency.Symbol(cur)),
+		},
+	}
+
+	// Add all accounts
+	accountIDNames, err := parseAccounts(&resources, budget.Accounts)
+	if err != nil {
+		return types.ParsedResources{}, fmt.Errorf("error parsing accounts: %w", err)
+	}
+
+	payeeIDNames, err := parsePayees(&resources, budget.Payees)
+	if err != nil {
+		return types.ParsedResources{}, fmt.Errorf("error parsing payees: %w", err)
+	}
+
+	// Copy all payee mappings to the account mappings as for Envelope Zero, both are accounts
+	maps.Copy(accountIDNames, payeeIDNames)
+
+	envelopeIDNames, err := parseCategories(&resources, budget.Categories)
+	if err != nil {
+		return types.ParsedResources{}, fmt.Errorf("error parsing categories and subcategories: %w", err)
+	}
+
+	err = parseTransactions(&resources, budget.Transactions, accountIDNames, envelopeIDNames)
+	if err != nil {
+		return types.ParsedResources{}, fmt.Errorf("error parsing transactions: %w", err)
+	}
+
+	err = parseAllocations(&resources, budget.MonthlyBudgets, envelopeIDNames)
+	if err != nil {
+		return types.ParsedResources{}, fmt.Errorf("error parsing budget allocations: %w", err)
+	}
+
+	return resources, nil
+}
+
+func parseHiddenCategoryName(f string) (category, envelope string, err error) {
+	// The format of hidden category strings is shown in the next line. Square brackets denote field names
+	// [Master Category Name] ` [Category Name] ` [Archival Number]
+	match := regexp.MustCompile("(.*) ` (.*) `").FindStringSubmatch(f)
+
+	// len needs to be 3 as the whole regex match is in match[0]
+	if len(match) != 3 {
+		return "", "", fmt.Errorf("incorrect hidden category format: match length is %d", len(match))
+	}
+
+	category = match[1]
+	envelope = match[2]
+	return
+}
+
+func parseAccounts(resources *types.ParsedResources, accounts []Account) (IDToName, error) {
+	idToNames := make(IDToName)
+
+	resources.Accounts = make(map[string]types.Account)
+	for _, account := range accounts {
+		idToNames[account.EntityID] = account.Name
+		resources.Accounts[account.Name] = types.Account{
+			Model: models.Account{
+				AccountCreate: models.AccountCreate{
+					Name:     account.Name,
+					Note:     account.Note,
+					OnBudget: account.OnBudget,
+					Hidden:   account.Hidden,
+				},
+			},
+		}
+	}
+
+	return idToNames, nil
+}
+
+func parsePayees(resources *types.ParsedResources, payees []Payee) (IDToName, error) {
+	idToNames := make(IDToName)
+
+	// Payees in YNAB 4 map to External Accounts in Envelope Zero
+	for _, payee := range payees {
+		if payee.Deleted {
+			continue
+		}
+
+		// Transfers are also stored as Payees with an entity ID of "Payee/Transfer:[Target account ID]"
+		// As we do not need this hack for Envelope Zero, we skip those Payees
+		if strings.HasPrefix(payee.EntityID, "Payee/Transfer") {
+			continue
+		}
+
+		// Create the account
+		idToNames[payee.EntityID] = payee.Name
+		resources.Accounts[payee.Name] = types.Account{
+			Model: models.Account{
+				AccountCreate: models.AccountCreate{
+					Name:     payee.Name,
+					OnBudget: false,
+					External: true,
+				},
+			},
+		}
+	}
+
+	return idToNames, nil
+}
+
+func parseCategories(resources *types.ParsedResources, categories []Category) (IDToEnvelopes, error) {
+	idToEnvelope := make(IDToEnvelopes)
+
+	// Create temporary variables to hold all the parsed
+	// data. They will be added to the ParsedResources
+	// when parsing is complete.
+	tCategories := make(map[string]types.Category)
+	type tEnvelope struct {
+		Envelope types.Envelope
+		Category string
+	}
+	var tEnvelopes []tEnvelope
+
+	for _, category := range categories {
+		// Add the category
+		tCategories[category.Name] = types.Category{
+			Model: models.Category{
+				CategoryCreate: models.CategoryCreate{
+					Name: category.Name,
+					Note: category.Note,
+					// we use category.Deleted here since the original data format does not have a hidden field. If the category is not referenced anywhere,
+					// it will not be imported anyway
+					Hidden: category.Deleted,
+				},
+			},
+			Envelopes: make(map[string]types.Envelope),
+		}
+
+		// Add the envelopes
+		for _, envelope := range category.SubCategories {
+			if envelope.Deleted {
+				continue
+			}
+
+			// Map the envelope ID to the category and envelope name
+			mapping := IDToEnvelope{
+				Envelope: envelope.Name,
+				Category: category.Name,
+			}
+
+			// For hidden categories, we need to extract the actual name
+			var hidden bool
+			if category.Name == "Hidden Categories" {
+				var err error
+				mapping.Category, mapping.Envelope, err = parseHiddenCategoryName(mapping.Envelope)
+				if err != nil {
+					return IDToEnvelopes{}, fmt.Errorf("hidden category could not be parsed: %w", err)
+				}
+
+				hidden = true
+			}
+
+			idToEnvelope[envelope.EntityID] = mapping
+
+			tEnvelopes = append(tEnvelopes, tEnvelope{
+				types.Envelope{
+					Model: models.Envelope{
+						EnvelopeCreate: models.EnvelopeCreate{
+							Name:   mapping.Envelope,
+							Note:   envelope.Note,
+							Hidden: hidden,
+						},
+					},
+				},
+				mapping.Category,
+			})
+		}
+	}
+
+	// Initialize the categories
+	resources.Categories = make(map[string]types.Category)
+
+	// Add all envelopes, adding categories as needed
+	for _, envelope := range tEnvelopes {
+		category, ok := tCategories[envelope.Category]
+		if !ok {
+			return IDToEnvelopes{}, errors.New("an envelope referenced a non-existing category. Your Budget.yfull file seems to be inconsistent")
+		}
+
+		// Check if the category already exists in the resources. If not, create it
+		_, ok = resources.Categories[envelope.Category]
+		if !ok {
+			resources.Categories[envelope.Category] = category
+		}
+
+		resources.Categories[envelope.Category].Envelopes[envelope.Envelope.Model.Name] = envelope.Envelope
+	}
+
+	return idToEnvelope, nil
+}
+
+func parseTransactions(resources *types.ParsedResources, transactions []Transaction, accountIDNames IDToName, envelopeIDNames IDToEnvelopes) error {
+	// If an account "No payee" for transactions without a payee needs to be added
+	addNoPayee := false
+
+	// Add all transactions
+	for _, transaction := range transactions {
+		// Don't import deleted transactions or transactions that are 0
+		//
+		// Transfers create two corresponding transaction entries in YNAB 4
+		//
+		// They use the same entityId, but one is suffixed with "_T_0"
+		// Therefore, we ignore transactions where the entity ID ends in
+		// "_T_0"
+		if transaction.Deleted || transaction.Amount.IsZero() || strings.HasSuffix(transaction.EntityID, "_T_0") {
+			continue
+		}
+
+		// For transactions, the payee string has the prefix "Payee/Transfer:"
+		payeeID := strings.TrimPrefix(transaction.PayeeID, "Payee/Transfer:")
+
+		// If we do not have a Payee for a transaction, we use the special import payee/account
+		// that will be created only if it is needed
+		payee := accountIDNames[payeeID]
+		if payee == "" {
+			payee = "YNAB 4 Import - No Payee"
+			addNoPayee = true
+		}
+
+		// Envelope Zero does not use a magic “Starting Balance” account, instead
+		// every account has a field for the starting balance
+		if payee == "Starting Balance" {
+			account := resources.Accounts[accountIDNames[transaction.AccountID]]
+			account.Model.InitialBalance = transaction.Amount
+
+			resources.Accounts[accountIDNames[transaction.AccountID]] = account
+
+			// Initial balance is set, no more processing needed
+			continue
+		}
+
+		// Parse the date of the transaction
+		date, err := time.Parse("2006-01-02", transaction.Date)
+		if err != nil {
+			return fmt.Errorf("could not parse date, the Budget.yfull file seems to be corrupt: %w", err)
+		}
+
+		newTransaction := types.Transaction{
+			Model: models.Transaction{
+				TransactionCreate: models.TransactionCreate{
+					Date: date,
+					Note: transaction.Memo,
+				},
+			},
+		}
+
+		if transaction.Amount.IsPositive() {
+			newTransaction.DestinationAccount = accountIDNames[transaction.AccountID]
+			newTransaction.SourceAccount = payee
+			newTransaction.Model.Amount = transaction.Amount
+		} else {
+			newTransaction.SourceAccount = accountIDNames[transaction.AccountID]
+			newTransaction.DestinationAccount = payee
+			newTransaction.Model.Amount = transaction.Amount.Neg()
+		}
+
+		if transaction.Cleared == "Reconciled" {
+			newTransaction.Model.TransactionCreate.Reconciled = true
+		}
+
+		// No subtransactions, add transaction directly
+		if len(transaction.SubTransactions) == 0 {
+			if mapping, ok := envelopeIDNames[transaction.CategoryID]; ok {
+				newTransaction.Envelope = mapping.Envelope
+				newTransaction.Category = mapping.Category
+			}
+
+			resources.Transactions = append(resources.Transactions, newTransaction)
+			// Transaction has been added, nothing more to do
+			continue
+		}
+
+		// Transaction has subtransactions, add them
+		for _, sub := range transaction.SubTransactions {
+			if mapping, ok := envelopeIDNames[sub.CategoryID]; ok {
+				newTransaction.Envelope = mapping.Envelope
+				newTransaction.Category = mapping.Category
+			}
+			newTransaction.Model.Amount = sub.Amount
+
+			resources.Transactions = append(resources.Transactions, newTransaction)
+		}
+	}
+
+	if addNoPayee {
+		if _, ok := resources.Accounts["YNAB 4 Import - No Payee"]; !ok {
+			resources.Accounts["YNAB 4 Import - No Payee"] = types.Account{
+				Model: models.Account{
+					AccountCreate: models.AccountCreate{
+						Name:     "YNAB 4 Import - No Payee",
+						Note:     "This is the opposing account for all transactions that were imported from YNAB 4, but did not have a Payee. In Envelope Zero, all transactions must have a Source and Destination account",
+						OnBudget: false,
+						External: true,
+					},
+				},
+			}
+		}
+	}
+
+	return nil
+}
+
+func parseAllocations(resources *types.ParsedResources, allocations []MonthlyBudget, envelopeIDNames IDToEnvelopes) error {
+	for _, monthBudget := range allocations {
+		month, err := time.Parse("2006-01-02", monthBudget.Month)
+		if err != nil {
+			return fmt.Errorf("could not parse date: %w", err)
+		}
+
+		for _, allocation := range monthBudget.MonthlySubCategoryBudgets {
+			// Ignore the ones that are zero
+			if allocation.Budgeted.IsZero() {
+				continue
+			}
+
+			resources.Allocations = append(resources.Allocations, types.Allocation{
+				Model: models.Allocation{
+					AllocationCreate: models.AllocationCreate{
+						Month:  month,
+						Amount: allocation.Budgeted,
+					},
+				},
+				Category: envelopeIDNames[allocation.CategoryID].Category,
+				Envelope: envelopeIDNames[allocation.CategoryID].Envelope,
+			})
+		}
+	}
+
+	return nil
+}

--- a/pkg/importer/parser/ynab4/parse_test.go
+++ b/pkg/importer/parser/ynab4/parse_test.go
@@ -1,0 +1,21 @@
+package ynab4_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/envelope-zero/backend/pkg/importer/parser/ynab4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	f, err := os.OpenFile("../../../../testdata/Budget.yfull", os.O_RDONLY, 0o400)
+	if err != nil {
+		assert.FailNow(t, "Failed to open the test file", err)
+	}
+
+	_, err = ynab4.Parse(f)
+	if err != nil {
+		assert.Fail(t, "Parsing failed", err)
+	}
+}

--- a/pkg/importer/parser/ynab4/types.go
+++ b/pkg/importer/parser/ynab4/types.go
@@ -1,0 +1,111 @@
+package ynab4
+
+import (
+	"github.com/shopspring/decimal"
+	"golang.org/x/text/language"
+)
+
+// IDToName is a map of strings to a string.
+//
+// Use it to map the YNAB 4 Entity IDs to the names
+// to enable easier mapping.
+type IDToName map[string]string
+
+// IDToEnvelopes maps the ID of a YNAB 4 subcategory to a category and envelope name
+// for Envelope Zero.
+type IDToEnvelopes map[string]IDToEnvelope
+
+type IDToEnvelope struct {
+	Category string
+	Envelope string
+}
+
+// This has been converted from testdata/Budget.yfull with the help of
+// https://mholt.github.io/json-to-go/
+//
+// Unused fields have been removed to keep the struct as small as possible.
+type Budget struct {
+	BudgetMetaData struct {
+		CurrencyLocale language.Tag `json:"currencyLocale"`
+	} `json:"budgetMetaData"`
+	Transactions          []Transaction          `json:"transactions"`
+	MonthlyBudgets        []MonthlyBudget        `json:"monthlyBudgets"`
+	Categories            []Category             `json:"masterCategories"`
+	ScheduledTransactions []ScheduledTransaction `json:"scheduledTransactions"`
+	Payees                []Payee                `json:"payees"`
+	Accounts              []Account              `json:"accounts"`
+}
+
+type Account struct {
+	EntityID string `json:"entityId"`
+	Note     string `json:"note"`
+	OnBudget bool   `json:"onBudget"`
+	Hidden   bool   `json:"hidden"`
+	Name     string `json:"accountName"`
+}
+
+type Payee struct {
+	EntityID string `json:"entityId"`
+	Name     string `json:"name"`
+	Deleted  bool   `json:"isTombstone,omitempty"`
+}
+
+type SubCategory struct {
+	EntityID   string `json:"entityId"`
+	CategoryID string `json:"masterCategoryId"`
+	Name       string `json:"name"`
+	Note       string `json:"note"`
+	Deleted    bool   `json:"isTombstone,omitempty"`
+}
+
+type Category struct {
+	SubCategories []SubCategory `json:"subCategories"`
+	EntityID      string        `json:"entityId"`
+	Name          string        `json:"name"`
+	Note          string        `json:"note"`
+	Deleted       bool          `json:"isTombstone,omitempty"`
+}
+
+type Transaction struct {
+	EntityID        string          `json:"entityId"`
+	Amount          decimal.Decimal `json:"amount"`
+	CategoryID      string          `json:"categoryId"`
+	Date            string          `json:"date"`
+	Memo            string          `json:"memo"`
+	Deleted         bool            `json:"isTombstone"`
+	PayeeID         string          `json:"payeeId"`
+	AccountID       string          `json:"accountId"`
+	Cleared         string          `json:"cleared"`
+	SubTransactions []struct {
+		CategoryID string          `json:"categoryId"`
+		Amount     decimal.Decimal `json:"amount"`
+	} `json:"subTransactions"`
+}
+
+type MonthlySubCategoryBudget struct {
+	Budgeted             decimal.Decimal `json:"budgeted"`
+	OverspendingHandling string          `json:"overspendingHandling"` // Unused. Needed when implementing https://github.com/envelope-zero/backend/issues/327
+	CategoryID           string          `json:"categoryId"`
+}
+
+type MonthlyBudget struct {
+	Month                     string                     `json:"month"`
+	MonthlySubCategoryBudgets []MonthlySubCategoryBudget `json:"monthlySubCategoryBudgets"`
+}
+
+// TODO: Clean up when implementing https://github.com/envelope-zero/backend/issues/379
+type ScheduledTransaction struct {
+	EntityID            string          `json:"entityId"`
+	EntityType          string          `json:"entityType"`
+	TwiceAMonthStartDay int             `json:"twiceAMonthStartDay"`
+	Amount              decimal.Decimal `json:"amount"`
+	Frequency           string          `json:"frequency"`
+	CategoryID          string          `json:"categoryId"`
+	Date                string          `json:"date"`
+	Accepted            bool            `json:"accepted"`
+	PayeeID             string          `json:"payeeId"`
+	EntityVersion       string          `json:"entityVersion"`
+	AccountID           string          `json:"accountId"`
+	Cleared             string          `json:"cleared"`
+	Memo                string          `json:"memo,omitempty"`
+}

--- a/pkg/importer/types/types.go
+++ b/pkg/importer/types/types.go
@@ -1,0 +1,41 @@
+package types
+
+import "github.com/envelope-zero/backend/pkg/models"
+
+// ParsedResources is the struct containing all resources that are to be created
+// Named resources are in maps with their names as keys to enable easy deduplication
+// and iteration through them.
+type ParsedResources struct {
+	Budget       models.Budget
+	Accounts     map[string]Account
+	Categories   map[string]Category
+	Allocations  []Allocation
+	Transactions []Transaction
+}
+
+type Account struct {
+	Model models.Account
+}
+
+type Category struct {
+	Model     models.Category
+	Envelopes map[string]Envelope
+}
+
+type Envelope struct {
+	Model models.Envelope
+}
+
+type Allocation struct {
+	Model    models.Allocation
+	Category string // There is a category here since an envelope with the same name can exist for multiple categories
+	Envelope string
+}
+
+type Transaction struct {
+	Model              models.Transaction
+	SourceAccount      string
+	DestinationAccount string
+	Category           string // There is a category here since an envelope with the same name can exist for multiple categories
+	Envelope           string
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -122,6 +122,7 @@ func AttachRoutes(co controllers.Controller, group *gin.RouterGroup) {
 	co.RegisterEnvelopeRoutes(v1.Group("/envelopes"))
 	co.RegisterAllocationRoutes(v1.Group("/allocations"))
 	co.RegisterMonthRoutes(v1.Group("/months"))
+	co.RegisterImportRoutes(v1.Group("/import"))
 }
 
 type RootResponse struct {
@@ -199,6 +200,7 @@ type V1Links struct {
 	Envelopes    string `json:"envelopes" example:"https://example.com/api/v1/envelopes"`
 	Allocations  string `json:"allocations" example:"https://example.com/api/v1/allocations"`
 	Months       string `json:"months" example:"https://example.com/api/v1/months"`
+	Import       string `json:"import" example:"https://example.com/api/v1/import"`
 }
 
 // @Summary     v1 API
@@ -216,6 +218,7 @@ func GetV1(c *gin.Context) {
 			Envelopes:    c.GetString("baseURL") + "/v1/envelopes",
 			Allocations:  c.GetString("baseURL") + "/v1/allocations",
 			Months:       c.GetString("baseURL") + "/v1/months",
+			Import:       c.GetString("baseURL") + "/v1/import",
 		},
 	})
 }

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -155,9 +155,9 @@ func TestOptions(t *testing.T) {
 		f        func(*gin.Context)
 		expected string
 	}{
-		{"/", router.OptionsRoot, "GET"},
-		{"/version", router.OptionsVersion, "GET"},
-		{"/v1", router.OptionsV1, "GET, DELETE"},
+		{"/", router.OptionsRoot, "OPTIONS, GET"},
+		{"/version", router.OptionsVersion, "OPTIONS, GET"},
+		{"/v1", router.OptionsV1, "OPTIONS, GET, DELETE"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -109,6 +109,7 @@ func TestGetV1(t *testing.T) {
 			Envelopes:    "/v1/envelopes",
 			Allocations:  "/v1/allocations",
 			Months:       "/v1/months",
+			Import:       "/v1/import",
 		},
 	}
 

--- a/testdata/Budget.yfull
+++ b/testdata/Budget.yfull
@@ -1,0 +1,1343 @@
+{
+	"accounts": [
+		{
+			"lastReconciledDate": null,
+			"lastReconciledBalance": 0,
+			"onBudget": true,
+			"lastEnteredCheckNumber": -1,
+			"accountName": "Cash",
+			"entityVersion": "A-207",
+			"hidden": false,
+			"entityId": "14960788-5E84-761E-CEAB-843CC3BC16F5",
+			"note": "This is the cash I carry around",
+			"accountType": "Cash",
+			"sortableIndex": 0,
+			"entityType": "account"
+		},
+		{
+			"lastReconciledDate": "2022-09-22",
+			"lastReconciledBalance": 0,
+			"onBudget": true,
+			"lastEnteredCheckNumber": -1,
+			"accountName": "Checking",
+			"entityVersion": "A-184",
+			"hidden": false,
+			"entityId": "E640A420-6FEA-5D9D-9128-66A1D1D70591",
+			"note": "My default bank account",
+			"accountType": "Checking",
+			"sortableIndex": 1073741823,
+			"entityType": "account"
+		},
+		{
+			"lastReconciledDate": null,
+			"lastReconciledBalance": 0,
+			"onBudget": true,
+			"lastEnteredCheckNumber": -1,
+			"accountName": "Deleted Account",
+			"entityVersion": "A-218",
+			"hidden": true,
+			"entityId": "722E5112-E43F-0558-BFAD-7581E452BEF6",
+			"accountType": "Cash",
+			"sortableIndex": 1610612735,
+			"entityType": "account"
+		},
+		{
+			"lastReconciledDate": null,
+			"lastReconciledBalance": 0,
+			"onBudget": true,
+			"lastEnteredCheckNumber": -1,
+			"accountName": "Starting Balance Tester",
+			"entityVersion": "A-268",
+			"hidden": true,
+			"entityId": "BD495219-9D21-5B84-0116-B2570214B439",
+			"accountType": "Checking",
+			"sortableIndex": 1879048191,
+			"entityType": "account"
+		}
+	],
+	"budgetMetaData": {
+		"dateLocale": "en_US",
+		"budgetType": "Personal",
+		"strictBudget": "TRUE",
+		"entityVersion": "A-181",
+		"currencyISOSymbol": null,
+		"entityId": "A2",
+		"entityType": "budgetMetaData",
+		"currencyLocale": "en_US"
+	},
+	"transactions": [
+		{
+			"payeeId": "4256A548-2572-B2CD-0860-843CC3CD8D38",
+			"entityType": "transaction",
+			"accountId": "14960788-5E84-761E-CEAB-843CC3BC16F5",
+			"cleared": "Cleared",
+			"amount": 0,
+			"date": "2022-08-09",
+			"accepted": true,
+			"categoryId": "Category/__ImmediateIncome__",
+			"isTombstone": true,
+			"entityVersion": "A-108",
+			"entityId": "2960ABDF-71E0-785A-DE30-843CC3C7E06C"
+		},
+		{
+			"payeeId": "E8C1D7B4-F18A-3FF7-8A69-843DD2629BBD",
+			"entityType": "transaction",
+			"accountId": "E640A420-6FEA-5D9D-9128-66A1D1D70591",
+			"cleared": "Reconciled",
+			"amount": 1000,
+			"date": "2022-08-01",
+			"accepted": true,
+			"categoryId": "Category/__ImmediateIncome__",
+			"memo": "Salary",
+			"entityVersion": "A-214",
+			"entityId": "D7D90A37-A5CF-8CF0-5A35-843D8C220140"
+		},
+		{
+			"payeeId": "E8C1D7B4-F18A-3FF7-8A69-843DD2629BBD",
+			"entityType": "transaction",
+			"accountId": "E640A420-6FEA-5D9D-9128-66A1D1D70591",
+			"cleared": "Cleared",
+			"amount": 1000,
+			"date": "2022-09-01",
+			"accepted": true,
+			"categoryId": "Category/__ImmediateIncome__",
+			"memo": "Salary",
+			"entityVersion": "A-247",
+			"entityId": "FDEB3CE3-5834-B138-98B7-845B3ED0BE8D"
+		},
+		{
+			"payeeId": "3139A659-EAA9-846C-3F36-845CDB81C55E",
+			"entityType": "transaction",
+			"accountId": "14960788-5E84-761E-CEAB-843CC3BC16F5",
+			"cleared": "Cleared",
+			"amount": -20,
+			"date": "2022-08-10",
+			"accepted": true,
+			"categoryId": "C4AAAB5C-548F-7855-46F9-843D4C631ABC",
+			"entityVersion": "A-178",
+			"entityId": "DAD9C7BF-8335-3814-2744-845CADAE3714"
+		},
+		{
+			"payeeId": "25A421B8-B860-B5C3-C9F7-84631E6BDB42",
+			"entityType": "transaction",
+			"accountId": "14960788-5E84-761E-CEAB-843CC3BC16F5",
+			"cleared": "Cleared",
+			"amount": -10,
+			"date": "2022-08-10",
+			"accepted": true,
+			"categoryId": "28901741-CC63-3536-5068-66A125711653",
+			"entityVersion": "A-179",
+			"entityId": "4497CB8A-4E21-6749-7FA6-8462FF6A3A74"
+		},
+		{
+			"payeeId": "25A421B8-B860-B5C3-C9F7-84631E6BDB42",
+			"entityType": "transaction",
+			"accountId": "14960788-5E84-761E-CEAB-843CC3BC16F5",
+			"cleared": "Uncleared",
+			"amount": 10,
+			"date": "2022-08-20",
+			"accepted": true,
+			"categoryId": "B988C739-E4C9-8036-CA52-843D631764CD",
+			"memo": "Why does my Kebap person pay my rent?",
+			"entityVersion": "A-209",
+			"entityId": "7206169F-D9A2-C3CC-D515-84A31DD15174"
+		},
+		{
+			"payeeId": "25A421B8-B860-B5C3-C9F7-84631E6BDB42",
+			"entityType": "transaction",
+			"accountId": "14960788-5E84-761E-CEAB-843CC3BC16F5",
+			"cleared": "Uncleared",
+			"amount": -50,
+			"date": "2022-09-10",
+			"accepted": true,
+			"categoryId": "B988C739-E4C9-8036-CA52-843D631764CD",
+			"isTombstone": true,
+			"entityVersion": "A-150",
+			"entityId": "C96DB284-619E-81C8-F2AB-DC8616F82F12"
+		},
+		{
+			"payeeId": "25A421B8-B860-B5C3-C9F7-84631E6BDB42",
+			"entityType": "transaction",
+			"accountId": "14960788-5E84-761E-CEAB-843CC3BC16F5",
+			"cleared": "Uncleared",
+			"amount": -20,
+			"date": "2022-09-10",
+			"accepted": true,
+			"categoryId": "28901741-CC63-3536-5068-66A125711653",
+			"entityVersion": "A-159",
+			"entityId": "ABC3D2F4-8098-EC93-A87A-DC86CD68435B"
+		},
+		{
+			"payeeId": "4256A548-2572-B2CD-0860-843CC3CD8D38",
+			"entityType": "transaction",
+			"accountId": "E640A420-6FEA-5D9D-9128-66A1D1D70591",
+			"cleared": "Reconciled",
+			"amount": 100,
+			"date": "2022-07-15",
+			"accepted": true,
+			"categoryId": "Category/__ImmediateIncome__",
+			"entityVersion": "A-177",
+			"entityId": "8B239AEE-D5AF-9AC6-E22E-66A1D1E1C432"
+		},
+		{
+			"payeeId": "Payee/Transfer:14960788-5E84-761E-CEAB-843CC3BC16F5",
+			"entityType": "transaction",
+			"accountId": "E640A420-6FEA-5D9D-9128-66A1D1D70591",
+			"cleared": "Reconciled",
+			"amount": -200,
+			"date": "2022-08-15",
+			"targetAccountId": "14960788-5E84-761E-CEAB-843CC3BC16F5",
+			"transferTransactionId": "359869C0-E78F-797F-8B51-66A230D5FCC2_T_0",
+			"accepted": true,
+			"categoryId": null,
+			"entityVersion": "A-175",
+			"entityId": "359869C0-E78F-797F-8B51-66A230D5FCC2"
+		},
+		{
+			"payeeId": "Payee/Transfer:E640A420-6FEA-5D9D-9128-66A1D1D70591",
+			"entityType": "transaction",
+			"accountId": "14960788-5E84-761E-CEAB-843CC3BC16F5",
+			"cleared": "Cleared",
+			"amount": 200,
+			"date": "2022-08-15",
+			"targetAccountId": "E640A420-6FEA-5D9D-9128-66A1D1D70591",
+			"transferTransactionId": "359869C0-E78F-797F-8B51-66A230D5FCC2",
+			"accepted": true,
+			"categoryId": null,
+			"entityVersion": "A-180",
+			"entityId": "359869C0-E78F-797F-8B51-66A230D5FCC2_T_0"
+		},
+		{
+			"payeeId": "E8C1D7B4-F18A-3FF7-8A69-843DD2629BBD",
+			"entityType": "transaction",
+			"accountId": "E640A420-6FEA-5D9D-9128-66A1D1D70591",
+			"cleared": "Uncleared",
+			"amount": 0,
+			"date": "2022-09-25",
+			"accepted": true,
+			"categoryId": "Category/__ImmediateIncome__",
+			"isTombstone": true,
+			"entityVersion": "A-213",
+			"entityId": "376640D6-1B18-46B1-E847-753BB05B0979"
+		},
+		{
+			"payeeId": "4256A548-2572-B2CD-0860-843CC3CD8D38",
+			"entityType": "transaction",
+			"accountId": "722E5112-E43F-0558-BFAD-7581E452BEF6",
+			"cleared": "Cleared",
+			"amount": 0,
+			"date": "2022-09-25",
+			"accepted": true,
+			"categoryId": "Category/__ImmediateIncome__",
+			"entityVersion": "A-217",
+			"entityId": "03E6A604-2A15-A3CA-3B1E-7581E470BB1C"
+		},
+		{
+			"payeeId": "E8C1D7B4-F18A-3FF7-8A69-843DD2629BBD",
+			"entityType": "transaction",
+			"accountId": "E640A420-6FEA-5D9D-9128-66A1D1D70591",
+			"cleared": "Uncleared",
+			"amount": 1000,
+			"date": "2022-09-25",
+			"accepted": false,
+			"categoryId": "Category/__DeferredIncome__",
+			"entityVersion": "A-226",
+			"dateEnteredFromSchedule": "2022-09-26",
+			"entityId": "19BD11E4-9302-6448-629E-753ABC9E7722_2022-09-25_0"
+		},
+		{
+			"payeeId": "3139A659-EAA9-846C-3F36-845CDB81C55E",
+			"entityType": "transaction",
+			"accountId": "E640A420-6FEA-5D9D-9128-66A1D1D70591",
+			"cleared": "Cleared",
+			"amount": -20,
+			"date": "2022-09-15",
+			"accepted": true,
+			"categoryId": "Category/__Split__",
+			"subTransactions": [
+				{
+					"categoryId": "41253F13-FA30-979D-C24A-A3A379A63DE7",
+					"parentTransactionId": "7A943D9D-D967-810F-9218-A3A2D9D8DF57",
+					"entityVersion": "A-242",
+					"entityId": "E46B690D-420B-43E7-9E7D-A3A38522C3A2",
+					"entityType": "subTransaction",
+					"amount": -15
+				},
+				{
+					"categoryId": "732E598D-821B-4C4C-B0CA-A3A3D7186AAD",
+					"parentTransactionId": "7A943D9D-D967-810F-9218-A3A2D9D8DF57",
+					"entityVersion": "A-244",
+					"entityId": "13FCC0B3-AE0F-429F-A1E4-A3A385742D18",
+					"entityType": "subTransaction",
+					"amount": -5
+				}
+			],
+			"entityVersion": "A-246",
+			"entityId": "7A943D9D-D967-810F-9218-A3A2D9D8DF57"
+		},
+		{
+			"payeeId": "4256A548-2572-B2CD-0860-843CC3CD8D38",
+			"entityType": "transaction",
+			"accountId": "BD495219-9D21-5B84-0116-B2570214B439",
+			"cleared": "Cleared",
+			"amount": 150,
+			"date": "2022-10-01",
+			"accepted": true,
+			"categoryId": "Category/__ImmediateIncome__",
+			"entityVersion": "A-267",
+			"entityId": "AFFC91CA-DE47-1FCF-988D-B257021D4B18"
+		},
+		{
+			"entityType": "transaction",
+			"accountId": "14960788-5E84-761E-CEAB-843CC3BC16F5",
+			"cleared": "Uncleared",
+			"amount": -17,
+			"date": "2022-09-15",
+			"accepted": true,
+			"categoryId": "4A60FACD-8328-819D-9892-753B4E92C81A",
+			"memo": "Test transaction without payee",
+			"entityVersion": "A-270",
+			"entityId": "42DC2A28-1DB7-BD86-AEAB-B35AA3AC438D"
+		}
+	],
+	"monthlyBudgets": [
+		{
+			"month": "2022-08-01",
+			"monthlySubCategoryBudgets": [
+				{
+					"parentMonthlyBudgetId": "MB/2022-08",
+					"categoryId": "C4AAAB5C-548F-7855-46F9-843D4C631ABC",
+					"entityVersion": "A-147",
+					"budgeted": 10,
+					"entityId": "MCB/2022-08/C4AAAB5C-548F-7855-46F9-843D4C631ABC",
+					"entityType": "monthlyCategoryBudget",
+					"overspendingHandling": "AffectsBuffer"
+				},
+				{
+					"parentMonthlyBudgetId": "MB/2022-08",
+					"categoryId": "B988C739-E4C9-8036-CA52-843D631764CD",
+					"entityVersion": "A-135",
+					"budgeted": 0,
+					"entityId": "MCB/2022-08/B988C739-E4C9-8036-CA52-843D631764CD",
+					"entityType": "monthlyCategoryBudget",
+					"overspendingHandling": null
+				},
+				{
+					"parentMonthlyBudgetId": "MB/2022-08",
+					"categoryId": "E261ACE3-149F-F9F8-421D-85DE6CC3FCAE",
+					"entityVersion": "A-233",
+					"budgeted": 10,
+					"entityId": "MCB/2022-08/E261ACE3-149F-F9F8-421D-85DE6CC3FCAE",
+					"entityType": "monthlyCategoryBudget",
+					"overspendingHandling": null
+				},
+				{
+					"parentMonthlyBudgetId": "MB/2022-08",
+					"categoryId": "28901741-CC63-3536-5068-66A125711653",
+					"entityVersion": "A-237",
+					"budgeted": 0,
+					"entityId": "MCB/2022-08/28901741-CC63-3536-5068-66A125711653",
+					"entityType": "monthlyCategoryBudget",
+					"overspendingHandling": "Confined"
+				}
+			],
+			"entityVersion": "A-37",
+			"entityId": "MB/2022-08",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2022-07-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-38",
+			"entityId": "MB/2022-07",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2022-06-01",
+			"monthlySubCategoryBudgets": [
+				{
+					"parentMonthlyBudgetId": "MB/2022-06",
+					"categoryId": "C4AAAB5C-548F-7855-46F9-843D4C631ABC",
+					"entityVersion": "A-153",
+					"budgeted": 20,
+					"entityId": "MCB/2022-06/C4AAAB5C-548F-7855-46F9-843D4C631ABC",
+					"entityType": "monthlyCategoryBudget",
+					"overspendingHandling": null
+				}
+			],
+			"entityVersion": "A-39",
+			"entityId": "MB/2022-06",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2022-05-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-40",
+			"entityId": "MB/2022-05",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2022-04-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-41",
+			"entityId": "MB/2022-04",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2022-03-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-42",
+			"entityId": "MB/2022-03",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2022-02-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-43",
+			"entityId": "MB/2022-02",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2022-01-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-44",
+			"entityId": "MB/2022-01",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2021-12-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-45",
+			"entityId": "MB/2021-12",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2021-11-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-46",
+			"entityId": "MB/2021-11",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2021-10-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-47",
+			"entityId": "MB/2021-10",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2021-09-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-48",
+			"entityId": "MB/2021-09",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2021-08-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-49",
+			"entityId": "MB/2021-08",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2021-07-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-50",
+			"entityId": "MB/2021-07",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2022-09-01",
+			"monthlySubCategoryBudgets": [
+				{
+					"parentMonthlyBudgetId": "MB/2022-09",
+					"categoryId": "B988C739-E4C9-8036-CA52-843D631764CD",
+					"entityVersion": "A-134",
+					"budgeted": 0,
+					"entityId": "MCB/2022-09/B988C739-E4C9-8036-CA52-843D631764CD",
+					"entityType": "monthlyCategoryBudget",
+					"overspendingHandling": null
+				},
+				{
+					"parentMonthlyBudgetId": "MB/2022-09",
+					"categoryId": "E261ACE3-149F-F9F8-421D-85DE6CC3FCAE",
+					"entityVersion": "A-232",
+					"budgeted": 100,
+					"entityId": "MCB/2022-09/E261ACE3-149F-F9F8-421D-85DE6CC3FCAE",
+					"entityType": "monthlyCategoryBudget",
+					"overspendingHandling": null
+				},
+				{
+					"parentMonthlyBudgetId": "MB/2022-09",
+					"categoryId": "28901741-CC63-3536-5068-66A125711653",
+					"entityVersion": "A-238",
+					"budgeted": 0,
+					"entityId": "MCB/2022-09/28901741-CC63-3536-5068-66A125711653",
+					"entityType": "monthlyCategoryBudget",
+					"overspendingHandling": "AffectsBuffer"
+				}
+			],
+			"entityVersion": "A-51",
+			"entityId": "MB/2022-09",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2022-10-01",
+			"monthlySubCategoryBudgets": [
+				{
+					"parentMonthlyBudgetId": "MB/2022-10",
+					"categoryId": "B988C739-E4C9-8036-CA52-843D631764CD",
+					"entityVersion": "A-133",
+					"budgeted": 0,
+					"entityId": "MCB/2022-10/B988C739-E4C9-8036-CA52-843D631764CD",
+					"entityType": "monthlyCategoryBudget",
+					"overspendingHandling": null
+				}
+			],
+			"entityVersion": "A-52",
+			"entityId": "MB/2022-10",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2022-11-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-53",
+			"entityId": "MB/2022-11",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2022-12-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-54",
+			"entityId": "MB/2022-12",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2023-01-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-55",
+			"entityId": "MB/2023-01",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2023-02-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-56",
+			"entityId": "MB/2023-02",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2023-03-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-57",
+			"entityId": "MB/2023-03",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2023-04-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-58",
+			"entityId": "MB/2023-04",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2023-05-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-59",
+			"entityId": "MB/2023-05",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2023-06-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-60",
+			"entityId": "MB/2023-06",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2023-07-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-61",
+			"entityId": "MB/2023-07",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2023-08-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-62",
+			"entityId": "MB/2023-08",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2023-09-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-63",
+			"entityId": "MB/2023-09",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2023-10-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-154",
+			"entityId": "MB/2023-10",
+			"entityType": "monthlyBudget"
+		},
+		{
+			"month": "2023-11-01",
+			"monthlySubCategoryBudgets": [],
+			"entityVersion": "A-236",
+			"entityId": "MB/2023-11",
+			"entityType": "monthlyBudget"
+		}
+	],
+	"fileMetaData": {
+		"currentKnowledge": "A-270",
+		"budgetDataVersion": "4.2",
+		"entityType": "fileMetaData"
+	},
+	"masterCategories": [
+		{
+			"deleteable": false,
+			"subCategories": [
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "MasterCategory/__Hidden__",
+					"sortableIndex": 1879048191,
+					"type": "OUTFLOW",
+					"entityVersion": "A-254",
+					"entityId": "C4AAAB5C-548F-7855-46F9-843D4C631ABC",
+					"name": "Running Costs ` Groceries (Hidden) ` BF7831EA-8CAC-A3C0-E420-66A1254D658C",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "MasterCategory/__Hidden__",
+					"sortableIndex": 2013265919,
+					"type": "OUTFLOW",
+					"entityVersion": "A-256",
+					"entityId": "E261ACE3-149F-F9F8-421D-85DE6CC3FCAE",
+					"name": "Some old master category (Hidden) ` Subcategory for old master category ` 7AAFDC85-9004-7806-69E8-85DE54041591",
+					"entityType": "category"
+				}
+			],
+			"sortableIndex": -1073741824,
+			"type": "OUTFLOW",
+			"entityVersion": "A-1",
+			"entityId": "MasterCategory/__Hidden__",
+			"name": "Hidden Categories",
+			"entityType": "masterCategory",
+			"expanded": true
+		},
+		{
+			"deleteable": true,
+			"subCategories": [
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A4",
+					"sortableIndex": 0,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-69",
+					"entityId": "A5",
+					"name": "Tithing",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A4",
+					"sortableIndex": 1073741823,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-68",
+					"entityId": "A6",
+					"name": "Charitable",
+					"entityType": "category"
+				}
+			],
+			"sortableIndex": 1879048191,
+			"type": "OUTFLOW",
+			"isTombstone": true,
+			"entityVersion": "A-70",
+			"entityId": "A4",
+			"name": "Giving",
+			"entityType": "masterCategory",
+			"expanded": true
+		},
+		{
+			"deleteable": true,
+			"subCategories": [
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A7",
+					"sortableIndex": 0,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-77",
+					"entityId": "A8",
+					"name": "Rent/Mortgage",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A7",
+					"sortableIndex": 1073741823,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-76",
+					"entityId": "A9",
+					"name": "Phone",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A7",
+					"sortableIndex": 1610612735,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-75",
+					"entityId": "A10",
+					"name": "Internet",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A7",
+					"sortableIndex": 1879048191,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-74",
+					"entityId": "A11",
+					"name": "Cable TV",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A7",
+					"sortableIndex": 2013265919,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-73",
+					"entityId": "A12",
+					"name": "Electricity",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A7",
+					"sortableIndex": 2080374783,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-72",
+					"entityId": "A13",
+					"name": "Water",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A7",
+					"sortableIndex": 2113929215,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-71",
+					"entityId": "A14",
+					"name": "Natural Gas/Propane/Oil",
+					"entityType": "category"
+				}
+			],
+			"sortableIndex": 2013265919,
+			"type": "OUTFLOW",
+			"isTombstone": true,
+			"entityVersion": "A-78",
+			"entityId": "A7",
+			"name": "Monthly Bills",
+			"entityType": "masterCategory",
+			"expanded": true
+		},
+		{
+			"deleteable": true,
+			"subCategories": [
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A15",
+					"sortableIndex": 0,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-85",
+					"entityId": "A16",
+					"name": "Groceries",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A15",
+					"sortableIndex": 1073741823,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-84",
+					"entityId": "A17",
+					"name": "Fuel",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A15",
+					"sortableIndex": 1610612735,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-83",
+					"entityId": "A18",
+					"name": "Spending Money",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A15",
+					"sortableIndex": 1879048191,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-82",
+					"entityId": "A19",
+					"name": "Restaurants",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A15",
+					"sortableIndex": 2013265919,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-81",
+					"entityId": "A20",
+					"name": "Medical",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A15",
+					"sortableIndex": 2080374783,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-80",
+					"entityId": "A21",
+					"name": "Clothing",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A15",
+					"sortableIndex": 2113929215,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-79",
+					"entityId": "A22",
+					"name": "Household Goods",
+					"entityType": "category"
+				}
+			],
+			"sortableIndex": 2080374783,
+			"type": "OUTFLOW",
+			"isTombstone": true,
+			"entityVersion": "A-86",
+			"entityId": "A15",
+			"name": "Everyday Expenses",
+			"entityType": "masterCategory",
+			"expanded": true
+		},
+		{
+			"deleteable": true,
+			"subCategories": [
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A23",
+					"sortableIndex": 0,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-94",
+					"entityId": "A24",
+					"name": "Emergency Fund",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A23",
+					"sortableIndex": 1073741823,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-93",
+					"entityId": "A25",
+					"name": "Car Repairs",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A23",
+					"sortableIndex": 1610612735,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-92",
+					"entityId": "A26",
+					"name": "Home Maintenance",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A23",
+					"sortableIndex": 1879048191,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-91",
+					"entityId": "A27",
+					"name": "Car Insurance",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A23",
+					"sortableIndex": 2013265919,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-90",
+					"entityId": "A28",
+					"name": "Life Insurance",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A23",
+					"sortableIndex": 2080374783,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-89",
+					"entityId": "A29",
+					"name": "Health Insurance",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A23",
+					"sortableIndex": 2113929215,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-88",
+					"entityId": "A30",
+					"name": "Birthdays",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A23",
+					"sortableIndex": 2130706431,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-87",
+					"entityId": "A31",
+					"name": "Christmas",
+					"entityType": "category"
+				}
+			],
+			"sortableIndex": 2113929215,
+			"type": "OUTFLOW",
+			"isTombstone": true,
+			"entityVersion": "A-95",
+			"entityId": "A23",
+			"name": "Rainy Day Funds",
+			"entityType": "masterCategory",
+			"expanded": true
+		},
+		{
+			"deleteable": true,
+			"subCategories": [
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A32",
+					"sortableIndex": 0,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-97",
+					"entityId": "A33",
+					"name": "Car Replacement",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A32",
+					"sortableIndex": 1073741823,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-96",
+					"entityId": "A34",
+					"name": "Vacation",
+					"entityType": "category"
+				}
+			],
+			"sortableIndex": 2130706431,
+			"type": "OUTFLOW",
+			"isTombstone": true,
+			"entityVersion": "A-98",
+			"entityId": "A32",
+			"name": "Savings Goals",
+			"entityType": "masterCategory",
+			"expanded": true
+		},
+		{
+			"deleteable": true,
+			"subCategories": [
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A35",
+					"sortableIndex": 0,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-101",
+					"entityId": "A36",
+					"name": "Car Payment",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A35",
+					"sortableIndex": 1073741823,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-100",
+					"entityId": "A37",
+					"name": "Student Loan Payment",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "A35",
+					"sortableIndex": 1610612735,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-99",
+					"entityId": "A38",
+					"name": "Personal Loan Payment",
+					"entityType": "category"
+				}
+			],
+			"sortableIndex": 2139095039,
+			"type": "OUTFLOW",
+			"isTombstone": true,
+			"entityVersion": "A-102",
+			"entityId": "A35",
+			"name": "Debt",
+			"entityType": "masterCategory",
+			"expanded": true
+		},
+		{
+			"deleteable": true,
+			"subCategories": [
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "B16339FC-9C95-7881-5F38-843D363522B2",
+					"sortableIndex": 1073741823,
+					"type": "OUTFLOW",
+					"entityVersion": "A-185",
+					"note": "note for rent",
+					"entityId": "B988C739-E4C9-8036-CA52-843D631764CD",
+					"name": "Rent",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "B16339FC-9C95-7881-5F38-843D363522B2",
+					"sortableIndex": 1610612735,
+					"type": "OUTFLOW",
+					"entityVersion": "A-187",
+					"entityId": "4A60FACD-8328-819D-9892-753B4E92C81A",
+					"name": "Insurances",
+					"entityType": "category"
+				}
+			],
+			"sortableIndex": 1879048191,
+			"type": "OUTFLOW",
+			"entityVersion": "A-161",
+			"entityId": "B16339FC-9C95-7881-5F38-843D363522B2",
+			"name": "Fixed Costs",
+			"entityType": "masterCategory",
+			"expanded": true
+		},
+		{
+			"deleteable": true,
+			"subCategories": [
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "BF7831EA-8CAC-A3C0-E420-66A1254D658C",
+					"sortableIndex": 0,
+					"type": "OUTFLOW",
+					"entityVersion": "A-224",
+					"entityId": "28901741-CC63-3536-5068-66A125711653",
+					"name": "Restaurants",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "BF7831EA-8CAC-A3C0-E420-66A1254D658C",
+					"sortableIndex": 1073741823,
+					"type": "OUTFLOW",
+					"entityVersion": "A-239",
+					"entityId": "41253F13-FA30-979D-C24A-A3A379A63DE7",
+					"name": "Toiletries",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "BF7831EA-8CAC-A3C0-E420-66A1254D658C",
+					"sortableIndex": 1610612735,
+					"type": "OUTFLOW",
+					"entityVersion": "A-240",
+					"entityId": "732E598D-821B-4C4C-B0CA-A3A3D7186AAD",
+					"name": "Beverages",
+					"entityType": "category"
+				},
+				{
+					"cachedBalance": 0,
+					"masterCategoryId": "BF7831EA-8CAC-A3C0-E420-66A1254D658C",
+					"sortableIndex": 1879048191,
+					"type": "OUTFLOW",
+					"isTombstone": true,
+					"entityVersion": "A-262",
+					"entityId": "5405270C-83DF-F1BB-76D7-B22BF5E4413B",
+					"name": "Some Deleted Subcategory",
+					"entityType": "category"
+				}
+			],
+			"sortableIndex": 2013265919,
+			"type": "OUTFLOW",
+			"entityVersion": "A-222",
+			"entityId": "BF7831EA-8CAC-A3C0-E420-66A1254D658C",
+			"name": "Running Costs",
+			"entityType": "masterCategory",
+			"expanded": true
+		},
+		{
+			"deleteable": true,
+			"subCategories": [],
+			"sortableIndex": 2080374783,
+			"type": "OUTFLOW",
+			"isTombstone": true,
+			"entityVersion": "A-255",
+			"entityId": "7AAFDC85-9004-7806-69E8-85DE54041591",
+			"name": "Some old master category (Hidden)",
+			"entityType": "masterCategory",
+			"expanded": true
+		},
+		{
+			"deleteable": true,
+			"subCategories": null,
+			"sortableIndex": 1744830463,
+			"type": "OUTFLOW",
+			"isTombstone": true,
+			"entityVersion": "A-258",
+			"entityId": "A8E1A52A-4A1D-6862-FA16-B22BE17503D6",
+			"name": "New Master Category",
+			"entityType": "masterCategory",
+			"expanded": true
+		},
+		{
+			"deleteable": true,
+			"subCategories": null,
+			"sortableIndex": 1744830463,
+			"type": "OUTFLOW",
+			"isTombstone": true,
+			"entityVersion": "A-264",
+			"entityId": "A2899064-65AC-9A46-53D9-B22C4E192A59",
+			"name": "Some deleted master category",
+			"entityType": "masterCategory",
+			"expanded": true
+		}
+	],
+	"scheduledTransactions": [
+		{
+			"payeeId": "E8C1D7B4-F18A-3FF7-8A69-843DD2629BBD",
+			"entityType": "scheduledTransaction",
+			"accountId": "E640A420-6FEA-5D9D-9128-66A1D1D70591",
+			"frequency": "Monthly",
+			"cleared": "Uncleared",
+			"twiceAMonthStartDay": 0,
+			"amount": 1000,
+			"date": "2022-10-25",
+			"accepted": true,
+			"categoryId": "Category/__DeferredIncome__",
+			"entityVersion": "A-227",
+			"entityId": "19BD11E4-9302-6448-629E-753ABC9E7722"
+		},
+		{
+			"payeeId": "FD50AF20-7C5D-38C7-1E75-753B8030CBA2",
+			"entityType": "scheduledTransaction",
+			"accountId": "E640A420-6FEA-5D9D-9128-66A1D1D70591",
+			"frequency": "Yearly",
+			"cleared": "Uncleared",
+			"twiceAMonthStartDay": 0,
+			"amount": -72.5,
+			"date": "2022-10-19",
+			"accepted": true,
+			"categoryId": "4A60FACD-8328-819D-9892-753B4E92C81A",
+			"memo": "Yearly liability insurance",
+			"entityVersion": "A-190",
+			"entityId": "DA741AE1-EB14-A519-2F1D-753AFDFAF038"
+		},
+		{
+			"payeeId": "25A421B8-B860-B5C3-C9F7-84631E6BDB42",
+			"entityType": "scheduledTransaction",
+			"accountId": "14960788-5E84-761E-CEAB-843CC3BC16F5",
+			"frequency": "Weekly",
+			"cleared": "Uncleared",
+			"twiceAMonthStartDay": 0,
+			"amount": -5,
+			"date": "2022-10-19",
+			"accepted": true,
+			"categoryId": "28901741-CC63-3536-5068-66A125711653",
+			"memo": "Ich hab 'ne Zwiebel auf dem Kopf",
+			"entityVersion": "A-200",
+			"entityId": "B9923864-ABE1-EE96-694F-753C7EBE66A4"
+		}
+	],
+	"accountMappings": [],
+	"payees": [
+		{
+			"targetAccountId": "14960788-5E84-761E-CEAB-843CC3BC16F5",
+			"autoFillCategoryId": null,
+			"autoFillMemo": "",
+			"autoFillAmount": -200,
+			"enabled": true,
+			"entityVersion": "A-208",
+			"renameConditions": null,
+			"entityId": "Payee/Transfer:14960788-5E84-761E-CEAB-843CC3BC16F5",
+			"locations": null,
+			"entityType": "payee",
+			"name": "Transfer : Cash"
+		},
+		{
+			"autoFillCategoryId": null,
+			"autoFillMemo": null,
+			"autoFillAmount": 0,
+			"enabled": false,
+			"entityVersion": "A-67",
+			"renameConditions": null,
+			"entityId": "4256A548-2572-B2CD-0860-843CC3CD8D38",
+			"locations": null,
+			"entityType": "payee",
+			"name": "Starting Balance"
+		},
+		{
+			"autoFillCategoryId": "Category/__ImmediateIncome__",
+			"autoFillMemo": "Salary",
+			"autoFillAmount": 1000,
+			"enabled": true,
+			"entityVersion": "A-212",
+			"renameConditions": [
+				{
+					"operand": "Employer",
+					"parentPayeeId": "E8C1D7B4-F18A-3FF7-8A69-843DD2629BBD",
+					"isTombstone": true,
+					"entityVersion": "A-196",
+					"operator": "Is",
+					"entityId": "62BA8597-0F1D-6F4D-8425-753BE93C3452",
+					"entityType": "payeeStringCondition"
+				},
+				{
+					"operand": "Employer",
+					"parentPayeeId": "E8C1D7B4-F18A-3FF7-8A69-843DD2629BBD",
+					"entityVersion": "A-197",
+					"operator": "Is",
+					"entityId": "EF778A34-071F-B264-571F-753C35B3E9F8",
+					"entityType": "payeeStringCondition"
+				}
+			],
+			"entityId": "E8C1D7B4-F18A-3FF7-8A69-843DD2629BBD",
+			"locations": null,
+			"entityType": "payee",
+			"name": "Company Name"
+		},
+		{
+			"autoFillCategoryId": "C4AAAB5C-548F-7855-46F9-843D4C631ABC",
+			"autoFillMemo": "",
+			"autoFillAmount": -20,
+			"enabled": true,
+			"entityVersion": "A-116",
+			"renameConditions": null,
+			"entityId": "3139A659-EAA9-846C-3F36-845CDB81C55E",
+			"locations": null,
+			"entityType": "payee",
+			"name": "Grocery Store"
+		},
+		{
+			"autoFillCategoryId": "B988C739-E4C9-8036-CA52-843D631764CD",
+			"autoFillMemo": "Why does my Kebap person pay my rent?",
+			"autoFillAmount": 10,
+			"enabled": true,
+			"entityVersion": "A-210",
+			"renameConditions": null,
+			"entityId": "25A421B8-B860-B5C3-C9F7-84631E6BDB42",
+			"locations": null,
+			"entityType": "payee",
+			"name": "Döner"
+		},
+		{
+			"targetAccountId": "E640A420-6FEA-5D9D-9128-66A1D1D70591",
+			"autoFillCategoryId": null,
+			"autoFillMemo": null,
+			"autoFillAmount": 0,
+			"enabled": true,
+			"entityVersion": "A-164",
+			"renameConditions": null,
+			"entityId": "Payee/Transfer:E640A420-6FEA-5D9D-9128-66A1D1D70591",
+			"locations": null,
+			"entityType": "payee",
+			"name": "Transfer : Checking"
+		},
+		{
+			"autoFillCategoryId": null,
+			"autoFillMemo": null,
+			"autoFillAmount": 0,
+			"enabled": true,
+			"entityVersion": "A-189",
+			"renameConditions": null,
+			"entityId": "FD50AF20-7C5D-38C7-1E75-753B8030CBA2",
+			"locations": null,
+			"entityType": "payee",
+			"name": "Insurance"
+		},
+		{
+			"autoFillCategoryId": "Category/__ImmediateIncome__",
+			"autoFillMemo": null,
+			"autoFillAmount": 0,
+			"enabled": true,
+			"isTombstone": true,
+			"entityVersion": "A-195",
+			"renameConditions": null,
+			"entityId": "1A855BF7-F175-44C5-F0A0-753C0B3AD139",
+			"locations": null,
+			"entityType": "payee",
+			"name": "Employer"
+		},
+		{
+			"targetAccountId": "722E5112-E43F-0558-BFAD-7581E452BEF6",
+			"autoFillCategoryId": null,
+			"autoFillMemo": null,
+			"autoFillAmount": 0,
+			"enabled": false,
+			"entityVersion": "A-219",
+			"renameConditions": null,
+			"entityId": "Payee/Transfer:722E5112-E43F-0558-BFAD-7581E452BEF6",
+			"locations": null,
+			"entityType": "payee",
+			"name": "Transfer : Deleted Account"
+		},
+		{
+			"targetAccountId": "BD495219-9D21-5B84-0116-B2570214B439",
+			"autoFillCategoryId": null,
+			"autoFillMemo": null,
+			"autoFillAmount": 0,
+			"enabled": false,
+			"entityVersion": "A-269",
+			"renameConditions": null,
+			"entityId": "Payee/Transfer:BD495219-9D21-5B84-0116-B2570214B439",
+			"locations": null,
+			"entityType": "payee",
+			"name": "Transfer : Starting Balance Tester"
+		}
+	]
+}

--- a/testdata/wrong-name.json
+++ b/testdata/wrong-name.json
@@ -1,0 +1,24 @@
+{
+  "accounts": [],
+  "budgetMetaData": {
+    "dateLocale": "en_US",
+    "budgetType": "Personal",
+    "strictBudget": "TRUE",
+    "entityVersion": "A-181",
+    "currencyISOSymbol": null,
+    "entityId": "A2",
+    "entityType": "budgetMetaData",
+    "currencyLocale": "en_US"
+  },
+  "transactions": [],
+  "monthlyBudgets": [],
+  "fileMetaData": {
+    "currentKnowledge": "A-264",
+    "budgetDataVersion": "4.2",
+    "entityType": "fileMetaData"
+  },
+  "masterCategories": [],
+  "scheduledTransactions": [],
+  "accountMappings": [],
+  "payees": []
+}


### PR DESCRIPTION
This adds the `/v1/import` endpoint which enables the importing of YNAB 4 budgets. Please read through [the import documentation](https://github.com/envelope-zero/backend/blob/275b5a3032d142b0b97a266ce2750863078a07a0/docs/import.md) to understand the current state of importing and supported features.

Resolves #369. 
