### PR TITLE
chore(renovate): automerge digest updates, too

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,7 +55,7 @@
         "dockerfile",
         "regex"
       ],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true
     },
     {


### PR DESCRIPTION
The x/exp modules used get digest updates. Those should be automerged, too.
