### PR TITLE
feat: add new endpoints for allocation setting/deleting of a whole month

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -984,7 +984,7 @@ const docTemplate = `{
                 }
             },
             "options": {
-                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs. **Use GET /month endpoint with month and budgetId query parameters instead.**",
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs. **Use OPTIONS /month endpoint with month and budgetId query parameters instead.**",
                 "tags": [
                     "Budgets"
                 ],
@@ -1030,11 +1030,12 @@ const docTemplate = `{
         },
         "/v1/budgets/{budgetId}/{month}/allocations": {
             "post": {
-                "description": "Sets allocations for a month for all envelopes that do not have an allocation yet",
+                "description": "Sets allocations for a month for all envelopes that do not have an allocation yet. **Use POST /month endpoint with month and budgetId query parameters instead.**",
                 "tags": [
                     "Budgets"
                 ],
                 "summary": "Set allocations for a month",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1079,11 +1080,12 @@ const docTemplate = `{
                 }
             },
             "delete": {
-                "description": "Deletes all allocation for the specified month",
+                "description": "Deletes all allocation for the specified month. **Use DELETE /month endpoint with month and budgetId query parameters instead.**",
                 "tags": [
                     "Budgets"
                 ],
                 "summary": "Delete allocations for a month",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1119,11 +1121,12 @@ const docTemplate = `{
                 }
             },
             "options": {
-                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs. **Use OPTIONS /month endpoint with month and budgetId query parameters instead.**",
                 "tags": [
                     "Budgets"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1879,6 +1882,101 @@ const docTemplate = `{
                     }
                 }
             },
+            "post": {
+                "description": "Sets allocations for a month for all envelopes that do not have an allocation yet",
+                "tags": [
+                    "Months"
+                ],
+                "summary": "Set allocations for a month",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID formatted as string",
+                        "name": "budget",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The month in YYYY-MM format",
+                        "name": "month",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "Budget",
+                        "name": "mode",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.BudgetAllocationMode"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes all allocation for the specified month",
+                "tags": [
+                    "Months"
+                ],
+                "summary": "Delete allocations for a month",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID formatted as string",
+                        "name": "budget",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The month in YYYY-MM format",
+                        "name": "month",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
             "options": {
                 "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs.",
                 "tags": [
@@ -2444,19 +2542,19 @@ const docTemplate = `{
                     "example": "https://example.com/api/v1/envelopes?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"
                 },
                 "groupedMonth": {
-                    "description": "This 'YYYY-MM' for clients to replace with the actual year and month.",
+                    "description": "This uses 'YYYY-MM' for clients to replace with the actual year and month.",
                     "type": "string",
-                    "example": "https://example.com/api/v1/month?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf\u0026month=YYYY-MM"
+                    "example": "https://example.com/api/v1/months?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf\u0026month=YYYY-MM"
                 },
                 "month": {
-                    "description": "This 'YYYY-MM' for clients to replace with the actual year and month.",
+                    "description": "This uses 'YYYY-MM' for clients to replace with the actual year and month.",
                     "type": "string",
                     "example": "https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/YYYY-MM"
                 },
                 "monthAllocations": {
                     "description": "This uses 'YYYY-MM' for clients to replace with the actual year and month.",
                     "type": "string",
-                    "example": "https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/YYYY-MM/allocations"
+                    "example": "https://example.com/api/v1/months?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf\u0026month=YYYY-MM"
                 },
                 "self": {
                     "type": "string",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -972,7 +972,7 @@
                 }
             },
             "options": {
-                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs. **Use GET /month endpoint with month and budgetId query parameters instead.**",
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs. **Use OPTIONS /month endpoint with month and budgetId query parameters instead.**",
                 "tags": [
                     "Budgets"
                 ],
@@ -1018,11 +1018,12 @@
         },
         "/v1/budgets/{budgetId}/{month}/allocations": {
             "post": {
-                "description": "Sets allocations for a month for all envelopes that do not have an allocation yet",
+                "description": "Sets allocations for a month for all envelopes that do not have an allocation yet. **Use POST /month endpoint with month and budgetId query parameters instead.**",
                 "tags": [
                     "Budgets"
                 ],
                 "summary": "Set allocations for a month",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1067,11 +1068,12 @@
                 }
             },
             "delete": {
-                "description": "Deletes all allocation for the specified month",
+                "description": "Deletes all allocation for the specified month. **Use DELETE /month endpoint with month and budgetId query parameters instead.**",
                 "tags": [
                     "Budgets"
                 ],
                 "summary": "Delete allocations for a month",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1107,11 +1109,12 @@
                 }
             },
             "options": {
-                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs. **Use OPTIONS /month endpoint with month and budgetId query parameters instead.**",
                 "tags": [
                     "Budgets"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1867,6 +1870,101 @@
                     }
                 }
             },
+            "post": {
+                "description": "Sets allocations for a month for all envelopes that do not have an allocation yet",
+                "tags": [
+                    "Months"
+                ],
+                "summary": "Set allocations for a month",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID formatted as string",
+                        "name": "budget",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The month in YYYY-MM format",
+                        "name": "month",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "Budget",
+                        "name": "mode",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.BudgetAllocationMode"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes all allocation for the specified month",
+                "tags": [
+                    "Months"
+                ],
+                "summary": "Delete allocations for a month",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID formatted as string",
+                        "name": "budget",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The month in YYYY-MM format",
+                        "name": "month",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
             "options": {
                 "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs.",
                 "tags": [
@@ -2432,19 +2530,19 @@
                     "example": "https://example.com/api/v1/envelopes?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"
                 },
                 "groupedMonth": {
-                    "description": "This 'YYYY-MM' for clients to replace with the actual year and month.",
+                    "description": "This uses 'YYYY-MM' for clients to replace with the actual year and month.",
                     "type": "string",
-                    "example": "https://example.com/api/v1/month?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf\u0026month=YYYY-MM"
+                    "example": "https://example.com/api/v1/months?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf\u0026month=YYYY-MM"
                 },
                 "month": {
-                    "description": "This 'YYYY-MM' for clients to replace with the actual year and month.",
+                    "description": "This uses 'YYYY-MM' for clients to replace with the actual year and month.",
                     "type": "string",
                     "example": "https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/YYYY-MM"
                 },
                 "monthAllocations": {
                     "description": "This uses 'YYYY-MM' for clients to replace with the actual year and month.",
                     "type": "string",
-                    "example": "https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/YYYY-MM/allocations"
+                    "example": "https://example.com/api/v1/months?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf\u0026month=YYYY-MM"
                 },
                 "self": {
                     "type": "string",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -168,19 +168,19 @@ definitions:
         example: https://example.com/api/v1/envelopes?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf
         type: string
       groupedMonth:
-        description: This 'YYYY-MM' for clients to replace with the actual year and
-          month.
-        example: https://example.com/api/v1/month?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf&month=YYYY-MM
+        description: This uses 'YYYY-MM' for clients to replace with the actual year
+          and month.
+        example: https://example.com/api/v1/months?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf&month=YYYY-MM
         type: string
       month:
-        description: This 'YYYY-MM' for clients to replace with the actual year and
-          month.
+        description: This uses 'YYYY-MM' for clients to replace with the actual year
+          and month.
         example: https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/YYYY-MM
         type: string
       monthAllocations:
         description: This uses 'YYYY-MM' for clients to replace with the actual year
           and month.
-        example: https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/YYYY-MM/allocations
+        example: https://example.com/api/v1/months?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf&month=YYYY-MM
         type: string
       self:
         example: https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf
@@ -1357,8 +1357,8 @@ paths:
     options:
       deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
-        allowed HTTP verbs. **Use GET /month endpoint with month and budgetId query
-        parameters instead.**
+        allowed HTTP verbs. **Use OPTIONS /month endpoint with month and budgetId
+        query parameters instead.**
       parameters:
       - description: ID formatted as string
         in: path
@@ -1388,7 +1388,9 @@ paths:
       - Budgets
   /v1/budgets/{budgetId}/{month}/allocations:
     delete:
-      description: Deletes all allocation for the specified month
+      deprecated: true
+      description: Deletes all allocation for the specified month. **Use DELETE /month
+        endpoint with month and budgetId query parameters instead.**
       parameters:
       - description: The month in YYYY-MM format
         in: path
@@ -1415,8 +1417,10 @@ paths:
       tags:
       - Budgets
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
-        allowed HTTP verbs
+        allowed HTTP verbs. **Use OPTIONS /month endpoint with month and budgetId
+        query parameters instead.**
       parameters:
       - description: ID formatted as string
         in: path
@@ -1445,8 +1449,10 @@ paths:
       tags:
       - Budgets
     post:
+      deprecated: true
       description: Sets allocations for a month for all envelopes that do not have
-        an allocation yet
+        an allocation yet. **Use POST /month endpoint with month and budgetId query
+        parameters instead.**
       parameters:
       - description: The month in YYYY-MM format
         in: path
@@ -1933,6 +1939,35 @@ paths:
       tags:
       - Import
   /v1/months:
+    delete:
+      description: Deletes all allocation for the specified month
+      parameters:
+      - description: ID formatted as string
+        in: query
+        name: budget
+        required: true
+        type: string
+      - description: The month in YYYY-MM format
+        in: query
+        name: month
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Delete allocations for a month
+      tags:
+      - Months
     get:
       description: Returns data about a specific month.
       parameters:
@@ -1973,6 +2008,42 @@ paths:
         "204":
           description: No Content
       summary: Allowed HTTP verbs
+      tags:
+      - Months
+    post:
+      description: Sets allocations for a month for all envelopes that do not have
+        an allocation yet
+      parameters:
+      - description: ID formatted as string
+        in: query
+        name: budget
+        required: true
+        type: string
+      - description: The month in YYYY-MM format
+        in: query
+        name: month
+        required: true
+        type: string
+      - description: Budget
+        in: body
+        name: mode
+        required: true
+        schema:
+          $ref: '#/definitions/controllers.BudgetAllocationMode'
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Set allocations for a month
       tags:
       - Months
   /v1/transactions:

--- a/pkg/controllers/budget.go
+++ b/pkg/controllers/budget.go
@@ -32,9 +32,9 @@ type BudgetLinks struct {
 	Categories       string `json:"categories" example:"https://example.com/api/v1/categories?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"`
 	Envelopes        string `json:"envelopes" example:"https://example.com/api/v1/envelopes?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"`
 	Transactions     string `json:"transactions" example:"https://example.com/api/v1/transactions?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"`
-	Month            string `json:"month" example:"https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/YYYY-MM"`                        // This 'YYYY-MM' for clients to replace with the actual year and month.
-	GroupedMonth     string `json:"groupedMonth" example:"https://example.com/api/v1/month?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf&month=YYYY-MM"`      // This 'YYYY-MM' for clients to replace with the actual year and month.
-	MonthAllocations string `json:"monthAllocations" example:"https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/YYYY-MM/allocations"` // This uses 'YYYY-MM' for clients to replace with the actual year and month.
+	Month            string `json:"month" example:"https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/YYYY-MM"`                        // This uses 'YYYY-MM' for clients to replace with the actual year and month.
+	GroupedMonth     string `json:"groupedMonth" example:"https://example.com/api/v1/months?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf&month=YYYY-MM"`     // This uses 'YYYY-MM' for clients to replace with the actual year and month.
+	MonthAllocations string `json:"monthAllocations" example:"https://example.com/api/v1/months?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf&month=YYYY-MM"` // This uses 'YYYY-MM' for clients to replace with the actual year and month.
 }
 
 type BudgetMonthResponse struct {
@@ -117,7 +117,7 @@ func (co Controller) OptionsBudgetDetail(c *gin.Context) {
 }
 
 // @Summary     Allowed HTTP verbs
-// @Description Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs. **Use GET /month endpoint with month and budgetId query parameters instead.**
+// @Description Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs. **Use OPTIONS /month endpoint with month and budgetId query parameters instead.**
 // @Tags        Budgets
 // @Success     204
 // @Failure     400 {object} httperrors.HTTPError
@@ -148,7 +148,7 @@ func (co Controller) OptionsBudgetMonth(c *gin.Context) {
 }
 
 // @Summary     Allowed HTTP verbs
-// @Description Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
+// @Description Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs. **Use OPTIONS /month endpoint with month and budgetId query parameters instead.**
 // @Tags        Budgets
 // @Success     204
 // @Failure     400 {object} httperrors.HTTPError
@@ -158,6 +158,7 @@ func (co Controller) OptionsBudgetMonth(c *gin.Context) {
 // @Param       budgetId path     string true "ID formatted as string"
 // @Param       month    path     string true "The month in YYYY-MM format"
 // @Router      /v1/budgets/{budgetId}/{month}/allocations [options]
+// @Deprecated  true
 func (co Controller) OptionsBudgetMonthAllocations(c *gin.Context) {
 	p, err := uuid.Parse(c.Param("budgetId"))
 	if err != nil {
@@ -466,7 +467,7 @@ func (co Controller) DeleteBudget(c *gin.Context) {
 }
 
 // @Summary     Delete allocations for a month
-// @Description Deletes all allocation for the specified month
+// @Description Deletes all allocation for the specified month. **Use DELETE /month endpoint with month and budgetId query parameters instead.**
 // @Tags        Budgets
 // @Success     204
 // @Failure     400      {object} httperrors.HTTPError
@@ -474,6 +475,7 @@ func (co Controller) DeleteBudget(c *gin.Context) {
 // @Param       month    path     string true "The month in YYYY-MM format"
 // @Param       budgetId path     string true "Budget ID formatted as string"
 // @Router      /v1/budgets/{budgetId}/{month}/allocations [delete]
+// @Deprecated  true.
 func (co Controller) DeleteAllocationsMonth(c *gin.Context) {
 	budgetID, err := uuid.Parse(c.Param("budgetId"))
 	if err != nil {
@@ -520,7 +522,7 @@ func (co Controller) DeleteAllocationsMonth(c *gin.Context) {
 }
 
 // @Summary     Set allocations for a month
-// @Description Sets allocations for a month for all envelopes that do not have an allocation yet
+// @Description Sets allocations for a month for all envelopes that do not have an allocation yet. **Use POST /month endpoint with month and budgetId query parameters instead.**
 // @Tags        Budgets
 // @Success     204
 // @Failure     400      {object} httperrors.HTTPError
@@ -529,6 +531,7 @@ func (co Controller) DeleteAllocationsMonth(c *gin.Context) {
 // @Param       budgetId path     string               true "Budget ID formatted as string"
 // @Param       mode     body     BudgetAllocationMode true "Budget"
 // @Router      /v1/budgets/{budgetId}/{month}/allocations [post]
+// @Deprecated  true.
 func (co Controller) SetAllocationsMonth(c *gin.Context) {
 	budgetID, err := uuid.Parse(c.Param("budgetId"))
 	if err != nil {
@@ -646,7 +649,7 @@ func (co Controller) getBudgetObject(c *gin.Context, id uuid.UUID) (Budget, bool
 			Transactions:     fmt.Sprintf("%s/v1/transactions?budget=%s", c.GetString("baseURL"), resource.ID),
 			Month:            url + "/YYYY-MM",
 			GroupedMonth:     fmt.Sprintf("%s/v1/months?budget=%s&month=YYYY-MM", c.GetString("baseURL"), resource.ID),
-			MonthAllocations: url + "/YYYY-MM/allocations",
+			MonthAllocations: fmt.Sprintf("%s/v1/months?budget=%s&month=YYYY-MM", c.GetString("baseURL"), resource.ID),
 		},
 	}, true
 }

--- a/pkg/controllers/budget_test.go
+++ b/pkg/controllers/budget_test.go
@@ -76,26 +76,6 @@ func (suite *TestSuiteStandard) TestOptionsBudgetMonth() {
 	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
-func (suite *TestSuiteStandard) TestOptionsBudgetMonthAllocations() {
-	budgetAllocationsLink := suite.createTestBudget(suite.T(), models.BudgetCreate{}).Data.Links.MonthAllocations
-
-	recorder := test.Request(suite.controller, suite.T(), http.MethodOptions, strings.Replace(budgetAllocationsLink, "YYYY-MM", "1970-01", 1), "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
-	assert.Equal(suite.T(), recorder.Header().Get("allow"), "OPTIONS, DELETE")
-
-	// Bad Request for invalid UUID
-	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/budgets/nouuid/2022-01/allocations", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
-
-	// Bad Request for invalid months
-	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, budgetAllocationsLink, "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
-
-	// Not found for non-existing budget
-	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/budgets/059cdead-249f-4f94-8d29-16a80c6b4a09/2032-03/allocations", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
-}
-
 func (suite *TestSuiteStandard) TestGetBudgets() {
 	_ = suite.createTestBudget(suite.T(), models.BudgetCreate{})
 

--- a/pkg/httputil/options.go
+++ b/pkg/httputil/options.go
@@ -22,6 +22,16 @@ func OptionsGetPost(c *gin.Context) {
 	c.Render(http.StatusNoContent, render.JSON{})
 }
 
+func OptionsGetPostDelete(c *gin.Context) {
+	c.Header("allow", "OPTIONS, GET, POST, DELETE")
+	c.Render(http.StatusNoContent, render.JSON{})
+}
+
+func OptionsGetPostPatchDelete(c *gin.Context) {
+	c.Header("allow", "OPTIONS, GET, POST, PATCH, DELETE")
+	c.Render(http.StatusNoContent, render.JSON{})
+}
+
 func OptionsGetDelete(c *gin.Context) {
 	c.Header("allow", "OPTIONS, GET, DELETE")
 	c.Render(http.StatusNoContent, render.JSON{})

--- a/pkg/httputil/options_test.go
+++ b/pkg/httputil/options_test.go
@@ -38,6 +38,34 @@ func TestOptionsGetPost(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, w.Code)
 }
 
+func TestOptionsGetPostDelete(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", httputil.OptionsGetPostDelete)
+
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Host = "example.com"
+	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, "OPTIONS, GET, POST, DELETE", w.Header().Get("allow"))
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestOptionsGetPostPatchDelete(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/", httputil.OptionsGetPostPatchDelete)
+
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Host = "example.com"
+	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, "OPTIONS, GET, POST, PATCH, DELETE", w.Header().Get("allow"))
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
 func TestOptionsPost(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, r := gin.CreateTestContext(w)


### PR DESCRIPTION
This adds new endpoints that fit better into the overall structure of the API.

Deprecates the existing endpoints.

Resolves #358.
