### PR TITLE
refactor: remove unnecessary parameters from test helpers

### DIFF
--- a/pkg/controllers/account_test.go
+++ b/pkg/controllers/account_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (suite *TestSuiteStandard) createTestAccount(t *testing.T, c models.AccountCreate, expectedStatus ...int) controllers.AccountResponse {
+func (suite *TestSuiteStandard) createTestAccount(c models.AccountCreate, expectedStatus ...int) controllers.AccountResponse {
 	if c.BudgetID == uuid.Nil {
-		c.BudgetID = suite.createTestBudget(t, models.BudgetCreate{Name: "Testing budget"}).Data.ID
+		c.BudgetID = suite.createTestBudget(models.BudgetCreate{Name: "Testing budget"}).Data.ID
 	}
 
 	// Default to 200 OK as expected status
@@ -23,11 +23,11 @@ func (suite *TestSuiteStandard) createTestAccount(t *testing.T, c models.Account
 		expectedStatus = append(expectedStatus, http.StatusCreated)
 	}
 
-	r := test.Request(suite.controller, t, http.MethodPost, "http://example.com/v1/accounts", c)
-	test.AssertHTTPStatus(t, &r, expectedStatus...)
+	r := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/accounts", c)
+	suite.assertHTTPStatus(&r, expectedStatus...)
 
 	var a controllers.AccountResponse
-	test.DecodeResponse(t, &r, &a)
+	suite.decodeResponse(&r, &a)
 
 	return a
 }
@@ -36,7 +36,7 @@ func (suite *TestSuiteStandard) TestAccounts() {
 	suite.CloseDB()
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusInternalServerError)
+	suite.assertHTTPStatus(&recorder, http.StatusInternalServerError)
 	assert.Contains(suite.T(), test.DecodeError(suite.T(), recorder.Body.Bytes()), "There is a problem with the database connection")
 }
 
@@ -48,35 +48,35 @@ func (suite *TestSuiteStandard) TestOptionsAccount() {
 	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/accounts/NotParseableAsUUID", "")
 	assert.Equal(suite.T(), http.StatusBadRequest, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
 
-	path = suite.createTestAccount(suite.T(), models.AccountCreate{}).Data.Links.Self
+	path = suite.createTestAccount(models.AccountCreate{}).Data.Links.Self
 	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, path, "")
 	assert.Equal(suite.T(), http.StatusNoContent, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
 }
 
 func (suite *TestSuiteStandard) TestGetAccounts() {
-	_ = suite.createTestAccount(suite.T(), models.AccountCreate{})
+	_ = suite.createTestAccount(models.AccountCreate{})
 
 	var response controllers.AccountListResponse
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusOK)
-	test.DecodeResponse(suite.T(), &recorder, &response)
+	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	suite.decodeResponse(&recorder, &response)
 
 	assert.Len(suite.T(), response.Data, 1)
 }
 
 func (suite *TestSuiteStandard) TestGetAccountsInvalidQuery() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts?onBudget=NotABoolean", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts?budget=8593-not-a-uuid", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestGetAccountsFilter() {
-	b1 := suite.createTestBudget(suite.T(), models.BudgetCreate{})
-	b2 := suite.createTestBudget(suite.T(), models.BudgetCreate{})
+	b1 := suite.createTestBudget(models.BudgetCreate{})
+	b2 := suite.createTestBudget(models.BudgetCreate{})
 
-	a1 := suite.createTestAccount(suite.T(), models.AccountCreate{
+	a1 := suite.createTestAccount(models.AccountCreate{
 		Name:     "Exact Account Match",
 		Note:     "This is a specific note",
 		BudgetID: b1.Data.ID,
@@ -84,7 +84,7 @@ func (suite *TestSuiteStandard) TestGetAccountsFilter() {
 		External: false,
 	})
 
-	a2 := suite.createTestAccount(suite.T(), models.AccountCreate{
+	a2 := suite.createTestAccount(models.AccountCreate{
 		Name:     "External Account Filter",
 		Note:     "This is a specific note",
 		BudgetID: b2.Data.ID,
@@ -92,7 +92,7 @@ func (suite *TestSuiteStandard) TestGetAccountsFilter() {
 		External: true,
 	})
 
-	a3 := suite.createTestAccount(suite.T(), models.AccountCreate{
+	a3 := suite.createTestAccount(models.AccountCreate{
 		Name:     "External Account Filter",
 		Note:     "A different note",
 		BudgetID: b1.Data.ID,
@@ -119,8 +119,8 @@ func (suite *TestSuiteStandard) TestGetAccountsFilter() {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			var re controllers.BudgetListResponse
 			r := test.Request(suite.controller, t, http.MethodGet, fmt.Sprintf("/v1/accounts?%s", tt.query), "")
-			test.AssertHTTPStatus(t, &r, http.StatusOK)
-			test.DecodeResponse(t, &r, &re)
+			suite.assertHTTPStatus(&r, http.StatusOK)
+			suite.decodeResponse(&r, &re)
 
 			var accountNames []string
 			for _, d := range re.Data {
@@ -141,7 +141,7 @@ func (suite *TestSuiteStandard) TestGetAccountsFilter() {
 
 func (suite *TestSuiteStandard) TestNoAccountNotFound() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts/39633f90-3d9f-4b1e-ac24-c341c432a6e3", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestAccountInvalidIDs() {
@@ -149,59 +149,59 @@ func (suite *TestSuiteStandard) TestAccountInvalidIDs() {
 	 *  GET
 	 */
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts/-56", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts/notANumber", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts/23", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	/*
 	 * PATCH
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/accounts/-274", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/accounts/stringRandom", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	/*
 	 * DELETE
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/accounts/-274", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/accounts/stringRandom", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateAccount() {
-	_ = suite.createTestAccount(suite.T(), models.AccountCreate{Name: "Test account for creation"})
+	_ = suite.createTestAccount(models.AccountCreate{Name: "Test account for creation"})
 }
 
 func (suite *TestSuiteStandard) TestCreateAccountNoBudget() {
 	r := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/accounts", models.Account{})
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateBrokenAccount() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/accounts", `{ "createdAt": "New Account", "note": "More tests for accounts to ensure less brokenness something" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateAccountNoBody() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/accounts", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateAccountNonExistingBudget() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/accounts", models.AccountCreate{BudgetID: uuid.New()})
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestGetAccount() {
-	a := suite.createTestAccount(suite.T(), models.AccountCreate{})
+	a := suite.createTestAccount(models.AccountCreate{})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, a.Data.Links.Self, "")
 	assert.Equal(suite.T(), http.StatusOK, r.Code)
@@ -213,17 +213,17 @@ func (suite *TestSuiteStandard) TestGetAccountTransactionsNonExistingAccount() {
 }
 
 func (suite *TestSuiteStandard) TestUpdateAccount() {
-	a := suite.createTestAccount(suite.T(), models.AccountCreate{Name: "Original name", OnBudget: true})
+	a := suite.createTestAccount(models.AccountCreate{Name: "Original name", OnBudget: true})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodPatch, a.Data.Links.Self, map[string]any{
 		"name":     "Updated new account for testing",
 		"note":     "",
 		"onBudget": false,
 	})
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusOK)
+	suite.assertHTTPStatus(&r, http.StatusOK)
 
 	var u controllers.AccountResponse
-	test.DecodeResponse(suite.T(), &r, &u)
+	suite.decodeResponse(&r, &u)
 
 	assert.Equal(suite.T(), "Updated new account for testing", u.Data.Name)
 	assert.Equal(suite.T(), "", u.Data.Note)
@@ -231,17 +231,17 @@ func (suite *TestSuiteStandard) TestUpdateAccount() {
 }
 
 func (suite *TestSuiteStandard) TestUpdateAccountBrokenJSON() {
-	a := suite.createTestAccount(suite.T(), models.AccountCreate{
+	a := suite.createTestAccount(models.AccountCreate{
 		Name: "New Account",
 		Note: "More tests something something",
 	})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodPatch, a.Data.Links.Self, `{ "name": 2" }`)
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateAccountInvalidType() {
-	a := suite.createTestAccount(suite.T(), models.AccountCreate{
+	a := suite.createTestAccount(models.AccountCreate{
 		Name: "New Account",
 		Note: "More tests something something",
 	})
@@ -249,38 +249,38 @@ func (suite *TestSuiteStandard) TestUpdateAccountInvalidType() {
 	r := test.Request(suite.controller, suite.T(), http.MethodPatch, a.Data.Links.Self, map[string]any{
 		"name": 2,
 	})
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateAccountInvalidBudgetID() {
-	a := suite.createTestAccount(suite.T(), models.AccountCreate{
+	a := suite.createTestAccount(models.AccountCreate{
 		Name: "New Account",
 		Note: "More tests something something",
 	})
 
 	// Sets the BudgetID to uuid.Nil
 	r := test.Request(suite.controller, suite.T(), http.MethodPatch, a.Data.Links.Self, models.AccountCreate{})
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateNonExistingAccount() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/accounts/9b81de41-eead-451d-bc6b-31fceedd236c", models.AccountCreate{Name: "This account does not exist"})
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteAccountsAndEmptyList() {
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts", "")
 
 	var l controllers.AccountListResponse
-	test.DecodeResponse(suite.T(), &r, &l)
+	suite.decodeResponse(&r, &l)
 
 	for _, a := range l.Data {
 		r = test.Request(suite.controller, suite.T(), http.MethodDelete, a.Links.Self, "")
-		test.AssertHTTPStatus(suite.T(), &r, http.StatusNoContent)
+		suite.assertHTTPStatus(&r, http.StatusNoContent)
 	}
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts", "")
-	test.DecodeResponse(suite.T(), &r, &l)
+	suite.decodeResponse(&r, &l)
 
 	// Verify that the account list is an empty list, not null
 	assert.NotNil(suite.T(), l.Data)
@@ -289,14 +289,14 @@ func (suite *TestSuiteStandard) TestDeleteAccountsAndEmptyList() {
 
 func (suite *TestSuiteStandard) TestDeleteNonExistingAccount() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/accounts/77b70a75-4bb3-4d1d-90cf-5b7a61f452f5", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteAccountWithBody() {
-	a := suite.createTestAccount(suite.T(), models.AccountCreate{Name: "Delete me now!"})
+	a := suite.createTestAccount(models.AccountCreate{Name: "Delete me now!"})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodDelete, a.Data.Links.Self, models.AccountCreate{Name: "Some other account"})
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusNoContent)
+	suite.assertHTTPStatus(&r, http.StatusNoContent)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, a.Data.Links.Self, "")
 }

--- a/pkg/controllers/allocation_test.go
+++ b/pkg/controllers/allocation_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (suite *TestSuiteStandard) createTestAllocation(t *testing.T, c models.AllocationCreate, expectedStatus ...int) controllers.AllocationResponse {
+func (suite *TestSuiteStandard) createTestAllocation(c models.AllocationCreate, expectedStatus ...int) controllers.AllocationResponse {
 	if c.EnvelopeID == uuid.Nil {
-		c.EnvelopeID = suite.createTestEnvelope(t, models.EnvelopeCreate{Name: "Transaction Test Envelope"}).Data.ID
+		c.EnvelopeID = suite.createTestEnvelope(models.EnvelopeCreate{Name: "Transaction Test Envelope"}).Data.ID
 	}
 
 	// Default to 200 OK as expected status
@@ -24,11 +24,11 @@ func (suite *TestSuiteStandard) createTestAllocation(t *testing.T, c models.Allo
 		expectedStatus = append(expectedStatus, http.StatusCreated)
 	}
 
-	r := test.Request(suite.controller, t, http.MethodPost, "http://example.com/v1/allocations", c)
-	test.AssertHTTPStatus(t, &r, expectedStatus...)
+	r := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/allocations", c)
+	suite.assertHTTPStatus(&r, expectedStatus...)
 
 	var a controllers.AllocationResponse
-	test.DecodeResponse(t, &r, &a)
+	suite.decodeResponse(&r, &a)
 
 	return a
 }
@@ -37,7 +37,7 @@ func (suite *TestSuiteStandard) TestAllocations() {
 	suite.CloseDB()
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/allocations", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusInternalServerError)
+	suite.assertHTTPStatus(&recorder, http.StatusInternalServerError)
 	assert.Contains(suite.T(), test.DecodeError(suite.T(), recorder.Body.Bytes()), "There is a problem with the database connection")
 }
 
@@ -49,13 +49,13 @@ func (suite *TestSuiteStandard) TestOptionsAllocation() {
 	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/allocations/NotParseableAsUUID", "")
 	assert.Equal(suite.T(), http.StatusBadRequest, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
 
-	path = suite.createTestAllocation(suite.T(), models.AllocationCreate{Month: time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC)}).Data.Links.Self
+	path = suite.createTestAllocation(models.AllocationCreate{Month: time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC)}).Data.Links.Self
 	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, path, "")
 	assert.Equal(suite.T(), http.StatusNoContent, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
 }
 
 func (suite *TestSuiteStandard) TestGetAllocations() {
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	_ = suite.createTestAllocation(models.AllocationCreate{
 		Month:  time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount: decimal.NewFromFloat(20.99),
 	})
@@ -63,9 +63,9 @@ func (suite *TestSuiteStandard) TestGetAllocations() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/allocations", "")
 
 	var response controllers.AllocationListResponse
-	test.DecodeResponse(suite.T(), &recorder, &response)
+	suite.decodeResponse(&recorder, &response)
 
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusOK)
+	suite.assertHTTPStatus(&recorder, http.StatusOK)
 	assert.Len(suite.T(), response.Data, 1)
 	assert.Equal(suite.T(), time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC), response.Data[0].Month)
 
@@ -73,27 +73,27 @@ func (suite *TestSuiteStandard) TestGetAllocations() {
 		assert.Fail(suite.T(), "Allocation amount does not equal 20.99", response.Data[0].Amount)
 	}
 
-	assert.LessOrEqual(suite.T(), time.Since(response.Data[0].CreatedAt), test.TOLERANCE)
-	assert.LessOrEqual(suite.T(), time.Since(response.Data[0].UpdatedAt), test.TOLERANCE)
+	assert.LessOrEqual(suite.T(), time.Since(response.Data[0].CreatedAt), tolerance)
+	assert.LessOrEqual(suite.T(), time.Since(response.Data[0].UpdatedAt), tolerance)
 }
 
 func (suite *TestSuiteStandard) TestGetAllocationsFilter() {
-	e1 := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{})
-	e2 := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{})
+	e1 := suite.createTestEnvelope(models.EnvelopeCreate{})
+	e2 := suite.createTestEnvelope(models.EnvelopeCreate{})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	_ = suite.createTestAllocation(models.AllocationCreate{
 		EnvelopeID: e1.Data.ID,
 		Month:      time.Date(2018, 9, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(314.1592),
 	})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	_ = suite.createTestAllocation(models.AllocationCreate{
 		EnvelopeID: e1.Data.ID,
 		Month:      time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(1371),
 	})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	_ = suite.createTestAllocation(models.AllocationCreate{
 		EnvelopeID: e2.Data.ID,
 		Month:      time.Date(2018, 9, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(1204),
@@ -114,8 +114,8 @@ func (suite *TestSuiteStandard) TestGetAllocationsFilter() {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			var re controllers.AllocationListResponse
 			r := test.Request(suite.controller, t, http.MethodGet, fmt.Sprintf("/v1/allocations?%s", tt.query), "")
-			test.AssertHTTPStatus(t, &r, http.StatusOK)
-			test.DecodeResponse(t, &r, &re)
+			suite.assertHTTPStatus(&r, http.StatusOK)
+			suite.decodeResponse(&r, &re)
 
 			assert.Equal(t, tt.len, len(re.Data), "Request ID: %s", r.Result().Header.Get("x-request-id"))
 		})
@@ -125,7 +125,7 @@ func (suite *TestSuiteStandard) TestGetAllocationsFilter() {
 func (suite *TestSuiteStandard) TestNoAllocationNotFound() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/allocations/f8b93ce2-309f-4e99-8886-6ab960df99c3", "")
 
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestGetAllocationsInvalidQuery() {
@@ -138,7 +138,7 @@ func (suite *TestSuiteStandard) TestGetAllocationsInvalidQuery() {
 	for _, tt := range tests {
 		suite.T().Run(tt, func(t *testing.T) {
 			recorder := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("http://example.com/v1/allocations?%s", tt), "")
-			test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+			suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 		})
 	}
 }
@@ -148,35 +148,35 @@ func (suite *TestSuiteStandard) TestAllocationInvalidIDs() {
 	 *  GET
 	 */
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/allocations/-56", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/allocations/notANumber", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/allocations/23", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	/*
 	 * PATCH
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/allocations/-274", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/allocations/stringRandom", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	/*
 	 * DELETE
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/allocations/-274", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/allocations/stringRandom", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateAllocation() {
-	a := suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	a := suite.createTestAllocation(models.AllocationCreate{
 		Month:  time.Date(2022, 10, 1, 0, 0, 0, 0, time.UTC),
 		Amount: decimal.NewFromFloat(15.42),
 	})
@@ -188,39 +188,39 @@ func (suite *TestSuiteStandard) TestCreateAllocation() {
 
 func (suite *TestSuiteStandard) TestCreateAllocationNoEnvelope() {
 	r := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/allocations", models.Allocation{})
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateBrokenAllocation() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/allocations", `{ "createdAt": "New Allocation" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateAllocationNonExistingEnvelope() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/allocations", models.AllocationCreate{EnvelopeID: uuid.New()})
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestCreateDuplicateAllocation() {
-	allocation := suite.createTestAllocation(suite.T(), models.AllocationCreate{Month: time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC)})
+	allocation := suite.createTestAllocation(models.AllocationCreate{Month: time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC)})
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/allocations", models.AllocationCreate{
 		EnvelopeID: allocation.Data.EnvelopeID,
 		Month:      allocation.Data.Month,
 	})
 
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateNonDuplicateAllocationSameMonth() {
-	e1 := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{})
-	e2 := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{})
+	e1 := suite.createTestEnvelope(models.EnvelopeCreate{})
+	e2 := suite.createTestEnvelope(models.EnvelopeCreate{})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	_ = suite.createTestAllocation(models.AllocationCreate{
 		Month:      time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC),
 		EnvelopeID: e1.Data.ID,
 	})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	_ = suite.createTestAllocation(models.AllocationCreate{
 		Month:      time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC),
 		EnvelopeID: e2.Data.ID,
 	})
@@ -228,11 +228,11 @@ func (suite *TestSuiteStandard) TestCreateNonDuplicateAllocationSameMonth() {
 
 func (suite *TestSuiteStandard) TestCreateAllocationNoBody() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/allocations", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestGetAllocation() {
-	a := suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	a := suite.createTestAllocation(models.AllocationCreate{
 		Month: time.Date(2022, 8, 1, 0, 0, 0, 0, time.UTC),
 	})
 
@@ -241,87 +241,87 @@ func (suite *TestSuiteStandard) TestGetAllocation() {
 }
 
 func (suite *TestSuiteStandard) TestUpdateAllocation() {
-	a := suite.createTestAllocation(suite.T(), models.AllocationCreate{Month: time.Date(2100, 6, 1, 0, 0, 0, 0, time.UTC)})
+	a := suite.createTestAllocation(models.AllocationCreate{Month: time.Date(2100, 6, 1, 0, 0, 0, 0, time.UTC)})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodPatch, a.Data.Links.Self, map[string]any{
 		"month": time.Date(2022, 6, 1, 0, 0, 0, 0, time.UTC),
 	})
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusOK)
+	suite.assertHTTPStatus(&r, http.StatusOK)
 
 	var updatedAllocation controllers.AllocationResponse
-	test.DecodeResponse(suite.T(), &r, &updatedAllocation)
+	suite.decodeResponse(&r, &updatedAllocation)
 
 	assert.Equal(suite.T(), 2022, updatedAllocation.Data.Month.Year())
 }
 
 func (suite *TestSuiteStandard) TestUpdateAllocationZeroValues() {
-	a := suite.createTestAllocation(suite.T(), models.AllocationCreate{Month: time.Date(2100, 8, 1, 0, 0, 0, 0, time.UTC)})
+	a := suite.createTestAllocation(models.AllocationCreate{Month: time.Date(2100, 8, 1, 0, 0, 0, 0, time.UTC)})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodPatch, a.Data.Links.Self, map[string]any{
 		"month": time.Date(0, 8, 1, 0, 0, 0, 0, time.UTC),
 	})
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusOK)
+	suite.assertHTTPStatus(&r, http.StatusOK)
 
 	var updatedAllocation controllers.AllocationResponse
-	test.DecodeResponse(suite.T(), &r, &updatedAllocation)
+	suite.decodeResponse(&r, &updatedAllocation)
 
 	assert.Equal(suite.T(), 0, updatedAllocation.Data.Month.Year(), "Year is not updated correctly")
 }
 
 func (suite *TestSuiteStandard) TestUpdateAllocationBrokenJSON() {
-	a := suite.createTestAllocation(suite.T(), models.AllocationCreate{Month: time.Date(2054, 5, 1, 0, 0, 0, 0, time.UTC)})
+	a := suite.createTestAllocation(models.AllocationCreate{Month: time.Date(2054, 5, 1, 0, 0, 0, 0, time.UTC)})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodPatch, a.Data.Links.Self, `{ "name": 2" }`)
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateAllocationInvalidType() {
-	a := suite.createTestAllocation(suite.T(), models.AllocationCreate{Month: time.Date(2062, 3, 1, 0, 0, 0, 0, time.UTC)})
+	a := suite.createTestAllocation(models.AllocationCreate{Month: time.Date(2062, 3, 1, 0, 0, 0, 0, time.UTC)})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodPatch, a.Data.Links.Self, map[string]any{
 		"month": "A long time ago in a galaxy far, far away",
 	})
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateAllocationInvalidEnvelopeID() {
-	a := suite.createTestAllocation(suite.T(), models.AllocationCreate{Month: time.Date(2099, 11, 1, 0, 0, 0, 0, time.UTC)})
+	a := suite.createTestAllocation(models.AllocationCreate{Month: time.Date(2099, 11, 1, 0, 0, 0, 0, time.UTC)})
 
 	// Sets the EnvelopeID to uuid.Nil by not specifying it
 	r := test.Request(suite.controller, suite.T(), http.MethodPatch, a.Data.Links.Self, models.AllocationCreate{Month: time.Date(2099, 11, 1, 0, 0, 0, 0, time.UTC)})
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateNonExistingAllocation() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/allocations/df684988-31df-444c-8aaa-b53195d55d6e", models.AllocationCreate{Month: time.Date(2142, 3, 1, 0, 0, 0, 0, time.UTC)})
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteAllocation() {
-	e := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{})
-	a := suite.createTestAllocation(suite.T(), models.AllocationCreate{Month: time.Date(2058, 7, 1, 0, 0, 0, 0, time.UTC), EnvelopeID: e.Data.ID})
+	e := suite.createTestEnvelope(models.EnvelopeCreate{})
+	a := suite.createTestAllocation(models.AllocationCreate{Month: time.Date(2058, 7, 1, 0, 0, 0, 0, time.UTC), EnvelopeID: e.Data.ID})
 	r := test.Request(suite.controller, suite.T(), http.MethodDelete, a.Data.Links.Self, "")
 
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusNoContent)
+	suite.assertHTTPStatus(&r, http.StatusNoContent)
 
 	// Regression Test: Verify that allocations are hard deleted instantly to avoid problems
 	// with the UNIQUE(id,month)
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{Month: time.Date(2058, 7, 1, 0, 0, 0, 0, time.UTC), EnvelopeID: e.Data.ID})
+	_ = suite.createTestAllocation(models.AllocationCreate{Month: time.Date(2058, 7, 1, 0, 0, 0, 0, time.UTC), EnvelopeID: e.Data.ID})
 }
 
 func (suite *TestSuiteStandard) TestDeleteNonExistingAllocation() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/allocations/34ac51a7-431c-454b-ba29-feaefeae70d5", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteAllocationWithBody() {
-	a := suite.createTestAllocation(suite.T(), models.AllocationCreate{Month: time.Date(2067, 3, 1, 0, 0, 0, 0, time.UTC)})
+	a := suite.createTestAllocation(models.AllocationCreate{Month: time.Date(2067, 3, 1, 0, 0, 0, 0, time.UTC)})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodDelete, a.Data.Links.Self, models.AllocationCreate{Month: time.Date(2067, 3, 1, 0, 0, 0, 0, time.UTC)})
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusNoContent)
+	suite.assertHTTPStatus(&r, http.StatusNoContent)
 }
 
 func (suite *TestSuiteStandard) TestDeleteNullAllocation() {
 	r := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/allocations/00000000-0000-0000-0000-000000000000", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 }

--- a/pkg/controllers/budget_test.go
+++ b/pkg/controllers/budget_test.go
@@ -15,31 +15,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (suite *TestSuiteStandard) createTestBudget(t *testing.T, c models.BudgetCreate, expectedStatus ...int) controllers.BudgetResponse {
+func (suite *TestSuiteStandard) createTestBudget(c models.BudgetCreate, expectedStatus ...int) controllers.BudgetResponse {
 	// Default to 200 OK as expected status
 	if len(expectedStatus) == 0 {
 		expectedStatus = append(expectedStatus, http.StatusCreated)
 	}
 
-	r := test.Request(suite.controller, t, http.MethodPost, "http://example.com/v1/budgets", c)
-	test.AssertHTTPStatus(t, &r, expectedStatus...)
+	r := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", c)
+	suite.assertHTTPStatus(&r, expectedStatus...)
 
 	var a controllers.BudgetResponse
-	test.DecodeResponse(t, &r, &a)
+	suite.decodeResponse(&r, &a)
 
 	return a
 }
 
 func (suite *TestSuiteStandard) TestCreateBudgetNoDB() {
 	suite.CloseDB()
-	suite.createTestBudget(suite.T(), models.BudgetCreate{}, http.StatusInternalServerError)
+	suite.createTestBudget(models.BudgetCreate{}, http.StatusInternalServerError)
 }
 
 func (suite *TestSuiteStandard) TestBudgets() {
 	suite.CloseDB()
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/budgets", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusInternalServerError)
+	suite.assertHTTPStatus(&recorder, http.StatusInternalServerError)
 	assert.Contains(suite.T(), test.DecodeError(suite.T(), recorder.Body.Bytes()), "There is a problem with the database connection")
 }
 
@@ -51,63 +51,63 @@ func (suite *TestSuiteStandard) TestOptionsBudget() {
 	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/budgets/NotParseableAsUUID", "")
 	assert.Equal(suite.T(), http.StatusBadRequest, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
 
-	path = suite.createTestBudget(suite.T(), models.BudgetCreate{}).Data.Links.Self
+	path = suite.createTestBudget(models.BudgetCreate{}).Data.Links.Self
 	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, path, "")
 	assert.Equal(suite.T(), http.StatusNoContent, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
 }
 
 func (suite *TestSuiteStandard) TestOptionsBudgetMonth() {
-	budgetLink := suite.createTestBudget(suite.T(), models.BudgetCreate{}).Data.Links.Month
+	budgetLink := suite.createTestBudget(models.BudgetCreate{}).Data.Links.Month
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodOptions, strings.Replace(budgetLink, "YYYY-MM", "1970-01", 1), "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
+	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
 	assert.Equal(suite.T(), recorder.Header().Get("allow"), "OPTIONS, GET")
 
 	// Bad Request for invalid UUID
 	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/budgets/nouuid/2022-01", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 
 	// Bad Request for invalid month
 	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, budgetLink, "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 
 	// Not found for non-existing budget
 	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/budgets/5b95e1a9-522d-4a36-9074-32f7c2ff0513/1980-06", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestGetBudgets() {
-	_ = suite.createTestBudget(suite.T(), models.BudgetCreate{})
+	_ = suite.createTestBudget(models.BudgetCreate{})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/budgets", "")
 
 	var response controllers.BudgetListResponse
-	test.DecodeResponse(suite.T(), &recorder, &response)
+	suite.decodeResponse(&recorder, &response)
 
 	assert.Equal(suite.T(), 200, recorder.Code)
 	assert.Len(suite.T(), response.Data, 1)
 
 	diff := time.Since(response.Data[0].CreatedAt)
-	assert.LessOrEqual(suite.T(), diff, test.TOLERANCE)
+	assert.LessOrEqual(suite.T(), diff, tolerance)
 
 	diff = time.Since(response.Data[0].UpdatedAt)
-	assert.LessOrEqual(suite.T(), diff, test.TOLERANCE)
+	assert.LessOrEqual(suite.T(), diff, tolerance)
 }
 
 func (suite *TestSuiteStandard) TestGetBudgetsFilter() {
-	_ = suite.createTestBudget(suite.T(), models.BudgetCreate{
+	_ = suite.createTestBudget(models.BudgetCreate{
 		Name:     "Exact String Match",
 		Note:     "This is a specific note",
 		Currency: "",
 	})
 
-	_ = suite.createTestBudget(suite.T(), models.BudgetCreate{
+	_ = suite.createTestBudget(models.BudgetCreate{
 		Name:     "",
 		Note:     "This is a specific note",
 		Currency: "$",
 	})
 
-	_ = suite.createTestBudget(suite.T(), models.BudgetCreate{
+	_ = suite.createTestBudget(models.BudgetCreate{
 		Name:     "Another String",
 		Note:     "A different note",
 		Currency: "€",
@@ -132,8 +132,8 @@ func (suite *TestSuiteStandard) TestGetBudgetsFilter() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			r := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("http://example.com/v1/budgets?%s", tt.query), "")
-			test.AssertHTTPStatus(suite.T(), &r, http.StatusOK)
-			test.DecodeResponse(suite.T(), &r, &re)
+			suite.assertHTTPStatus(&r, http.StatusOK)
+			suite.decodeResponse(&r, &re)
 			assert.Equal(suite.T(), tt.len, len(re.Data))
 		})
 	}
@@ -142,7 +142,7 @@ func (suite *TestSuiteStandard) TestGetBudgetsFilter() {
 func (suite *TestSuiteStandard) TestNoBudgetNotFound() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/budgets/65064e6f-04b4-46e0-8bbc-88c96c6b21bd", "")
 
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestBudgetInvalidIDs() {
@@ -150,86 +150,86 @@ func (suite *TestSuiteStandard) TestBudgetInvalidIDs() {
 	 *  GET
 	 */
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/budgets/-56", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/budgets/notANumber", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/budgets/23", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/budgets/d19a622f-broken-uuid/2022-01", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	/*
 	 * PATCH
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/budgets/-274", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/budgets/stringRandom", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	/*
 	 * DELETE
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/budgets/-274", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/budgets/stringRandom", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateBudget() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", `{ "name": "New Budget", "note": "More tests something something" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusCreated)
+	suite.assertHTTPStatus(&recorder, http.StatusCreated)
 
 	var budgetObject, savedObject controllers.BudgetResponse
-	test.DecodeResponse(suite.T(), &recorder, &budgetObject)
+	suite.decodeResponse(&recorder, &budgetObject)
 
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, budgetObject.Data.Links.Self, "")
-	test.DecodeResponse(suite.T(), &recorder, &savedObject)
+	suite.decodeResponse(&recorder, &savedObject)
 
 	assert.Equal(suite.T(), savedObject, budgetObject)
 }
 
 func (suite *TestSuiteStandard) TestCreateBrokenBudget() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", `{ "createdAt": "New Budget", "note": "More tests something something" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateBudgetNoBody() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 // TestBudgetMonth verifies that the monthly calculations are correct.
 func (suite *TestSuiteStandard) TestBudgetMonth() {
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
-	envelope := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID, Name: "Utilities"})
-	account := suite.createTestAccount(suite.T(), models.AccountCreate{BudgetID: budget.Data.ID})
-	externalAccount := suite.createTestAccount(suite.T(), models.AccountCreate{BudgetID: budget.Data.ID, External: true})
+	budget := suite.createTestBudget(models.BudgetCreate{})
+	category := suite.createTestCategory(models.CategoryCreate{BudgetID: budget.Data.ID})
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID, Name: "Utilities"})
+	account := suite.createTestAccount(models.AccountCreate{BudgetID: budget.Data.ID})
+	externalAccount := suite.createTestAccount(models.AccountCreate{BudgetID: budget.Data.ID, External: true})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	_ = suite.createTestAllocation(models.AllocationCreate{
 		EnvelopeID: envelope.Data.ID,
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(20.99),
 	})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	_ = suite.createTestAllocation(models.AllocationCreate{
 		EnvelopeID: envelope.Data.ID,
 		Month:      time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(47.12),
 	})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	_ = suite.createTestAllocation(models.AllocationCreate{
 		EnvelopeID: envelope.Data.ID,
 		Month:      time.Date(2022, 3, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(31.17),
 	})
 
-	_ = suite.createTestTransaction(suite.T(), models.TransactionCreate{
+	_ = suite.createTestTransaction(models.TransactionCreate{
 		Date:                 time.Date(2022, 1, 15, 0, 0, 0, 0, time.UTC),
 		Amount:               decimal.NewFromFloat(10.0),
 		Note:                 "Water bill for January",
@@ -240,7 +240,7 @@ func (suite *TestSuiteStandard) TestBudgetMonth() {
 		Reconciled:           true,
 	})
 
-	_ = suite.createTestTransaction(suite.T(), models.TransactionCreate{
+	_ = suite.createTestTransaction(models.TransactionCreate{
 		Date:                 time.Date(2022, 2, 15, 0, 0, 0, 0, time.UTC),
 		Amount:               decimal.NewFromFloat(5.0),
 		Note:                 "Water bill for February",
@@ -251,7 +251,7 @@ func (suite *TestSuiteStandard) TestBudgetMonth() {
 		Reconciled:           true,
 	})
 
-	_ = suite.createTestTransaction(suite.T(), models.TransactionCreate{
+	_ = suite.createTestTransaction(models.TransactionCreate{
 		Date:                 time.Date(2022, 3, 15, 0, 0, 0, 0, time.UTC),
 		Amount:               decimal.NewFromFloat(15.0),
 		Note:                 "Water bill for March",
@@ -262,7 +262,7 @@ func (suite *TestSuiteStandard) TestBudgetMonth() {
 		Reconciled:           true,
 	})
 
-	_ = suite.createTestTransaction(suite.T(), models.TransactionCreate{
+	_ = suite.createTestTransaction(models.TransactionCreate{
 		Date:                 time.Date(2022, 3, 1, 7, 38, 17, 0, time.UTC),
 		Amount:               decimal.NewFromFloat(1500),
 		Note:                 "Income for march",
@@ -335,8 +335,8 @@ func (suite *TestSuiteStandard) TestBudgetMonth() {
 	var budgetMonth controllers.BudgetMonthResponse
 	for _, tt := range tests {
 		r := test.Request(suite.controller, suite.T(), http.MethodGet, tt.path, "")
-		test.AssertHTTPStatus(suite.T(), &r, http.StatusOK)
-		test.DecodeResponse(suite.T(), &r, &budgetMonth)
+		suite.assertHTTPStatus(&r, http.StatusOK)
+		suite.decodeResponse(&r, &budgetMonth)
 
 		// Verify income calculation
 		assert.True(suite.T(), budgetMonth.Data.Income.Equal(tt.response.Data.Income))
@@ -354,18 +354,18 @@ func (suite *TestSuiteStandard) TestBudgetMonth() {
 }
 
 func (suite *TestSuiteStandard) TestBudgetMonthBudgeted() {
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
-	envelope := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID, Name: "Utilities"})
-	envelopeZero := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID, Name: "Zero"})
+	budget := suite.createTestBudget(models.BudgetCreate{})
+	category := suite.createTestCategory(models.CategoryCreate{BudgetID: budget.Data.ID})
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID, Name: "Utilities"})
+	envelopeZero := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID, Name: "Zero"})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	_ = suite.createTestAllocation(models.AllocationCreate{
 		EnvelopeID: envelopeZero.Data.ID,
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(19.01),
 	})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	_ = suite.createTestAllocation(models.AllocationCreate{
 		EnvelopeID: envelope.Data.ID,
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(20.99),
@@ -374,8 +374,8 @@ func (suite *TestSuiteStandard) TestBudgetMonthBudgeted() {
 	var budgetMonth controllers.BudgetMonthResponse
 
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("%s/2022-01", budget.Data.Links.Self), "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusOK)
-	test.DecodeResponse(suite.T(), &r, &budgetMonth)
+	suite.assertHTTPStatus(&r, http.StatusOK)
+	suite.decodeResponse(&r, &budgetMonth)
 
 	assert.True(suite.T(), budgetMonth.Data.Budgeted.Equal(decimal.NewFromFloat(40)), "Calculation of budgeted sum for a month is off. Should be 40, is %s", budgetMonth.Data.Budgeted)
 }
@@ -383,40 +383,40 @@ func (suite *TestSuiteStandard) TestBudgetMonthBudgeted() {
 // TestBudgetMonthNonExistent verifies that month requests for non-existing budgets return a HTTP 404 Not Found.
 func (suite *TestSuiteStandard) TestBudgetMonthNonExistent() {
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/budgets/65064e6f-04b4-46e0-8bbc-88c96c6b21bd/2022-01", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusNotFound)
+	suite.assertHTTPStatus(&r, http.StatusNotFound)
 }
 
 // TestBudgetMonthZero tests that we return a HTTP Bad Request when requesting data for the zero timestamp.
 func (suite *TestSuiteStandard) TestBudgetMonthZero() {
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
+	budget := suite.createTestBudget(models.BudgetCreate{})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("%s/0001-01", budget.Data.Links.Self), "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 }
 
 // TestBudgetMonthInvalid tests that we return a HTTP Bad Request when requesting data for the zero timestamp.
 func (suite *TestSuiteStandard) TestBudgetMonthInvalid() {
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
+	budget := suite.createTestBudget(models.BudgetCreate{})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("%s/December-2020", budget.Data.Links.Self), "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateBudget() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", `{ "name": "New Budget", "note": "More tests something something" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusCreated)
+	suite.assertHTTPStatus(&recorder, http.StatusCreated)
 
 	var budget controllers.BudgetResponse
-	test.DecodeResponse(suite.T(), &recorder, &budget)
+	suite.decodeResponse(&recorder, &budget)
 
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPatch, budget.Data.Links.Self, map[string]any{
 		"name": "Updated new budget",
 		"note": "",
 	})
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusOK)
+	suite.assertHTTPStatus(&recorder, http.StatusOK)
 
 	var updatedBudget controllers.BudgetResponse
-	test.DecodeResponse(suite.T(), &recorder, &updatedBudget)
+	suite.decodeResponse(&recorder, &updatedBudget)
 
 	assert.Equal(suite.T(), "", updatedBudget.Data.Note)
 	assert.Equal(suite.T(), "Updated new budget", updatedBudget.Data.Name)
@@ -424,73 +424,73 @@ func (suite *TestSuiteStandard) TestUpdateBudget() {
 
 func (suite *TestSuiteStandard) TestUpdateBudgetBrokenJSON() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", `{ "name": "New Budget", "note": "More tests something something" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusCreated)
+	suite.assertHTTPStatus(&recorder, http.StatusCreated)
 
 	var budget controllers.BudgetResponse
-	test.DecodeResponse(suite.T(), &recorder, &budget)
+	suite.decodeResponse(&recorder, &budget)
 
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPatch, budget.Data.Links.Self, `{ "name": 2" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateBudgetInvalidType() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", `{ "name": "New Budget", "note": "More tests something something" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusCreated)
+	suite.assertHTTPStatus(&recorder, http.StatusCreated)
 
 	var budget controllers.BudgetResponse
-	test.DecodeResponse(suite.T(), &recorder, &budget)
+	suite.decodeResponse(&recorder, &budget)
 
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPatch, budget.Data.Links.Self, map[string]any{
 		"name": 2,
 	})
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateNonExistingBudget() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/budgets/a29bd123-beec-47de-a9cd-b6f7483fe00f", `{ "name": "2" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteBudget() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", `{ "name": "Delete me now!" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusCreated)
+	suite.assertHTTPStatus(&recorder, http.StatusCreated)
 
 	var budget controllers.BudgetResponse
-	test.DecodeResponse(suite.T(), &recorder, &budget)
+	suite.decodeResponse(&recorder, &budget)
 
 	recorder = test.Request(suite.controller, suite.T(), http.MethodDelete, budget.Data.Links.Self, "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
+	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
 }
 
 func (suite *TestSuiteStandard) TestDeleteNonExistingBudget() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/budgets/c3d34346-609a-4734-9364-98f5b0100150", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteBudgetWithBody() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", `{ "name": "Delete me now!" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusCreated)
+	suite.assertHTTPStatus(&recorder, http.StatusCreated)
 
 	var budget controllers.BudgetResponse
-	test.DecodeResponse(suite.T(), &recorder, &budget)
+	suite.decodeResponse(&recorder, &budget)
 
 	recorder = test.Request(suite.controller, suite.T(), http.MethodDelete, budget.Data.Links.Self, `{ "name": "test name 23" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
+	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
 }
 
 func (suite *TestSuiteStandard) TestDeleteAllocationsMonth() {
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
-	envelope1 := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
-	envelope2 := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
+	budget := suite.createTestBudget(models.BudgetCreate{})
+	category := suite.createTestCategory(models.CategoryCreate{BudgetID: budget.Data.ID})
+	envelope1 := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
+	envelope2 := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
 
-	allocation1 := suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	allocation1 := suite.createTestAllocation(models.AllocationCreate{
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(15.42),
 		EnvelopeID: envelope1.Data.ID,
 	})
 
-	allocation2 := suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	allocation2 := suite.createTestAllocation(models.AllocationCreate{
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(15.42),
 		EnvelopeID: envelope2.Data.ID,
@@ -498,45 +498,45 @@ func (suite *TestSuiteStandard) TestDeleteAllocationsMonth() {
 
 	// Clear allocations
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, strings.Replace(budget.Data.Links.MonthAllocations, "YYYY-MM", "2022-01", 1), "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
+	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
 
 	// Verify that allocations are deleted
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, allocation1.Data.Links.Self, "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, allocation2.Data.Links.Self, "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteAllocationsMonthFailures() {
-	budgetAllocationsLink := suite.createTestBudget(suite.T(), models.BudgetCreate{}).Data.Links.MonthAllocations
+	budgetAllocationsLink := suite.createTestBudget(models.BudgetCreate{}).Data.Links.MonthAllocations
 
 	// Bad Request for invalid UUID
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/budgets/nouuid/2022-01/allocations", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 
 	// Bad Request for invalid months
 	recorder = test.Request(suite.controller, suite.T(), http.MethodDelete, budgetAllocationsLink, "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 
 	// Not found for non-existing budget
 	recorder = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/budgets/059cdead-249f-4f94-8d29-16a80c6b4a09/2032-03/allocations", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestSetAllocationsMonthBudgeted() {
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
-	envelope1 := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
-	envelope2 := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
+	budget := suite.createTestBudget(models.BudgetCreate{})
+	category := suite.createTestCategory(models.CategoryCreate{BudgetID: budget.Data.ID})
+	envelope1 := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
+	envelope2 := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
 
-	allocation1 := suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	allocation1 := suite.createTestAllocation(models.AllocationCreate{
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(30),
 		EnvelopeID: envelope1.Data.ID,
 	})
 
-	allocation2 := suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	allocation2 := suite.createTestAllocation(models.AllocationCreate{
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(40),
 		EnvelopeID: envelope2.Data.ID,
@@ -544,46 +544,46 @@ func (suite *TestSuiteStandard) TestSetAllocationsMonthBudgeted() {
 
 	// Update in budgeted mode allocations
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, strings.Replace(budget.Data.Links.MonthAllocations, "YYYY-MM", "2022-02", 1), controllers.BudgetAllocationMode{Mode: controllers.AllocateLastMonthBudget})
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
+	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
 
 	// Verify the allocation for the first envelope
 	requestString := strings.Replace(envelope1.Data.Links.Month, "YYYY-MM", "2022-02", 1)
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, requestString, "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusOK)
+	suite.assertHTTPStatus(&recorder, http.StatusOK)
 	var envelope1Month controllers.EnvelopeMonthResponse
-	test.DecodeResponse(suite.T(), &recorder, &envelope1Month)
+	suite.decodeResponse(&recorder, &envelope1Month)
 	suite.Assert().True(allocation1.Data.Amount.Equal(envelope1Month.Data.Allocation), "Expected: %s, got %s, Request ID: %s", allocation1.Data.Amount, envelope1Month.Data.Allocation, recorder.Header().Get("x-request-id"))
 
 	// Verify the allocation for the second envelope
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(envelope2.Data.Links.Month, "YYYY-MM", "2022-02", 1), "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusOK)
+	suite.assertHTTPStatus(&recorder, http.StatusOK)
 	var envelope2Month controllers.EnvelopeMonthResponse
-	test.DecodeResponse(suite.T(), &recorder, &envelope2Month)
+	suite.decodeResponse(&recorder, &envelope2Month)
 	suite.Assert().True(allocation2.Data.Amount.Equal(envelope2Month.Data.Allocation), "Expected: %s, got %s, Request ID: %s", allocation2.Data.Amount, envelope2Month.Data.Allocation, recorder.Header().Get("x-request-id"))
 }
 
 func (suite *TestSuiteStandard) TestSetAllocationsMonthSpend() {
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
-	cashAccount := suite.createTestAccount(suite.T(), models.AccountCreate{External: false})
-	externalAccount := suite.createTestAccount(suite.T(), models.AccountCreate{External: true})
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
-	envelope1 := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
-	envelope2 := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
+	budget := suite.createTestBudget(models.BudgetCreate{})
+	cashAccount := suite.createTestAccount(models.AccountCreate{External: false})
+	externalAccount := suite.createTestAccount(models.AccountCreate{External: true})
+	category := suite.createTestCategory(models.CategoryCreate{BudgetID: budget.Data.ID})
+	envelope1 := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
+	envelope2 := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	_ = suite.createTestAllocation(models.AllocationCreate{
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(30),
 		EnvelopeID: envelope1.Data.ID,
 	})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	_ = suite.createTestAllocation(models.AllocationCreate{
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(40),
 		EnvelopeID: envelope2.Data.ID,
 	})
 
 	eID := &envelope1.Data.ID
-	transaction1 := suite.createTestTransaction(suite.T(), models.TransactionCreate{
+	transaction1 := suite.createTestTransaction(models.TransactionCreate{
 		Date:                 time.Date(2022, 1, 15, 14, 43, 27, 0, time.UTC),
 		EnvelopeID:           eID,
 		BudgetID:             budget.Data.ID,
@@ -594,70 +594,70 @@ func (suite *TestSuiteStandard) TestSetAllocationsMonthSpend() {
 
 	// Update in budgeted mode allocations
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, strings.Replace(budget.Data.Links.MonthAllocations, "YYYY-MM", "2022-02", 1), controllers.BudgetAllocationMode{Mode: controllers.AllocateLastMonthSpend})
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
+	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
 
 	// Verify the allocation for the first envelope
 	requestString := strings.Replace(envelope1.Data.Links.Month, "YYYY-MM", "2022-02", 1)
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, requestString, "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusOK)
+	suite.assertHTTPStatus(&recorder, http.StatusOK)
 	var envelope1Month controllers.EnvelopeMonthResponse
-	test.DecodeResponse(suite.T(), &recorder, &envelope1Month)
+	suite.decodeResponse(&recorder, &envelope1Month)
 	suite.Assert().True(transaction1.Data.Amount.Equal(envelope1Month.Data.Allocation), "Expected: %s, got %s, Request ID: %s", transaction1.Data.Amount, envelope1Month.Data.Allocation, recorder.Header().Get("x-request-id"))
 
 	// Verify the allocation for the second envelope
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(envelope2.Data.Links.Month, "YYYY-MM", "2022-02", 1), "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusOK)
+	suite.assertHTTPStatus(&recorder, http.StatusOK)
 	var envelope2Month controllers.EnvelopeMonthResponse
-	test.DecodeResponse(suite.T(), &recorder, &envelope2Month)
+	suite.decodeResponse(&recorder, &envelope2Month)
 	suite.Assert().True(envelope2Month.Data.Allocation.Equal(decimal.NewFromFloat(0)), "Expected: 0, got %s, Request ID: %s", envelope2Month.Data.Allocation, recorder.Header().Get("x-request-id"))
 }
 
 func (suite *TestSuiteStandard) TestSetAllocationsMonthFailures() {
-	budgetAllocationsLink := suite.createTestBudget(suite.T(), models.BudgetCreate{}).Data.Links.MonthAllocations
+	budgetAllocationsLink := suite.createTestBudget(models.BudgetCreate{}).Data.Links.MonthAllocations
 
 	// Bad Request for invalid UUID
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets/nouuid/2022-01/allocations", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 
 	// Bad Request for invalid months
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, budgetAllocationsLink, "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 
 	// Not found for non-existing budget
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets/059cdead-249f-4f94-8d29-16a80c6b4a09/2032-03/allocations", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 
 	// Bad Request for invalid json in body
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, strings.Replace(budgetAllocationsLink, "YYYY-MM", "2022-01", 1), `{ "mode": INVALID_JSON" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 
 	// Bad Request for invalid mode
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, strings.Replace(budgetAllocationsLink, "YYYY-MM", "2022-01", 1), `{ "mode": "UNKNOWN_MODE" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 // TestBudgetBalanceDoubleRegression verifies that the Budget balance is only added once.
 func (suite *TestSuiteStandard) TestBudgetBalanceDoubleRegression() {
 	shouldBalance := decimal.NewFromFloat(1000)
 
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{Name: "TestBudgetBalanceDoubleRegression"})
+	budget := suite.createTestBudget(models.BudgetCreate{Name: "TestBudgetBalanceDoubleRegression"})
 
-	internalAccount := suite.createTestAccount(suite.T(), models.AccountCreate{
+	internalAccount := suite.createTestAccount(models.AccountCreate{
 		BudgetID: budget.Data.ID,
 		OnBudget: true,
 		External: false,
 	})
 
-	externalAccount := suite.createTestAccount(suite.T(), models.AccountCreate{
+	externalAccount := suite.createTestAccount(models.AccountCreate{
 		BudgetID: budget.Data.ID,
 		OnBudget: true,
 		External: true,
 	})
 
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
-	envelope := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
+	category := suite.createTestCategory(models.CategoryCreate{BudgetID: budget.Data.ID})
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
 
-	_ = suite.createTestTransaction(suite.T(), models.TransactionCreate{
+	_ = suite.createTestTransaction(models.TransactionCreate{
 		BudgetID:             budget.Data.ID,
 		Amount:               shouldBalance,
 		SourceAccountID:      externalAccount.Data.ID,
@@ -667,7 +667,7 @@ func (suite *TestSuiteStandard) TestBudgetBalanceDoubleRegression() {
 
 	var budgetResponse controllers.BudgetResponse
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, budget.Data.Links.Self, "")
-	test.DecodeResponse(suite.T(), &recorder, &budgetResponse)
+	suite.decodeResponse(&recorder, &budgetResponse)
 
 	assert.True(suite.T(), budgetResponse.Data.Balance.Equal(shouldBalance), "Balance is %s, should be %s", budgetResponse.Data.Balance, shouldBalance)
 }

--- a/pkg/controllers/category_test.go
+++ b/pkg/controllers/category_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (suite *TestSuiteStandard) createTestCategory(t *testing.T, c models.CategoryCreate, expectedStatus ...int) controllers.CategoryResponse {
+func (suite *TestSuiteStandard) createTestCategory(c models.CategoryCreate, expectedStatus ...int) controllers.CategoryResponse {
 	if c.BudgetID == uuid.Nil {
-		c.BudgetID = suite.createTestBudget(t, models.BudgetCreate{Name: "Testing budget"}).Data.ID
+		c.BudgetID = suite.createTestBudget(models.BudgetCreate{Name: "Testing budget"}).Data.ID
 	}
 
 	if c.Name == "" {
@@ -27,11 +27,11 @@ func (suite *TestSuiteStandard) createTestCategory(t *testing.T, c models.Catego
 		expectedStatus = append(expectedStatus, http.StatusCreated)
 	}
 
-	r := test.Request(suite.controller, t, http.MethodPost, "http://example.com/v1/categories", c)
-	test.AssertHTTPStatus(t, &r, expectedStatus...)
+	r := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/categories", c)
+	suite.assertHTTPStatus(&r, expectedStatus...)
 
 	var category controllers.CategoryResponse
-	test.DecodeResponse(t, &r, &category)
+	suite.decodeResponse(&r, &category)
 
 	return category
 }
@@ -40,7 +40,7 @@ func (suite *TestSuiteStandard) TestCategories() {
 	suite.CloseDB()
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/categories", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusInternalServerError)
+	suite.assertHTTPStatus(&recorder, http.StatusInternalServerError)
 	assert.Contains(suite.T(), test.DecodeError(suite.T(), recorder.Body.Bytes()), "There is a problem with the database connection")
 }
 
@@ -52,38 +52,38 @@ func (suite *TestSuiteStandard) TestOptionsCategory() {
 	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/categories/NotParseableAsUUID", "")
 	assert.Equal(suite.T(), http.StatusBadRequest, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
 
-	path = suite.createTestCategory(suite.T(), models.CategoryCreate{}).Data.Links.Self
+	path = suite.createTestCategory(models.CategoryCreate{}).Data.Links.Self
 	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, path, "")
 	assert.Equal(suite.T(), http.StatusNoContent, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
 }
 
 func (suite *TestSuiteStandard) TestGetCategories() {
-	_ = suite.createTestCategory(suite.T(), models.CategoryCreate{})
+	_ = suite.createTestCategory(models.CategoryCreate{})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/categories", "")
 
 	var response controllers.CategoryListResponse
-	test.DecodeResponse(suite.T(), &recorder, &response)
+	suite.decodeResponse(&recorder, &response)
 
 	assert.Equal(suite.T(), 200, recorder.Code)
 	assert.Len(suite.T(), response.Data, 1)
 
 	diff := time.Since(response.Data[0].CreatedAt)
-	assert.LessOrEqual(suite.T(), diff, test.TOLERANCE)
+	assert.LessOrEqual(suite.T(), diff, tolerance)
 
 	diff = time.Since(response.Data[0].UpdatedAt)
-	assert.LessOrEqual(suite.T(), diff, test.TOLERANCE)
+	assert.LessOrEqual(suite.T(), diff, tolerance)
 }
 
 func (suite *TestSuiteStandard) TestGetCategoriesEnvelopes() {
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{})
-	_ = suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
-	_ = suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
+	category := suite.createTestCategory(models.CategoryCreate{})
+	_ = suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
+	_ = suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/categories", "")
 
 	var response controllers.CategoryListResponse
-	test.DecodeResponse(suite.T(), &recorder, &response)
+	suite.decodeResponse(&recorder, &response)
 
 	assert.Equal(suite.T(), 200, recorder.Code)
 	assert.Len(suite.T(), response.Data, 1)
@@ -91,12 +91,12 @@ func (suite *TestSuiteStandard) TestGetCategoriesEnvelopes() {
 }
 
 func (suite *TestSuiteStandard) TestGetCategoriesNoEnvelopesEmptyArray() {
-	_ = suite.createTestCategory(suite.T(), models.CategoryCreate{})
+	_ = suite.createTestCategory(models.CategoryCreate{})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/categories", "")
 
 	var response controllers.CategoryListResponse
-	test.DecodeResponse(suite.T(), &recorder, &response)
+	suite.decodeResponse(&recorder, &response)
 
 	assert.Equal(suite.T(), 200, recorder.Code)
 	assert.Len(suite.T(), response.Data, 1)
@@ -112,28 +112,28 @@ func (suite *TestSuiteStandard) TestGetCategoriesInvalidQuery() {
 	for _, tt := range tests {
 		suite.T().Run(tt, func(t *testing.T) {
 			recorder := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("http://example.com/v1/categories?%s", tt), "")
-			test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+			suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 		})
 	}
 }
 
 func (suite *TestSuiteStandard) TestGetCategoriesFilter() {
-	b1 := suite.createTestBudget(suite.T(), models.BudgetCreate{})
-	b2 := suite.createTestBudget(suite.T(), models.BudgetCreate{})
+	b1 := suite.createTestBudget(models.BudgetCreate{})
+	b2 := suite.createTestBudget(models.BudgetCreate{})
 
-	_ = suite.createTestCategory(suite.T(), models.CategoryCreate{
+	_ = suite.createTestCategory(models.CategoryCreate{
 		Name:     "Category Name",
 		Note:     "A note for this category",
 		BudgetID: b1.Data.ID,
 	})
 
-	_ = suite.createTestCategory(suite.T(), models.CategoryCreate{
+	_ = suite.createTestCategory(models.CategoryCreate{
 		Name:     "Saving",
 		Note:     "For later",
 		BudgetID: b2.Data.ID,
 	})
 
-	_ = suite.createTestCategory(suite.T(), models.CategoryCreate{
+	_ = suite.createTestCategory(models.CategoryCreate{
 		Name:     "Daily stuff",
 		Note:     "Groceries, Drug Store, …",
 		BudgetID: b2.Data.ID,
@@ -155,8 +155,8 @@ func (suite *TestSuiteStandard) TestGetCategoriesFilter() {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			var re controllers.CategoryListResponse
 			r := test.Request(suite.controller, t, http.MethodGet, fmt.Sprintf("/v1/categories?%s", tt.query), "")
-			test.AssertHTTPStatus(t, &r, http.StatusOK)
-			test.DecodeResponse(t, &r, &re)
+			suite.assertHTTPStatus(&r, http.StatusOK)
+			suite.decodeResponse(&r, &re)
 
 			assert.Equal(t, tt.len, len(re.Data), "Request ID: %s", r.Result().Header.Get("x-request-id"))
 		})
@@ -164,16 +164,16 @@ func (suite *TestSuiteStandard) TestGetCategoriesFilter() {
 }
 
 func (suite *TestSuiteStandard) TestGetCategory() {
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{Name: "Catch me if you can!"})
+	category := suite.createTestCategory(models.CategoryCreate{Name: "Catch me if you can!"})
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, category.Data.Links.Self, "")
 
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusOK)
+	suite.assertHTTPStatus(&recorder, http.StatusOK)
 }
 
 func (suite *TestSuiteStandard) TestNoCategoryNotFound() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/categories/4e743e94-6a4b-44d6-aba5-d77c87103ff7", "")
 
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestCategoryInvalidIDs() {
@@ -181,54 +181,54 @@ func (suite *TestSuiteStandard) TestCategoryInvalidIDs() {
 	 *  GET
 	 */
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/categories/-56", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/categories/notANumber", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/categories/23", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	/*
 	 * PATCH
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/categories/-274", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/categories/stringRandom", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	/*
 	 * DELETE
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/categories/-274", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/categories/stringRandom", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateCategory() {
-	_ = suite.createTestCategory(suite.T(), models.CategoryCreate{Name: "New Category", Note: "Something to test creation"})
+	_ = suite.createTestCategory(models.CategoryCreate{Name: "New Category", Note: "Something to test creation"})
 }
 
 func (suite *TestSuiteStandard) TestCreateBrokenCategory() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/categories", `{ "createdAt": "New Category", "note": "More tests for categories to ensure less brokenness something" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateBudgetDoesNotExist() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/categories", `{ "budgetId": "f8c74664-9b79-4e15-8d3d-4618f3e3c230" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestCreateCategoryNoBody() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/categories", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateCategoryDuplicateName() {
-	c := suite.createTestCategory(suite.T(), models.CategoryCreate{
+	c := suite.createTestCategory(models.CategoryCreate{
 		Name: "Unique Category Name",
 	})
 
@@ -236,69 +236,69 @@ func (suite *TestSuiteStandard) TestCreateCategoryDuplicateName() {
 		BudgetID: c.Data.BudgetID,
 		Name:     c.Data.Name,
 	})
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateCategory() {
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{Name: "New category", Note: "Mor(r)e tests"})
+	category := suite.createTestCategory(models.CategoryCreate{Name: "New category", Note: "Mor(r)e tests"})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, category.Data.Links.Self, map[string]any{
 		"name": "Updated new category for testing",
 		"note": "",
 	})
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusOK)
+	suite.assertHTTPStatus(&recorder, http.StatusOK)
 
 	var updatedCategory controllers.CategoryResponse
-	test.DecodeResponse(suite.T(), &recorder, &updatedCategory)
+	suite.decodeResponse(&recorder, &updatedCategory)
 
 	assert.Equal(suite.T(), "", updatedCategory.Data.Note)
 	assert.Equal(suite.T(), "Updated new category for testing", updatedCategory.Data.Name)
 }
 
 func (suite *TestSuiteStandard) TestUpdateCategoryBrokenJSON() {
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{Name: "New category", Note: "Mor(r)e tests"})
+	category := suite.createTestCategory(models.CategoryCreate{Name: "New category", Note: "Mor(r)e tests"})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, category.Data.Links.Self, `{ "name": 2" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateCategoryInvalidType() {
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{Name: "New category", Note: "Mor(r)e tests"})
+	category := suite.createTestCategory(models.CategoryCreate{Name: "New category", Note: "Mor(r)e tests"})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, category.Data.Links.Self, map[string]any{
 		"name": 2,
 	})
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateCategoryInvalidBudgetID() {
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{Name: "New category", Note: "Mor(r)e tests"})
+	category := suite.createTestCategory(models.CategoryCreate{Name: "New category", Note: "Mor(r)e tests"})
 
 	// Sets the BudgetID to uuid.Nil
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, category.Data.Links.Self, models.CategoryCreate{})
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateNonExistingCategory() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/categories/f9288848-517e-4b8c-9f14-b3d849ca275b", `{ "name": "2" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteCategory() {
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{Name: "Delete me now!"})
+	category := suite.createTestCategory(models.CategoryCreate{Name: "Delete me now!"})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, category.Data.Links.Self, "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
+	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
 }
 
 func (suite *TestSuiteStandard) TestDeleteNonExistingCategory() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/categories/a2aa0569-5ac5-42e1-8563-7c61194cc7d9", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteCategoryWithBody() {
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{Name: "Delete me now!"})
+	category := suite.createTestCategory(models.CategoryCreate{Name: "Delete me now!"})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, category.Data.Links.Self, `{ "name": "test name 23" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
+	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
 }

--- a/pkg/controllers/cleanup_test.go
+++ b/pkg/controllers/cleanup_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 func (suite *TestSuiteStandard) TestCleanup() {
-	_ = suite.createTestBudget(suite.T(), models.BudgetCreate{})
-	_ = suite.createTestAccount(suite.T(), models.AccountCreate{})
-	_ = suite.createTestCategory(suite.T(), models.CategoryCreate{})
-	_ = suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{})
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{})
-	_ = suite.createTestTransaction(suite.T(), models.TransactionCreate{Amount: decimal.NewFromFloat(17.32)})
+	_ = suite.createTestBudget(models.BudgetCreate{})
+	_ = suite.createTestAccount(models.AccountCreate{})
+	_ = suite.createTestCategory(models.CategoryCreate{})
+	_ = suite.createTestEnvelope(models.EnvelopeCreate{})
+	_ = suite.createTestAllocation(models.AllocationCreate{})
+	_ = suite.createTestTransaction(models.TransactionCreate{Amount: decimal.NewFromFloat(17.32)})
 
 	tests := []string{
 		"http://example.com/v1/budgets",
@@ -27,19 +27,19 @@ func (suite *TestSuiteStandard) TestCleanup() {
 
 	// Delete
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
+	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
 
 	// Verify
 	for _, tt := range tests {
 		suite.Run(tt, func() {
 			recorder := test.Request(suite.controller, suite.T(), http.MethodGet, tt, "")
-			test.AssertHTTPStatus(suite.T(), &recorder, http.StatusOK)
+			suite.assertHTTPStatus(&recorder, http.StatusOK)
 
 			var response struct {
 				Data []any `json:"data"`
 			}
 
-			test.DecodeResponse(suite.T(), &recorder, &response)
+			suite.decodeResponse(&recorder, &response)
 			suite.Assert().Len(response.Data, 0, "There are resources left for type %s", tt)
 		})
 	}

--- a/pkg/controllers/import_test.go
+++ b/pkg/controllers/import_test.go
@@ -67,7 +67,7 @@ func (suite *TestSuiteStandard) TestImportFails() {
 	suite.Assert().Contains(test.DecodeError(suite.T(), recorder.Body.Bytes()), "not a valid YNAB4 Budget.yfull file: unexpected end of JSON input")
 
 	// Budget with name already exists
-	_ = suite.createTestBudget(suite.T(), models.BudgetCreate{Name: "Import Test"})
+	_ = suite.createTestBudget(models.BudgetCreate{Name: "Import Test"})
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/import?budgetName=Import Test", "")
 	suite.Assert().Equal(http.StatusBadRequest, recorder.Code, "Request ID %s, response %s", recorder.Header().Get("x-request-id"), recorder.Body.String())
 	suite.Assert().Contains(test.DecodeError(suite.T(), recorder.Body.Bytes()), "This budget name is already in use")

--- a/pkg/controllers/month_test.go
+++ b/pkg/controllers/month_test.go
@@ -20,31 +20,31 @@ func (suite *TestSuiteStandard) TestOptionsMonth() {
 
 // TestBudgetMonth verifies that the monthly calculations are correct.
 func (suite *TestSuiteStandard) TestMonth() {
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID, Name: "Upkeep"})
-	envelope := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID, Name: "Utilities"})
-	account := suite.createTestAccount(suite.T(), models.AccountCreate{BudgetID: budget.Data.ID})
-	externalAccount := suite.createTestAccount(suite.T(), models.AccountCreate{BudgetID: budget.Data.ID, External: true})
+	budget := suite.createTestBudget(models.BudgetCreate{})
+	category := suite.createTestCategory(models.CategoryCreate{BudgetID: budget.Data.ID, Name: "Upkeep"})
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID, Name: "Utilities"})
+	account := suite.createTestAccount(models.AccountCreate{BudgetID: budget.Data.ID})
+	externalAccount := suite.createTestAccount(models.AccountCreate{BudgetID: budget.Data.ID, External: true})
 
-	allocationJanuary := suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	allocationJanuary := suite.createTestAllocation(models.AllocationCreate{
 		EnvelopeID: envelope.Data.ID,
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(20.99),
 	})
 
-	allocationFebruary := suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	allocationFebruary := suite.createTestAllocation(models.AllocationCreate{
 		EnvelopeID: envelope.Data.ID,
 		Month:      time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(47.12),
 	})
 
-	allocationMarch := suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	allocationMarch := suite.createTestAllocation(models.AllocationCreate{
 		EnvelopeID: envelope.Data.ID,
 		Month:      time.Date(2022, 3, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(31.17),
 	})
 
-	_ = suite.createTestTransaction(suite.T(), models.TransactionCreate{
+	_ = suite.createTestTransaction(models.TransactionCreate{
 		Date:                 time.Date(2022, 1, 15, 0, 0, 0, 0, time.UTC),
 		Amount:               decimal.NewFromFloat(10.0),
 		Note:                 "Water bill for January",
@@ -55,7 +55,7 @@ func (suite *TestSuiteStandard) TestMonth() {
 		Reconciled:           true,
 	})
 
-	_ = suite.createTestTransaction(suite.T(), models.TransactionCreate{
+	_ = suite.createTestTransaction(models.TransactionCreate{
 		Date:                 time.Date(2022, 2, 15, 0, 0, 0, 0, time.UTC),
 		Amount:               decimal.NewFromFloat(5.0),
 		Note:                 "Water bill for February",
@@ -66,7 +66,7 @@ func (suite *TestSuiteStandard) TestMonth() {
 		Reconciled:           true,
 	})
 
-	_ = suite.createTestTransaction(suite.T(), models.TransactionCreate{
+	_ = suite.createTestTransaction(models.TransactionCreate{
 		Date:                 time.Date(2022, 3, 15, 0, 0, 0, 0, time.UTC),
 		Amount:               decimal.NewFromFloat(15.0),
 		Note:                 "Water bill for March",
@@ -77,7 +77,7 @@ func (suite *TestSuiteStandard) TestMonth() {
 		Reconciled:           true,
 	})
 
-	_ = suite.createTestTransaction(suite.T(), models.TransactionCreate{
+	_ = suite.createTestTransaction(models.TransactionCreate{
 		Date:                 time.Date(2022, 3, 1, 7, 38, 17, 0, time.UTC),
 		Amount:               decimal.NewFromFloat(1500),
 		Note:                 "Income for march",
@@ -180,8 +180,8 @@ func (suite *TestSuiteStandard) TestMonth() {
 	var month controllers.MonthResponse
 	for _, tt := range tests {
 		r := test.Request(suite.controller, suite.T(), http.MethodGet, tt.path, "")
-		test.AssertHTTPStatus(suite.T(), &r, http.StatusOK)
-		test.DecodeResponse(suite.T(), &r, &month)
+		suite.assertHTTPStatus(&r, http.StatusOK)
+		suite.decodeResponse(&r, &month)
 
 		// Verify income calculation
 		suite.Assert().True(month.Data.Income.Equal(tt.response.Data.Income))
@@ -212,13 +212,13 @@ func (suite *TestSuiteStandard) TestMonth() {
 func (suite *TestSuiteStandard) TestEnvelopeNoAllocationLink() {
 	var month controllers.MonthResponse
 
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
-	_ = suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
+	budget := suite.createTestBudget(models.BudgetCreate{})
+	category := suite.createTestCategory(models.CategoryCreate{BudgetID: budget.Data.ID})
+	_ = suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-01", 1), "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusOK)
-	test.DecodeResponse(suite.T(), &r, &month)
+	suite.assertHTTPStatus(&r, http.StatusOK)
+	suite.decodeResponse(&r, &month)
 	suite.Assert().NotEmpty(month.Data.Categories[0].Envelopes)
 	suite.Assert().Equal("http://example.com/v1/allocations", month.Data.Categories[0].Envelopes[0].Links.Allocation)
 }
@@ -226,14 +226,14 @@ func (suite *TestSuiteStandard) TestEnvelopeNoAllocationLink() {
 func (suite *TestSuiteStandard) TestEnvelopeAllocationLink() {
 	var month controllers.MonthResponse
 
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
-	envelope := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
-	allocation := suite.createTestAllocation(suite.T(), models.AllocationCreate{Amount: decimal.New(1, 1), EnvelopeID: envelope.Data.ID, Month: time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)})
+	budget := suite.createTestBudget(models.BudgetCreate{})
+	category := suite.createTestCategory(models.CategoryCreate{BudgetID: budget.Data.ID})
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
+	allocation := suite.createTestAllocation(models.AllocationCreate{Amount: decimal.New(1, 1), EnvelopeID: envelope.Data.ID, Month: time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-01", 1), "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusOK)
-	test.DecodeResponse(suite.T(), &r, &month)
+	suite.assertHTTPStatus(&r, http.StatusOK)
+	suite.decodeResponse(&r, &month)
 	suite.Assert().NotEmpty(month.Data.Categories[0].Envelopes)
 	suite.Assert().Equal(allocation.Data.Links.Self, month.Data.Categories[0].Envelopes[0].Links.Allocation)
 }
@@ -242,65 +242,65 @@ func (suite *TestSuiteStandard) TestMonthNotNil() {
 	var month controllers.MonthResponse
 
 	// Verify that the categories list is empty, not nil
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
+	budget := suite.createTestBudget(models.BudgetCreate{})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-01", 1), "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusOK)
-	test.DecodeResponse(suite.T(), &r, &month)
+	suite.assertHTTPStatus(&r, http.StatusOK)
+	suite.decodeResponse(&r, &month)
 	if !suite.Assert().NotNil(month.Data.Categories) {
 		suite.Assert().FailNow("Categories field is nil, cannot continue")
 	}
 	suite.Assert().Empty(month.Data.Categories)
 
 	// Verify that the envelopes list is empty, not nil
-	_ = suite.createTestCategory(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
+	_ = suite.createTestCategory(models.CategoryCreate{BudgetID: budget.Data.ID})
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-01", 1), "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusOK)
-	test.DecodeResponse(suite.T(), &r, &month)
+	suite.assertHTTPStatus(&r, http.StatusOK)
+	suite.decodeResponse(&r, &month)
 	suite.Assert().NotNil(month.Data.Categories[0].Envelopes)
 	suite.Assert().Empty(month.Data.Categories[0].Envelopes)
 }
 
 func (suite *TestSuiteStandard) TestMonthInvalidRequest() {
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/months?month=-56", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/months?budget=noUUID", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
+	budget := suite.createTestBudget(models.BudgetCreate{})
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "0001-01", 1), "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+	suite.assertHTTPStatus(&r, http.StatusBadRequest)
 	suite.Assert().Equal("The month query parameter must be set", test.DecodeError(suite.T(), r.Body.Bytes()))
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/months?budget=6a463cc8-1938-474a-8aeb-0482b82ffb6f&month=2000-12", "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusNotFound)
+	suite.assertHTTPStatus(&r, http.StatusNotFound)
 	suite.Assert().Equal("No budget found for the specified ID", test.DecodeError(suite.T(), r.Body.Bytes()))
 }
 
 func (suite *TestSuiteStandard) TestMonthDBFail() {
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
+	budget := suite.createTestBudget(models.BudgetCreate{})
 
 	suite.CloseDB()
 
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-01", 1), "")
-	test.AssertHTTPStatus(suite.T(), &r, http.StatusInternalServerError)
+	suite.assertHTTPStatus(&r, http.StatusInternalServerError)
 }
 
 func (suite *TestSuiteStandard) TestDeleteMonth() {
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
-	envelope1 := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
-	envelope2 := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
+	budget := suite.createTestBudget(models.BudgetCreate{})
+	category := suite.createTestCategory(models.CategoryCreate{BudgetID: budget.Data.ID})
+	envelope1 := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
+	envelope2 := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
 
-	allocation1 := suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	allocation1 := suite.createTestAllocation(models.AllocationCreate{
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(15.42),
 		EnvelopeID: envelope1.Data.ID,
 	})
 
-	allocation2 := suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	allocation2 := suite.createTestAllocation(models.AllocationCreate{
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(15.42),
 		EnvelopeID: envelope2.Data.ID,
@@ -308,45 +308,45 @@ func (suite *TestSuiteStandard) TestDeleteMonth() {
 
 	// Clear allocations
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, strings.Replace(budget.Data.Links.MonthAllocations, "YYYY-MM", "2022-01", 1), "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
+	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
 
 	// Verify that allocations are deleted
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, allocation1.Data.Links.Self, "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, allocation2.Data.Links.Self, "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteMonthFailures() {
-	budgetAllocationsLink := suite.createTestBudget(suite.T(), models.BudgetCreate{}).Data.Links.MonthAllocations
+	budgetAllocationsLink := suite.createTestBudget(models.BudgetCreate{}).Data.Links.MonthAllocations
 
 	// Bad Request for invalid UUID
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/months?budget=nouuid&month=2022-01", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 
 	// Bad Request for invalid months
 	recorder = test.Request(suite.controller, suite.T(), http.MethodDelete, budgetAllocationsLink, "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 
 	// Not found for non-existing budget
 	recorder = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/months?budget=059cdead-249f-4f94-8d29-16a80c6b4a09&month=2032-03", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestSetMonthBudgeted() {
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
-	envelope1 := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
-	envelope2 := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
+	budget := suite.createTestBudget(models.BudgetCreate{})
+	category := suite.createTestCategory(models.CategoryCreate{BudgetID: budget.Data.ID})
+	envelope1 := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
+	envelope2 := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
 
-	allocation1 := suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	allocation1 := suite.createTestAllocation(models.AllocationCreate{
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(30),
 		EnvelopeID: envelope1.Data.ID,
 	})
 
-	allocation2 := suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	allocation2 := suite.createTestAllocation(models.AllocationCreate{
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(40),
 		EnvelopeID: envelope2.Data.ID,
@@ -354,46 +354,46 @@ func (suite *TestSuiteStandard) TestSetMonthBudgeted() {
 
 	// Update in budgeted mode allocations
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, strings.Replace(budget.Data.Links.MonthAllocations, "YYYY-MM", "2022-02", 1), controllers.BudgetAllocationMode{Mode: controllers.AllocateLastMonthBudget})
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
+	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
 
 	// Verify the allocation for the first envelope
 	requestString := strings.Replace(envelope1.Data.Links.Month, "YYYY-MM", "2022-02", 1)
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, requestString, "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusOK)
+	suite.assertHTTPStatus(&recorder, http.StatusOK)
 	var envelope1Month controllers.EnvelopeMonthResponse
-	test.DecodeResponse(suite.T(), &recorder, &envelope1Month)
+	suite.decodeResponse(&recorder, &envelope1Month)
 	suite.Assert().True(allocation1.Data.Amount.Equal(envelope1Month.Data.Allocation), "Expected: %s, got %s, Request ID: %s", allocation1.Data.Amount, envelope1Month.Data.Allocation, recorder.Header().Get("x-request-id"))
 
 	// Verify the allocation for the second envelope
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(envelope2.Data.Links.Month, "YYYY-MM", "2022-02", 1), "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusOK)
+	suite.assertHTTPStatus(&recorder, http.StatusOK)
 	var envelope2Month controllers.EnvelopeMonthResponse
-	test.DecodeResponse(suite.T(), &recorder, &envelope2Month)
+	suite.decodeResponse(&recorder, &envelope2Month)
 	suite.Assert().True(allocation2.Data.Amount.Equal(envelope2Month.Data.Allocation), "Expected: %s, got %s, Request ID: %s", allocation2.Data.Amount, envelope2Month.Data.Allocation, recorder.Header().Get("x-request-id"))
 }
 
 func (suite *TestSuiteStandard) TestSetMonthSpend() {
-	budget := suite.createTestBudget(suite.T(), models.BudgetCreate{})
-	cashAccount := suite.createTestAccount(suite.T(), models.AccountCreate{External: false})
-	externalAccount := suite.createTestAccount(suite.T(), models.AccountCreate{External: true})
-	category := suite.createTestCategory(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
-	envelope1 := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
-	envelope2 := suite.createTestEnvelope(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
+	budget := suite.createTestBudget(models.BudgetCreate{})
+	cashAccount := suite.createTestAccount(models.AccountCreate{External: false})
+	externalAccount := suite.createTestAccount(models.AccountCreate{External: true})
+	category := suite.createTestCategory(models.CategoryCreate{BudgetID: budget.Data.ID})
+	envelope1 := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
+	envelope2 := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	_ = suite.createTestAllocation(models.AllocationCreate{
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(30),
 		EnvelopeID: envelope1.Data.ID,
 	})
 
-	_ = suite.createTestAllocation(suite.T(), models.AllocationCreate{
+	_ = suite.createTestAllocation(models.AllocationCreate{
 		Month:      time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		Amount:     decimal.NewFromFloat(40),
 		EnvelopeID: envelope2.Data.ID,
 	})
 
 	eID := &envelope1.Data.ID
-	transaction1 := suite.createTestTransaction(suite.T(), models.TransactionCreate{
+	transaction1 := suite.createTestTransaction(models.TransactionCreate{
 		Date:                 time.Date(2022, 1, 15, 14, 43, 27, 0, time.UTC),
 		EnvelopeID:           eID,
 		BudgetID:             budget.Data.ID,
@@ -404,44 +404,44 @@ func (suite *TestSuiteStandard) TestSetMonthSpend() {
 
 	// Update in budgeted mode allocations
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, strings.Replace(budget.Data.Links.MonthAllocations, "YYYY-MM", "2022-02", 1), controllers.BudgetAllocationMode{Mode: controllers.AllocateLastMonthSpend})
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
+	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
 
 	// Verify the allocation for the first envelope
 	requestString := strings.Replace(envelope1.Data.Links.Month, "YYYY-MM", "2022-02", 1)
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, requestString, "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusOK)
+	suite.assertHTTPStatus(&recorder, http.StatusOK)
 	var envelope1Month controllers.EnvelopeMonthResponse
-	test.DecodeResponse(suite.T(), &recorder, &envelope1Month)
+	suite.decodeResponse(&recorder, &envelope1Month)
 	suite.Assert().True(transaction1.Data.Amount.Equal(envelope1Month.Data.Allocation), "Expected: %s, got %s, Request ID: %s", transaction1.Data.Amount, envelope1Month.Data.Allocation, recorder.Header().Get("x-request-id"))
 
 	// Verify the allocation for the second envelope
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(envelope2.Data.Links.Month, "YYYY-MM", "2022-02", 1), "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusOK)
+	suite.assertHTTPStatus(&recorder, http.StatusOK)
 	var envelope2Month controllers.EnvelopeMonthResponse
-	test.DecodeResponse(suite.T(), &recorder, &envelope2Month)
+	suite.decodeResponse(&recorder, &envelope2Month)
 	suite.Assert().True(envelope2Month.Data.Allocation.Equal(decimal.NewFromFloat(0)), "Expected: 0, got %s, Request ID: %s", envelope2Month.Data.Allocation, recorder.Header().Get("x-request-id"))
 }
 
 func (suite *TestSuiteStandard) TestSetMonthFailures() {
-	budgetAllocationsLink := suite.createTestBudget(suite.T(), models.BudgetCreate{}).Data.Links.MonthAllocations
+	budgetAllocationsLink := suite.createTestBudget(models.BudgetCreate{}).Data.Links.MonthAllocations
 
 	// Bad Request for invalid UUID
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/months?budget=nouuid&month=2022-01", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 
 	// Bad Request for invalid months
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, budgetAllocationsLink, "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 
 	// Not found for non-existing budget
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/months?budget=059cdead-249f-4f94-8d29-16a80c6b4a09&month=2032-03", "")
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
 
 	// Bad Request for invalid json in body
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, strings.Replace(budgetAllocationsLink, "YYYY-MM", "2022-01", 1), `{ "mode": INVALID_JSON" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 
 	// Bad Request for invalid mode
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, strings.Replace(budgetAllocationsLink, "YYYY-MM", "2022-01", 1), `{ "mode": "UNKNOWN_MODE" }`)
-	test.AssertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
 }

--- a/pkg/controllers/test_helpers_test.go
+++ b/pkg/controllers/test_helpers_test.go
@@ -1,0 +1,29 @@
+package controllers_test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"reflect"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TOLERANCE is the number of seconds that a CreatedAt or UpdatedAt time.Time
+// is allowed to differ from the time at which it is checked.
+//
+// As CreatedAt and UpdatedAt are automatically set by gorm, we need a tolerance here.
+// This is in nanoseconds, so we multiply by 1000000000 for seconds.
+const tolerance time.Duration = 1000000000 * 60
+
+func (suite *TestSuiteStandard) assertHTTPStatus(r *httptest.ResponseRecorder, expectedStatus ...int) {
+	assert.Contains(suite.T(), expectedStatus, r.Code, "HTTP status is wrong. Request ID: '%s' Response body: %s", r.Result().Header.Get("x-request-id"), r.Body.String())
+}
+
+// decodeResponse decodes an HTTP response into a target struct.
+func (suite *TestSuiteStandard) decodeResponse(r *httptest.ResponseRecorder, target interface{}) {
+	err := json.NewDecoder(r.Body).Decode(target)
+	if err != nil {
+		assert.FailNow(suite.T(), "Parsing error", "Unable to parse response from server %q into %v, '%v', Request ID: %s", r.Body, reflect.TypeOf(target), err, r.Result().Header.Get("x-request-id"))
+	}
+}

--- a/pkg/controllers/test_list_test.go
+++ b/pkg/controllers/test_list_test.go
@@ -21,6 +21,6 @@ func (suite *TestSuiteStandard) TestMethodNotAllowed() {
 	for _, tt := range methodNotAllowedTests {
 		recorder := test.Request(suite.controller, suite.T(), tt.method, tt.path, "")
 
-		test.AssertHTTPStatus(suite.T(), &recorder, http.StatusMethodNotAllowed)
+		suite.assertHTTPStatus(&recorder, http.StatusMethodNotAllowed)
 	}
 }

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -1,19 +1,28 @@
 package router_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/envelope-zero/backend/pkg/controllers"
 	"github.com/envelope-zero/backend/pkg/database"
 	"github.com/envelope-zero/backend/pkg/router"
-	"github.com/envelope-zero/backend/test"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
+
+// decodeResponse decodes an HTTP response into a target struct.
+func decodeResponse(t *testing.T, r *httptest.ResponseRecorder, target interface{}) {
+	err := json.NewDecoder(r.Body).Decode(target)
+	if err != nil {
+		assert.FailNow(t, "Parsing error", "Unable to parse response from server %q into %v, '%v', Request ID: %s", r.Body, reflect.TypeOf(target), err, r.Result().Header.Get("x-request-id"))
+	}
+}
 
 func TestGinMode(t *testing.T) {
 	os.Setenv("GIN_MODE", "debug")
@@ -84,7 +93,7 @@ func TestGetRoot(t *testing.T) {
 	c.Request, _ = http.NewRequest(http.MethodGet, "https://example.com/", nil)
 	r.ServeHTTP(w, c.Request)
 
-	test.DecodeResponse(t, w, &lr)
+	decodeResponse(t, w, &lr)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, l, lr)
 }
@@ -118,7 +127,7 @@ func TestGetV1(t *testing.T) {
 	c.Request, _ = http.NewRequest(http.MethodGet, "http://example.com/v1", nil)
 	r.ServeHTTP(w, c.Request)
 
-	test.DecodeResponse(t, w, &lr)
+	decodeResponse(t, w, &lr)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, l, lr)
 }
@@ -143,7 +152,7 @@ func TestGetVersion(t *testing.T) {
 	c.Request, _ = http.NewRequest(http.MethodGet, "https://example.com/version", nil)
 	r.ServeHTTP(w, c.Request)
 
-	test.DecodeResponse(t, w, &lr)
+	decodeResponse(t, w, &lr)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, l, lr)
 }

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -7,20 +7,12 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/envelope-zero/backend/pkg/controllers"
 	"github.com/envelope-zero/backend/pkg/httperrors"
 	"github.com/envelope-zero/backend/pkg/router"
 	"github.com/stretchr/testify/assert"
 )
-
-// TOLERANCE is the number of seconds that a CreatedAt or UpdatedAt time.Time
-// is allowed to differ from the time at which it is checked.
-//
-// As CreatedAt and UpdatedAt are automatically set by gorm, we need a tolerance here.
-// This is in nanoseconds, so we multiply by 1000000000 for seconds.
-const TOLERANCE time.Duration = 1000000000 * 60
 
 type APIResponse struct {
 	Links map[string]string
@@ -64,18 +56,6 @@ func Request(co controllers.Controller, t *testing.T, method, url string, body a
 	r.ServeHTTP(recorder, req)
 
 	return *recorder
-}
-
-func AssertHTTPStatus(t *testing.T, r *httptest.ResponseRecorder, expectedStatus ...int) {
-	assert.Contains(t, expectedStatus, r.Code, "HTTP status is wrong. Request ID: '%s' Response body: %s", r.Result().Header.Get("x-request-id"), r.Body.String())
-}
-
-// DecodeResponse decodes an HTTP response into a target struct.
-func DecodeResponse(t *testing.T, r *httptest.ResponseRecorder, target interface{}) {
-	err := json.NewDecoder(r.Body).Decode(target)
-	if err != nil {
-		assert.FailNow(t, "Parsing error", "Unable to parse response from server %q into %v, '%v', Request ID: %s", r.Body, reflect.TypeOf(target), err, r.Result().Header.Get("x-request-id"))
-	}
 }
 
 func DecodeError(t *testing.T, s []byte) string {


### PR DESCRIPTION
Cleans up unnecessary complication in testing helpers.

Resolves #360.
