### PR TITLE
feat: print version when starting

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,20 +90,20 @@ func main() {
 
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatal().Str("event", "Error during startup").Err(err).Msg("Router")
+			log.Fatal().Str("event", "Error during startup").Err(err).Msg("backend")
 		}
 	}()
-	log.Info().Str("event", "Startup complete").Msg("Router")
+	log.Info().Str("event", "Startup complete").Msg("backend")
 
 	<-quit
-	log.Info().Str("event", "Received SIGINT or SIGTERM, stopping gracefully with 25 seconds timeout").Msg("Router")
+	log.Info().Str("event", "Received SIGINT or SIGTERM, stopping gracefully with 25 seconds timeout").Msg("backend")
 
 	// Create a context with a 25 second timeout for the server to shut down in
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
 	defer cancel()
 
 	if err := srv.Shutdown(ctx); err != nil {
-		log.Fatal().Str("event", "Graceful shutdown failed, terminating").Err(err).Msg("Router")
+		log.Fatal().Str("event", "Graceful shutdown failed, terminating").Err(err).Msg("backend")
 	}
-	log.Info().Str("event", "Backend stopped").Msg("Router")
+	log.Info().Str("event", "Backend stopped").Msg("backend")
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -89,6 +89,7 @@ func Config() (*gin.Engine, error) {
 	}
 
 	log.Debug().Str("API Base URL", url.String()).Str("Host", url.Host).Str("Path", url.Path).Msg("Router")
+	log.Info().Str("version", version).Msg("Router")
 
 	docs.SwaggerInfo.Host = url.Host
 	docs.SwaggerInfo.BasePath = url.Path


### PR DESCRIPTION
With this, the version of the backend is printed in INFO severity when starting up.

Resolves #364.
