### PR TITLE
fix: do not prompt for restart on any db error, do not log not found errors

### DIFF
--- a/pkg/controllers/database.go
+++ b/pkg/controllers/database.go
@@ -50,7 +50,9 @@ func TryDBConnect(e error) error {
 		return errors.New("database is read-only")
 	}
 
-	log.Warn().Str("db", "unknown database error, restart the backend").Err(e).Msg("TryDBConnect")
+	if e != gorm.ErrRecordNotFound {
+		log.Info().Err(e).Msg("Database")
+	}
 	return e
 }
 


### PR DESCRIPTION
This fixes a bug where the log would prompt for a backend restart on any
unknown database error. This does not make sense as e.g. unique constraint
errors are not connection errors, but data errors that need to be fixed
by the user or client.

This also turns off logging for "not found" errors where no record exists that
matches the query as this could be confusing when analyzing the log - a record
not existing is not an error in the sense of our functionality here.
