### PR TITLE
feat: MonthConfigs

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1832,6 +1832,317 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/month-configs": {
+            "get": {
+                "description": "Returns a list of MonthConfigs",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MonthConfigs"
+                ],
+                "summary": "List MonthConfigs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by name",
+                        "name": "envelope",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by month",
+                        "name": "month",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.MonthConfigListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs.",
+                "tags": [
+                    "MonthConfigs"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/v1/month-configs/{envelopeId}/{month}": {
+            "get": {
+                "description": "Returns configuration for a specific month",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MonthConfigs"
+                ],
+                "summary": "Get MonthConfig",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID of the Envelope",
+                        "name": "envelopeId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The month in YYYY-MM format",
+                        "name": "month",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.MonthConfigResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new MonthConfig",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MonthConfigs"
+                ],
+                "summary": "Create MonthConfig",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID of the Envelope",
+                        "name": "envelopeId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The month in YYYY-MM format",
+                        "name": "month",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "MonthConfig",
+                        "name": "monthConfig",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.MonthConfigCreate"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.MonthConfigResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes configuration settings for a specific month",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MonthConfigs"
+                ],
+                "summary": "Delete MonthConfig",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID of the Envelope",
+                        "name": "envelopeId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The month in YYYY-MM format",
+                        "name": "month",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "tags": [
+                    "MonthConfigs"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID of the Envelope",
+                        "name": "envelopeId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The month in YYYY-MM format",
+                        "name": "month",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Creates a new MonthConfig",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MonthConfigs"
+                ],
+                "summary": "Create MonthConfig",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID of the Envelope",
+                        "name": "envelopeId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The month in YYYY-MM format",
+                        "name": "month",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "MonthConfig",
+                        "name": "monthConfig",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.MonthConfigCreate"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.MonthConfigResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/months": {
             "get": {
                 "description": "Returns data about a specific month.",
@@ -2762,6 +3073,72 @@ const docTemplate = `{
                 }
             }
         },
+        "controllers.MonthConfig": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "deletedAt": {
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
+                "envelopeId": {
+                    "type": "string",
+                    "example": "10b9705d-3356-459e-9d5a-28d42a6c4547"
+                },
+                "links": {
+                    "$ref": "#/definitions/controllers.MonthConfigLinks"
+                },
+                "month": {
+                    "description": "This is always set to 00:00 UTC on the first of the month.",
+                    "type": "string",
+                    "example": "1969-06-01T00:00:00.000000Z"
+                },
+                "overspendMode": {
+                    "type": "string",
+                    "default": "AFFECT_AVAILABLE",
+                    "example": "AFFECT_ENVELOPE"
+                },
+                "updatedAt": {
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
+                }
+            }
+        },
+        "controllers.MonthConfigLinks": {
+            "type": "object",
+            "properties": {
+                "envelope": {
+                    "type": "string",
+                    "example": "https://example.com/api/v1/envelopes/61027ebb-ab75-4a49-9e23-a104ddd9ba6b"
+                },
+                "self": {
+                    "type": "string",
+                    "example": "https://example.com/api/v1/month-configs/61027ebb-ab75-4a49-9e23-a104ddd9ba6b/2017-10"
+                }
+            }
+        },
+        "controllers.MonthConfigListResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.MonthConfig"
+                    }
+                }
+            }
+        },
+        "controllers.MonthConfigResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/controllers.MonthConfig"
+                }
+            }
+        },
         "controllers.MonthResponse": {
             "type": "object",
             "properties": {
@@ -3135,6 +3512,16 @@ const docTemplate = `{
                     "description": "The name of the Budget",
                     "type": "string",
                     "example": "Zero budget"
+                }
+            }
+        },
+        "models.MonthConfigCreate": {
+            "type": "object",
+            "properties": {
+                "overspendMode": {
+                    "type": "string",
+                    "default": "AFFECT_AVAILABLE",
+                    "example": "AFFECT_ENVELOPE"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1820,6 +1820,317 @@
                 }
             }
         },
+        "/v1/month-configs": {
+            "get": {
+                "description": "Returns a list of MonthConfigs",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MonthConfigs"
+                ],
+                "summary": "List MonthConfigs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by name",
+                        "name": "envelope",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by month",
+                        "name": "month",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.MonthConfigListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs.",
+                "tags": [
+                    "MonthConfigs"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/v1/month-configs/{envelopeId}/{month}": {
+            "get": {
+                "description": "Returns configuration for a specific month",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MonthConfigs"
+                ],
+                "summary": "Get MonthConfig",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID of the Envelope",
+                        "name": "envelopeId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The month in YYYY-MM format",
+                        "name": "month",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.MonthConfigResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new MonthConfig",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MonthConfigs"
+                ],
+                "summary": "Create MonthConfig",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID of the Envelope",
+                        "name": "envelopeId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The month in YYYY-MM format",
+                        "name": "month",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "MonthConfig",
+                        "name": "monthConfig",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.MonthConfigCreate"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.MonthConfigResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes configuration settings for a specific month",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MonthConfigs"
+                ],
+                "summary": "Delete MonthConfig",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID of the Envelope",
+                        "name": "envelopeId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The month in YYYY-MM format",
+                        "name": "month",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "tags": [
+                    "MonthConfigs"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID of the Envelope",
+                        "name": "envelopeId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The month in YYYY-MM format",
+                        "name": "month",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Creates a new MonthConfig",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MonthConfigs"
+                ],
+                "summary": "Create MonthConfig",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID of the Envelope",
+                        "name": "envelopeId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The month in YYYY-MM format",
+                        "name": "month",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "MonthConfig",
+                        "name": "monthConfig",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.MonthConfigCreate"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.MonthConfigResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/months": {
             "get": {
                 "description": "Returns data about a specific month.",
@@ -2750,6 +3061,72 @@
                 }
             }
         },
+        "controllers.MonthConfig": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "deletedAt": {
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
+                "envelopeId": {
+                    "type": "string",
+                    "example": "10b9705d-3356-459e-9d5a-28d42a6c4547"
+                },
+                "links": {
+                    "$ref": "#/definitions/controllers.MonthConfigLinks"
+                },
+                "month": {
+                    "description": "This is always set to 00:00 UTC on the first of the month.",
+                    "type": "string",
+                    "example": "1969-06-01T00:00:00.000000Z"
+                },
+                "overspendMode": {
+                    "type": "string",
+                    "default": "AFFECT_AVAILABLE",
+                    "example": "AFFECT_ENVELOPE"
+                },
+                "updatedAt": {
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
+                }
+            }
+        },
+        "controllers.MonthConfigLinks": {
+            "type": "object",
+            "properties": {
+                "envelope": {
+                    "type": "string",
+                    "example": "https://example.com/api/v1/envelopes/61027ebb-ab75-4a49-9e23-a104ddd9ba6b"
+                },
+                "self": {
+                    "type": "string",
+                    "example": "https://example.com/api/v1/month-configs/61027ebb-ab75-4a49-9e23-a104ddd9ba6b/2017-10"
+                }
+            }
+        },
+        "controllers.MonthConfigListResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.MonthConfig"
+                    }
+                }
+            }
+        },
+        "controllers.MonthConfigResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/controllers.MonthConfig"
+                }
+            }
+        },
         "controllers.MonthResponse": {
             "type": "object",
             "properties": {
@@ -3123,6 +3500,16 @@
                     "description": "The name of the Budget",
                     "type": "string",
                     "example": "Zero budget"
+                }
+            }
+        },
+        "models.MonthConfigCreate": {
+            "type": "object",
+            "properties": {
+                "overspendMode": {
+                    "type": "string",
+                    "default": "AFFECT_AVAILABLE",
+                    "example": "AFFECT_ENVELOPE"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -325,6 +325,52 @@ definitions:
       data:
         $ref: '#/definitions/controllers.Envelope'
     type: object
+  controllers.MonthConfig:
+    properties:
+      createdAt:
+        example: "2022-04-02T19:28:44.491514Z"
+        type: string
+      deletedAt:
+        example: "2022-04-22T21:01:05.058161Z"
+        type: string
+      envelopeId:
+        example: 10b9705d-3356-459e-9d5a-28d42a6c4547
+        type: string
+      links:
+        $ref: '#/definitions/controllers.MonthConfigLinks'
+      month:
+        description: This is always set to 00:00 UTC on the first of the month.
+        example: "1969-06-01T00:00:00.000000Z"
+        type: string
+      overspendMode:
+        default: AFFECT_AVAILABLE
+        example: AFFECT_ENVELOPE
+        type: string
+      updatedAt:
+        example: "2022-04-17T20:14:01.048145Z"
+        type: string
+    type: object
+  controllers.MonthConfigLinks:
+    properties:
+      envelope:
+        example: https://example.com/api/v1/envelopes/61027ebb-ab75-4a49-9e23-a104ddd9ba6b
+        type: string
+      self:
+        example: https://example.com/api/v1/month-configs/61027ebb-ab75-4a49-9e23-a104ddd9ba6b/2017-10
+        type: string
+    type: object
+  controllers.MonthConfigListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/controllers.MonthConfig'
+        type: array
+    type: object
+  controllers.MonthConfigResponse:
+    properties:
+      data:
+        $ref: '#/definitions/controllers.MonthConfig'
+    type: object
   controllers.MonthResponse:
     properties:
       data:
@@ -604,6 +650,13 @@ definitions:
       name:
         description: The name of the Budget
         example: Zero budget
+        type: string
+    type: object
+  models.MonthConfigCreate:
+    properties:
+      overspendMode:
+        default: AFFECT_AVAILABLE
+        example: AFFECT_ENVELOPE
         type: string
     type: object
   models.TransactionCreate:
@@ -1938,6 +1991,216 @@ paths:
       summary: Import
       tags:
       - Import
+  /v1/month-configs:
+    get:
+      description: Returns a list of MonthConfigs
+      parameters:
+      - description: Filter by name
+        in: query
+        name: envelope
+        type: string
+      - description: Filter by month
+        in: query
+        name: month
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.MonthConfigListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: List MonthConfigs
+      tags:
+      - MonthConfigs
+    options:
+      description: Returns an empty response with the HTTP Header "allow" set to the
+        allowed HTTP verbs.
+      responses:
+        "204":
+          description: No Content
+      summary: Allowed HTTP verbs
+      tags:
+      - MonthConfigs
+  /v1/month-configs/{envelopeId}/{month}:
+    delete:
+      description: Deletes configuration settings for a specific month
+      parameters:
+      - description: ID of the Envelope
+        in: path
+        name: envelopeId
+        required: true
+        type: string
+      - description: The month in YYYY-MM format
+        in: path
+        name: month
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Delete MonthConfig
+      tags:
+      - MonthConfigs
+    get:
+      description: Returns configuration for a specific month
+      parameters:
+      - description: ID of the Envelope
+        in: path
+        name: envelopeId
+        required: true
+        type: string
+      - description: The month in YYYY-MM format
+        in: path
+        name: month
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.MonthConfigResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Get MonthConfig
+      tags:
+      - MonthConfigs
+    options:
+      description: Returns an empty response with the HTTP Header "allow" set to the
+        allowed HTTP verbs
+      parameters:
+      - description: ID of the Envelope
+        in: path
+        name: envelopeId
+        required: true
+        type: string
+      - description: The month in YYYY-MM format
+        in: path
+        name: month
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Allowed HTTP verbs
+      tags:
+      - MonthConfigs
+    patch:
+      description: Creates a new MonthConfig
+      parameters:
+      - description: ID of the Envelope
+        in: path
+        name: envelopeId
+        required: true
+        type: string
+      - description: The month in YYYY-MM format
+        in: path
+        name: month
+        required: true
+        type: string
+      - description: MonthConfig
+        in: body
+        name: monthConfig
+        required: true
+        schema:
+          $ref: '#/definitions/models.MonthConfigCreate'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/controllers.MonthConfigResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Create MonthConfig
+      tags:
+      - MonthConfigs
+    post:
+      description: Creates a new MonthConfig
+      parameters:
+      - description: ID of the Envelope
+        in: path
+        name: envelopeId
+        required: true
+        type: string
+      - description: The month in YYYY-MM format
+        in: path
+        name: month
+        required: true
+        type: string
+      - description: MonthConfig
+        in: body
+        name: monthConfig
+        required: true
+        schema:
+          $ref: '#/definitions/models.MonthConfigCreate'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/controllers.MonthConfigResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Create MonthConfig
+      tags:
+      - MonthConfigs
   /v1/months:
     delete:
       description: Deletes all allocation for the specified month

--- a/pkg/controllers/account.go
+++ b/pkg/controllers/account.go
@@ -290,7 +290,7 @@ func (co Controller) getAccountResource(c *gin.Context, id uuid.UUID) (models.Ac
 	var account models.Account
 
 	if !queryWithRetry(c, co.DB.Where(&models.Account{
-		Model: models.Model{
+		DefaultModel: models.DefaultModel{
 			ID: id,
 		},
 	}).First(&account), "No account found for the specified ID") {

--- a/pkg/controllers/allocation.go
+++ b/pkg/controllers/allocation.go
@@ -289,7 +289,7 @@ func (co Controller) getAllocationResource(c *gin.Context, id uuid.UUID) (models
 	var allocation models.Allocation
 
 	if !queryWithRetry(c, co.DB.First(&allocation, &models.Allocation{
-		Model: models.Model{
+		DefaultModel: models.DefaultModel{
 			ID: id,
 		},
 	}), "No allocation found for the specified ID") {

--- a/pkg/controllers/budget.go
+++ b/pkg/controllers/budget.go
@@ -592,7 +592,7 @@ func (co Controller) SetAllocationsMonth(c *gin.Context) {
 		// If the mode is the spend of last month, calculate and set it
 		amount := allocation.Amount
 		if data.Mode == AllocateLastMonthSpend {
-			amount = models.Envelope{Model: models.Model{ID: allocation.EnvelopeID}}.Spent(co.DB, pastMonth)
+			amount = models.Envelope{DefaultModel: models.DefaultModel{ID: allocation.EnvelopeID}}.Spent(co.DB, pastMonth)
 		}
 
 		if !queryWithRetry(c, co.DB.Create(&models.Allocation{
@@ -621,7 +621,7 @@ func (co Controller) getBudgetResource(c *gin.Context, id uuid.UUID) (models.Bud
 	var budget models.Budget
 
 	if !queryWithRetry(c, co.DB.Where(&models.Budget{
-		Model: models.Model{
+		DefaultModel: models.DefaultModel{
 			ID: id,
 		},
 	}).First(&budget), "No budget found for the specified ID") {

--- a/pkg/controllers/budget.go
+++ b/pkg/controllers/budget.go
@@ -215,7 +215,6 @@ func (co Controller) CreateBudget(c *gin.Context) {
 // @Success     200 {object} BudgetListResponse
 // @Failure     500 {object} httperrors.HTTPError
 // @Router      /v1/budgets [get]
-// @Router      /v1/budgets [get]
 // @Param       name     query string false "Filter by name"
 // @Param       note     query string false "Filter by note"
 // @Param       currency query string false "Filter by currency"

--- a/pkg/controllers/category.go
+++ b/pkg/controllers/category.go
@@ -283,7 +283,7 @@ func (co Controller) getCategoryResource(c *gin.Context, id uuid.UUID) (models.C
 	var category models.Category
 
 	if !queryWithRetry(c, co.DB.Where(&models.Category{
-		Model: models.Model{
+		DefaultModel: models.DefaultModel{
 			ID: id,
 		},
 	}).First(&category), "No category found for the specified ID") {

--- a/pkg/controllers/envelope.go
+++ b/pkg/controllers/envelope.go
@@ -331,7 +331,7 @@ func (co Controller) getEnvelopeResource(c *gin.Context, id uuid.UUID) (models.E
 	var envelope models.Envelope
 
 	if !queryWithRetry(c, co.DB.Where(&models.Envelope{
-		Model: models.Model{
+		DefaultModel: models.DefaultModel{
 			ID: id,
 		},
 	}).First(&envelope), "No envelope found for the specified ID") {

--- a/pkg/controllers/month.go
+++ b/pkg/controllers/month.go
@@ -23,8 +23,8 @@ type MonthResponse struct {
 // the budget resource itself.
 func (co Controller) parseMonthQuery(c *gin.Context) (time.Time, models.Budget, bool) {
 	var query struct {
-		Month    time.Time `form:"month" time_format:"2006-01" time_utc:"1" example:"2022-07"`
-		BudgetID string    `form:"budget" example:"81b0c9ce-6fd3-4e1e-becc-106055898a2a"`
+		QueryMonth
+		BudgetID string `form:"budget" example:"81b0c9ce-6fd3-4e1e-becc-106055898a2a"`
 	}
 
 	if err := c.Bind(&query); err != nil {

--- a/pkg/controllers/month.go
+++ b/pkg/controllers/month.go
@@ -268,7 +268,7 @@ func (co Controller) SetAllocations(c *gin.Context) {
 		// If the mode is the spend of last month, calculate and set it
 		amount := allocation.Amount
 		if data.Mode == AllocateLastMonthSpend {
-			amount = models.Envelope{Model: models.Model{ID: allocation.EnvelopeID}}.Spent(co.DB, pastMonth)
+			amount = models.Envelope{DefaultModel: models.DefaultModel{ID: allocation.EnvelopeID}}.Spent(co.DB, pastMonth)
 		}
 
 		if !queryWithRetry(c, co.DB.Create(&models.Allocation{

--- a/pkg/controllers/month_config.go
+++ b/pkg/controllers/month_config.go
@@ -1,0 +1,364 @@
+package controllers
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/envelope-zero/backend/pkg/httperrors"
+	"github.com/envelope-zero/backend/pkg/httputil"
+	"github.com/envelope-zero/backend/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+type MonthConfigLinks struct {
+	Self     string `json:"self" example:"https://example.com/api/v1/month-configs/61027ebb-ab75-4a49-9e23-a104ddd9ba6b/2017-10"`
+	Envelope string `json:"envelope" example:"https://example.com/api/v1/envelopes/61027ebb-ab75-4a49-9e23-a104ddd9ba6b"`
+}
+
+type MonthConfig struct {
+	models.MonthConfig
+	Links MonthConfigLinks `json:"links"`
+}
+
+type MonthConfigResponse struct {
+	Data MonthConfig `json:"data"`
+}
+
+type MonthConfigListResponse struct {
+	Data []MonthConfig `json:"data"`
+}
+
+type MonthConfigQueryFilter struct {
+	EnvelopeID string `form:"envelope"`
+	Month      string `form:"month"`
+}
+
+type MonthConfigFilter struct {
+	EnvelopeID uuid.UUID
+	Month      time.Time
+}
+
+func (m MonthConfigQueryFilter) Parse(c *gin.Context) (MonthConfigFilter, bool) {
+	envelopeID, ok := httputil.UUIDFromString(c, m.EnvelopeID)
+	if !ok {
+		return MonthConfigFilter{}, false
+	}
+
+	var month QueryMonth
+	if err := c.Bind(&month); err != nil {
+		httperrors.Handler(c, err)
+		return MonthConfigFilter{}, false
+	}
+
+	return MonthConfigFilter{
+		EnvelopeID: envelopeID,
+		Month:      month.Month,
+	}, true
+}
+
+// RegisterMonthConfigRoutes registers the routes for transactions with
+// the RouterGroup that is passed.
+func (co Controller) RegisterMonthConfigRoutes(r *gin.RouterGroup) {
+	r.OPTIONS("", co.OptionsMonthConfigList)
+	r.GET("", co.GetMonthConfigs)
+
+	r.OPTIONS("/:envelopeId/:month", co.OptionsMonthConfigDetail)
+	r.GET("/:envelopeId/:month", co.GetMonthConfig)
+	r.POST("/:envelopeId/:month", co.CreateMonthConfig)
+	r.PATCH("/:envelopeId/:month", co.UpdateMonthConfig)
+	r.DELETE("/:envelopeId/:month", co.DeleteMonthConfig)
+}
+
+// @Summary     Allowed HTTP verbs
+// @Description Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs.
+// @Tags        MonthConfigs
+// @Success     204
+// @Router      /v1/month-configs [options]
+func (co Controller) OptionsMonthConfigList(c *gin.Context) {
+	httputil.OptionsGet(c)
+}
+
+// @Summary     Allowed HTTP verbs
+// @Description Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
+// @Tags        MonthConfigs
+// @Success     204
+// @Failure     400        {object} httperrors.HTTPError
+// @Failure     404        {object} httperrors.HTTPError
+// @Param       envelopeId path     string true "ID of the Envelope"
+// @Param       month      path     string true "The month in YYYY-MM format"
+// @Router      /v1/month-configs/{envelopeId}/{month} [options]
+func (co Controller) OptionsMonthConfigDetail(c *gin.Context) {
+	_, err := uuid.Parse(c.Param("envelopeId"))
+	if err != nil {
+		httperrors.InvalidUUID(c)
+		return
+	}
+
+	var month URIMonth
+	if err := c.BindUri(&month); err != nil {
+		httperrors.InvalidMonth(c)
+		return
+	}
+
+	httputil.OptionsGetPostPatchDelete(c)
+}
+
+// @Summary     Get MonthConfig
+// @Description Returns configuration for a specific month
+// @Tags        MonthConfigs
+// @Produce     json
+// @Success     200        {object} MonthConfigResponse
+// @Failure     400        {object} httperrors.HTTPError
+// @Failure     404        {object} httperrors.HTTPError
+// @Param       envelopeId path     string true "ID of the Envelope"
+// @Param       month      path     string true "The month in YYYY-MM format"
+// @Router      /v1/month-configs/{envelopeId}/{month} [get]
+func (co Controller) GetMonthConfig(c *gin.Context) {
+	envelopeID, err := uuid.Parse(c.Param("envelopeId"))
+	if err != nil {
+		httperrors.InvalidUUID(c)
+		return
+	}
+
+	var month URIMonth
+	if err := c.BindUri(&month); err != nil {
+		httperrors.InvalidMonth(c)
+		return
+	}
+
+	_, ok := co.getEnvelopeObject(c, envelopeID)
+	if !ok {
+		return
+	}
+
+	mConfig, ok := co.getMonthConfigResource(c, envelopeID, month.Month)
+	if !ok {
+		return
+	}
+
+	c.JSON(http.StatusOK, MonthConfigResponse{Data: co.getMonthConfigObject(c, mConfig)})
+}
+
+// @Summary     List MonthConfigs
+// @Description Returns a list of MonthConfigs
+// @Tags        MonthConfigs
+// @Produce     json
+// @Success     200      {object} MonthConfigListResponse
+// @Failure     400      {object} httperrors.HTTPError
+// @Failure     404      {object} httperrors.HTTPError
+// @Failure     500      {object} httperrors.HTTPError
+// @Param       envelope query    string false "Filter by name"
+// @Param       month    query    string false "Filter by month"
+// @Router      /v1/month-configs [get]
+func (co Controller) GetMonthConfigs(c *gin.Context) {
+	var filter MonthConfigQueryFilter
+	if err := c.Bind(&filter); err != nil {
+		httperrors.InvalidQueryString(c)
+		return
+	}
+
+	// Get the set parameters in the query string
+	queryFields := httputil.GetURLFields(c.Request.URL, filter)
+
+	// Convert the QueryFilter to a Filter struct
+	parsed, ok := filter.Parse(c)
+	if !ok {
+		return
+	}
+
+	var mConfigs []models.MonthConfig
+	if !queryWithRetry(c, co.DB.Where(&models.MonthConfig{
+		EnvelopeID: parsed.EnvelopeID,
+		Month:      parsed.Month,
+	}, queryFields...).Find(&mConfigs)) {
+		return
+	}
+
+	// When there are no resources, we want an empty list, not null
+	// Therefore, we use make to create a slice with zero elements
+	// which will be marshalled to an empty JSON array
+	mConfigObjects := make([]MonthConfig, 0)
+
+	for _, mConfig := range mConfigs {
+		o := co.getMonthConfigObject(c, mConfig)
+		mConfigObjects = append(mConfigObjects, o)
+	}
+
+	c.JSON(http.StatusOK, MonthConfigListResponse{Data: mConfigObjects})
+}
+
+// @Summary     Create MonthConfig
+// @Description Creates a new MonthConfig
+// @Tags        MonthConfigs
+// @Produce     json
+// @Success     201         {object} MonthConfigResponse
+// @Failure     400         {object} httperrors.HTTPError
+// @Failure     404         {object} httperrors.HTTPError
+// @Failure     500         {object} httperrors.HTTPError
+// @Param       envelopeId  path     string                   true "ID of the Envelope"
+// @Param       month       path     string                   true "The month in YYYY-MM format"
+// @Param       monthConfig body     models.MonthConfigCreate true "MonthConfig"
+// @Router      /v1/month-configs/{envelopeId}/{month} [post]
+func (co Controller) CreateMonthConfig(c *gin.Context) {
+	envelopeID, err := uuid.Parse(c.Param("envelopeId"))
+	if err != nil {
+		httperrors.InvalidUUID(c)
+		return
+	}
+
+	var month URIMonth
+	if err := c.BindUri(&month); err != nil {
+		httperrors.InvalidMonth(c)
+		return
+	}
+
+	var mConfig models.MonthConfig
+	if err = httputil.BindData(c, &mConfig); err != nil {
+		return
+	}
+
+	// Set config to path parameters
+	mConfig.EnvelopeID = envelopeID
+	mConfig.Month = month.Month
+
+	_, ok := co.getEnvelopeResource(c, mConfig.EnvelopeID)
+	if !ok {
+		return
+	}
+
+	err = co.DB.Create(&mConfig).Error
+	if err != nil {
+		if !strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			httperrors.Handler(c, err)
+			return
+		}
+
+		httperrors.New(c, http.StatusBadRequest, "Cannot create MonthConfig for Envelope with ID %s and month %s as it already exists", mConfig.EnvelopeID, mConfig.Month)
+		return
+	}
+
+	mConfigObject := co.getMonthConfigObject(c, mConfig)
+	c.JSON(http.StatusCreated, MonthConfigResponse{Data: mConfigObject})
+}
+
+// @Summary     Create MonthConfig
+// @Description Creates a new MonthConfig
+// @Tags        MonthConfigs
+// @Produce     json
+// @Success     201         {object} MonthConfigResponse
+// @Failure     400         {object} httperrors.HTTPError
+// @Failure     500         {object} httperrors.HTTPError
+// @Param       envelopeId  path     string                   true "ID of the Envelope"
+// @Param       month       path     string                   true "The month in YYYY-MM format"
+// @Param       monthConfig body     models.MonthConfigCreate true "MonthConfig"
+// @Router      /v1/month-configs/{envelopeId}/{month} [patch]
+func (co Controller) UpdateMonthConfig(c *gin.Context) {
+	envelopeID, err := uuid.Parse(c.Param("envelopeId"))
+	if err != nil {
+		httperrors.InvalidUUID(c)
+		return
+	}
+
+	var month URIMonth
+	if err := c.BindUri(&month); err != nil {
+		httperrors.InvalidMonth(c)
+		return
+	}
+
+	_, ok := co.getEnvelopeResource(c, envelopeID)
+	if !ok {
+		return
+	}
+
+	mConfig, ok := co.getMonthConfigResource(c, envelopeID, month.Month)
+	if !ok {
+		return
+	}
+
+	updateFields, err := httputil.GetBodyFields(c, models.MonthConfigCreate{})
+	if err != nil {
+		return
+	}
+
+	var data models.MonthConfig
+	if err = httputil.BindData(c, &data); err != nil {
+		return
+	}
+
+	if !queryWithRetry(c, co.DB.Model(&mConfig).Select("", updateFields...).Updates(data)) {
+		return
+	}
+
+	c.JSON(http.StatusOK, MonthConfigResponse{Data: co.getMonthConfigObject(c, mConfig)})
+}
+
+// @Summary     Delete MonthConfig
+// @Description Deletes configuration settings for a specific month
+// @Tags        MonthConfigs
+// @Produce     json
+// @Success     204
+// @Failure     400        {object} httperrors.HTTPError
+// @Failure     404        {object} httperrors.HTTPError
+// @Param       envelopeId path     string true "ID of the Envelope"
+// @Param       month      path     string true "The month in YYYY-MM format"
+// @Router      /v1/month-configs/{envelopeId}/{month} [delete]
+func (co Controller) DeleteMonthConfig(c *gin.Context) {
+	envelopeID, err := uuid.Parse(c.Param("envelopeId"))
+	if err != nil {
+		httperrors.InvalidUUID(c)
+		return
+	}
+
+	var month URIMonth
+	if err := c.BindUri(&month); err != nil {
+		httperrors.InvalidMonth(c)
+		return
+	}
+
+	_, ok := co.getEnvelopeObject(c, envelopeID)
+	if !ok {
+		return
+	}
+
+	mConfig, ok := co.getMonthConfigResource(c, envelopeID, month.Month)
+	if !ok {
+		return
+	}
+
+	if !queryWithRetry(c, co.DB.Delete(&mConfig)) {
+		return
+	}
+
+	c.JSON(http.StatusNoContent, gin.H{})
+}
+
+func (co Controller) getMonthConfigObject(c *gin.Context, mConfig models.MonthConfig) MonthConfig {
+	return MonthConfig{
+		mConfig,
+		MonthConfigLinks{
+			Self: fmt.Sprintf("%s/v1/month-configs/%s/%d-%d", c.GetString("baseURL"), mConfig.EnvelopeID, mConfig.Month.Year(), mConfig.Month.Month()),
+		},
+	}
+}
+
+// getMonthConfigResource verifies that the request URI is valid for the transaction and returns it.
+func (co Controller) getMonthConfigResource(c *gin.Context, envelopeID uuid.UUID, month time.Time) (models.MonthConfig, bool) {
+	if envelopeID == uuid.Nil {
+		httperrors.New(c, http.StatusBadRequest, "no envelope ID specified")
+		return models.MonthConfig{}, false
+	}
+
+	var mConfig models.MonthConfig
+
+	if !queryWithRetry(c, co.DB.First(&mConfig, &models.MonthConfig{
+		EnvelopeID: envelopeID,
+		Month:      month,
+	}), "No MonthConfig found for the Envelope and month specified") {
+		return models.MonthConfig{}, false
+	}
+
+	return mConfig, true
+}

--- a/pkg/controllers/month_config_test.go
+++ b/pkg/controllers/month_config_test.go
@@ -1,0 +1,309 @@
+package controllers_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/envelope-zero/backend/pkg/controllers"
+	"github.com/envelope-zero/backend/pkg/models"
+	"github.com/envelope-zero/backend/test"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *TestSuiteStandard) createTestMonthConfig(envelopeID uuid.UUID, month time.Time, c models.MonthConfigCreate, expectedStatus ...int) controllers.MonthConfigResponse {
+	if envelopeID == uuid.Nil {
+		envelopeID = suite.createTestEnvelope(models.EnvelopeCreate{Name: "Transaction Test Envelope"}).Data.ID
+	}
+
+	// Default to 201 Created as expected status
+	if len(expectedStatus) == 0 {
+		expectedStatus = append(expectedStatus, http.StatusCreated)
+	}
+
+	monthString := fmt.Sprintf("%04d-%02d", month.Year(), month.Month())
+	path := fmt.Sprintf("http://example.com/v1/month-configs/%s/%s", envelopeID, monthString)
+	r := test.Request(suite.controller, suite.T(), http.MethodPost, path, c)
+	suite.assertHTTPStatus(&r, expectedStatus...)
+
+	var mc controllers.MonthConfigResponse
+	suite.decodeResponse(&r, &mc)
+
+	return mc
+}
+
+func (suite *TestSuiteStandard) TestMonthConfigsEmptyList() {
+	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/month-configs", "")
+
+	var l controllers.MonthConfigListResponse
+	suite.decodeResponse(&r, &l)
+
+	// Verify that the list is an empty list, not null
+	suite.Assert().NotNil(l.Data)
+	suite.Assert().Empty(l.Data)
+}
+
+func (suite *TestSuiteStandard) TestMonthConfigsCreate() {
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{})
+	someMonth := time.Date(2020, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		envelopeID uuid.UUID
+		month      time.Time
+		status     int
+	}{
+		{"Standard create", envelope.Data.ID, someMonth, http.StatusCreated},
+		{"duplicate config for same envelope and month", envelope.Data.ID, someMonth, http.StatusBadRequest},
+		{"No envelope", uuid.New(), someMonth, http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			_ = suite.createTestMonthConfig(tt.envelopeID, tt.month, models.MonthConfigCreate{}, tt.status)
+		})
+	}
+}
+
+func (suite *TestSuiteStandard) TestMonthConfigsCreateInvalid() {
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{})
+
+	tests := []struct {
+		name       string
+		envelopeID string
+		month      string
+		body       string
+	}{
+		{"Invalid Body", envelope.Data.ID.String(), "2022-03", `{"name": "not valid body"`},
+		{"Invaid UUID", "not a uuid", "2017-04", ""},
+		{"Invalid month", envelope.Data.ID.String(), "September Seventy Seven", ""},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			path := fmt.Sprintf("%s/%s/%s", "http://example.com/v1/month-configs", tt.envelopeID, tt.month)
+
+			recorder := test.Request(suite.controller, suite.T(), http.MethodPost, path, tt.body)
+			assert.Equal(t, http.StatusBadRequest, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
+		})
+	}
+}
+
+func (suite *TestSuiteStandard) TestMonthConfigsGet() {
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{})
+	someMonth := time.Date(2020, 3, 1, 0, 0, 0, 0, time.UTC)
+	someMonthString := fmt.Sprintf("%04d-%02d", someMonth.Year(), someMonth.Month())
+
+	_ = suite.createTestMonthConfig(envelope.Data.ID, someMonth, models.MonthConfigCreate{})
+
+	tests := []struct {
+		name       string
+		envelopeID string
+		month      string
+		status     int
+	}{
+		{"Standard get", envelope.Data.ID.String(), someMonthString, http.StatusOK},
+		{"No envelope", uuid.New().String(), someMonthString, http.StatusNotFound},
+		{"Invalid UUID", "Not a UUID", someMonthString, http.StatusBadRequest},
+		{"Invalid month", envelope.Data.ID.String(), "2193-1", http.StatusBadRequest},
+		{"No MonthConfig", envelope.Data.ID.String(), "0333-11", http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			path := fmt.Sprintf("%s/%s/%s", "http://example.com/v1/month-configs", tt.envelopeID, tt.month)
+
+			recorder := test.Request(suite.controller, suite.T(), http.MethodGet, path, "")
+			assert.Equal(t, tt.status, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
+		})
+	}
+}
+
+func (suite *TestSuiteStandard) TestMonthConfigsCreateDBError() {
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{})
+	suite.CloseDB()
+
+	_ = suite.createTestMonthConfig(envelope.Data.ID, time.Date(2020, 3, 1, 0, 0, 0, 0, time.UTC), models.MonthConfigCreate{}, http.StatusInternalServerError)
+}
+
+func (suite *TestSuiteStandard) TestMonthConfigsOptions() {
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{})
+	_ = suite.createTestMonthConfig(
+		envelope.Data.ID,
+		time.Date(2014, 5, 1, 0, 0, 0, 0, time.UTC),
+		models.MonthConfigCreate{},
+	)
+
+	tests := []struct {
+		name     string
+		envelope string
+		month    string
+		status   int
+		errMsg   string
+	}{
+		{"Bad Envelope ID", "Definitely-Not-A-UUID", "1984-03", http.StatusBadRequest, "not a valid UUID"},
+		{"Invalid Month", envelope.Data.ID.String(), "2000-00", http.StatusBadRequest, "Could not parse the specified month"},
+		{"No envelope", uuid.New().String(), "1984-03", http.StatusNoContent, ""},
+		{"No MonthConfig", envelope.Data.ID.String(), "1984-03", http.StatusNoContent, ""},
+		{"Existing", envelope.Data.ID.String(), "2014-05", http.StatusNoContent, ""},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			path := fmt.Sprintf("%s/%s/%s", "http://example.com/v1/month-configs", tt.envelope, tt.month)
+			recorder := test.Request(suite.controller, suite.T(), http.MethodOptions, path, "")
+			assert.Equal(t, tt.status, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
+
+			if tt.status != http.StatusNoContent {
+				assert.Contains(t, test.DecodeError(suite.T(), recorder.Body.Bytes()), tt.errMsg)
+			}
+		})
+	}
+}
+
+func (suite *TestSuiteStandard) TestMonthConfigsGetList() {
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{})
+	_ = suite.createTestMonthConfig(
+		envelope.Data.ID,
+		time.Date(2007, 10, 1, 0, 0, 0, 0, time.UTC),
+		models.MonthConfigCreate{},
+	)
+
+	_ = suite.createTestMonthConfig(
+		envelope.Data.ID,
+		time.Date(3017, 10, 1, 0, 0, 0, 0, time.UTC),
+		models.MonthConfigCreate{},
+	)
+
+	tests := []struct {
+		name   string
+		query  string
+		status int
+		length int
+	}{
+		{"No envelope", fmt.Sprintf("envelope=%s&month=%s", uuid.New().String(), "1984-03"), http.StatusOK, 0},
+		{"No MonthConfig", fmt.Sprintf("envelope=%s&month=%s", envelope.Data.ID.String(), "1984-03"), http.StatusOK, 0},
+		{"Exact MonthConfig", fmt.Sprintf("envelope=%s&month=%s", envelope.Data.ID.String(), "2007-10"), http.StatusOK, 1},
+		{"Month only", "month=2007-10", http.StatusOK, 1},
+		{"Envelope ID only", fmt.Sprintf("envelope=%s", envelope.Data.ID.String()), http.StatusOK, 2},
+		{"Bad Envelope ID", fmt.Sprintf("envelope=%s&month=%s", "Definitely-Not-A-UUID", "1984-03"), http.StatusBadRequest, 0},
+		{"Invalid Month", fmt.Sprintf("envelope=%s&month=%s", envelope.Data.ID.String(), "2000-00"), http.StatusBadRequest, 0},
+		{"Invalid query string", "envelope=;", http.StatusBadRequest, 0},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			path := fmt.Sprintf("%s?%s", "http://example.com/v1/month-configs", tt.query)
+			recorder := test.Request(suite.controller, suite.T(), http.MethodGet, path, "")
+			assert.Equal(t, tt.status, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
+
+			var l controllers.MonthConfigListResponse
+			suite.decodeResponse(&recorder, &l)
+			assert.Len(t, l.Data, tt.length)
+		})
+	}
+}
+
+func (suite *TestSuiteStandard) TestMonthConfigsGetDBError() {
+	suite.CloseDB()
+
+	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/month-configs", "")
+	suite.Assert().Equal(http.StatusInternalServerError, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
+}
+
+func (suite *TestSuiteStandard) TestMonthConfigsDelete() {
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{})
+	someMonth := time.Date(2020, 3, 1, 0, 0, 0, 0, time.UTC)
+	someMonthString := fmt.Sprintf("%04d-%02d", someMonth.Year(), someMonth.Month())
+
+	_ = suite.createTestMonthConfig(envelope.Data.ID, someMonth, models.MonthConfigCreate{})
+
+	tests := []struct {
+		name       string
+		envelopeID string
+		month      string
+		status     int
+	}{
+		{"Standard get", envelope.Data.ID.String(), someMonthString, http.StatusNoContent},
+		{"No envelope", uuid.New().String(), someMonthString, http.StatusNotFound},
+		{"Invalid UUID", "Not a UUID", someMonthString, http.StatusBadRequest},
+		{"Invalid month", envelope.Data.ID.String(), "2193-1", http.StatusBadRequest},
+		{"No MonthConfig", envelope.Data.ID.String(), "0333-11", http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			path := fmt.Sprintf("%s/%s/%s", "http://example.com/v1/month-configs", tt.envelopeID, tt.month)
+
+			recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, path, "")
+			assert.Equal(t, tt.status, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
+		})
+	}
+}
+
+func (suite *TestSuiteStandard) TestUpdateMonthConfig() {
+	mConfig := suite.createTestMonthConfig(uuid.Nil, time.Now(), models.MonthConfigCreate{})
+
+	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, mConfig.Data.Links.Self, models.MonthConfigCreate{
+		OverspendMode: "AFFECT_ENVELOPE",
+	})
+	suite.assertHTTPStatus(&recorder, http.StatusOK)
+
+	var updatedMonthConfig controllers.MonthConfigResponse
+	suite.decodeResponse(&recorder, &updatedMonthConfig)
+
+	var mode models.OverspendMode = "AFFECT_ENVELOPE"
+	assert.Equal(suite.T(), mode, updatedMonthConfig.Data.OverspendMode)
+}
+
+func (suite *TestSuiteStandard) TestMonthConfigsUpdateInvalid() {
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{})
+	mConfig := suite.createTestMonthConfig(envelope.Data.ID, time.Date(2022, 3, 1, 0, 0, 0, 0, time.UTC), models.MonthConfigCreate{})
+	mConfigMonthString := fmt.Sprintf("%04d-%02d", mConfig.Data.Month.Year(), mConfig.Data.Month.Month())
+
+	tests := []struct {
+		name       string
+		envelopeID string
+		month      string
+		body       string
+		status     int
+	}{
+		{"Invalid Body", envelope.Data.ID.String(), mConfigMonthString, `{"name": "not valid body"`, http.StatusBadRequest},
+		{"Invaid UUID", "not a uuid", "2017-04", "", http.StatusBadRequest},
+		{"Invalid month", envelope.Data.ID.String(), "September Seventy Seven", "", http.StatusBadRequest},
+		{"No envelope", uuid.NewString(), mConfigMonthString, "", http.StatusNotFound},
+		{"No month config", envelope.Data.ID.String(), "0137-12", "", http.StatusNotFound},
+		{"Broken values", envelope.Data.ID.String(), mConfigMonthString, `{"overspendMode": 2 }`, http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			path := fmt.Sprintf("%s/%s/%s", "http://example.com/v1/month-configs", tt.envelopeID, tt.month)
+
+			recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, path, tt.body)
+			assert.Equal(t, tt.status, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
+		})
+	}
+}
+
+func (suite *TestSuiteStandard) TestUpdateMonthConfigBrokenJSON() {
+	mConfig := suite.createTestMonthConfig(uuid.Nil, time.Now(), models.MonthConfigCreate{})
+
+	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, mConfig.Data.Links.Self, `{ test`)
+	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+}
+
+// func (suite *TestSuiteStandard) TestUpdateEnvelopeInvalidCategoryID() {
+// 	envelope := suite.createTestEnvelope(models.EnvelopeCreate{Name: "New envelope", Note: "Keks is a cuddly cat"})
+
+// 	// Sets the CategoryID to uuid.Nil
+// 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, envelope.Data.Links.Self, models.EnvelopeCreate{})
+// 	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+// }
+
+// func (suite *TestSuiteStandard) TestUpdateNonExistingEnvelope() {
+// 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/envelopes/dcf472ba-a64e-4f0f-900e-a789319e432c", `{ "name": "2" }`)
+// 	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+// }

--- a/pkg/controllers/test_options_test.go
+++ b/pkg/controllers/test_options_test.go
@@ -2,25 +2,32 @@ package controllers_test
 
 import (
 	"net/http"
+	"testing"
 
 	"github.com/envelope-zero/backend/test"
 	"github.com/stretchr/testify/assert"
 )
 
 func (suite *TestSuiteStandard) TestOptionsHeaderResources() {
-	optionsHeaderTests := []string{
-		"http://example.com/v1/budgets",
-		"http://example.com/v1/accounts",
-		"http://example.com/v1/categories",
-		"http://example.com/v1/envelopes",
-		"http://example.com/v1/allocations",
-		"http://example.com/v1/transactions",
+	optionsHeaderTests := []struct {
+		path     string
+		response string
+	}{
+		{"http://example.com/v1/budgets", "OPTIONS, GET, POST"},
+		{"http://example.com/v1/accounts", "OPTIONS, GET, POST"},
+		{"http://example.com/v1/categories", "OPTIONS, GET, POST"},
+		{"http://example.com/v1/envelopes", "OPTIONS, GET, POST"},
+		{"http://example.com/v1/allocations", "OPTIONS, GET, POST"},
+		{"http://example.com/v1/transactions", "OPTIONS, GET, POST"},
+		{"http://example.com/v1/month-configs", "OPTIONS, GET"},
 	}
 
-	for _, path := range optionsHeaderTests {
-		recorder := test.Request(suite.controller, suite.T(), http.MethodOptions, path, "")
+	for _, tt := range optionsHeaderTests {
+		suite.T().Run(tt.path, func(t *testing.T) {
+			recorder := test.Request(suite.controller, suite.T(), http.MethodOptions, tt.path, "")
 
-		assert.Equal(suite.T(), http.StatusNoContent, recorder.Code)
-		assert.Equal(suite.T(), recorder.Header().Get("allow"), "OPTIONS, GET, POST")
+			assert.Equal(suite.T(), http.StatusNoContent, recorder.Code)
+			assert.Equal(suite.T(), recorder.Header().Get("allow"), tt.response)
+		})
 	}
 }

--- a/pkg/controllers/transaction.go
+++ b/pkg/controllers/transaction.go
@@ -403,7 +403,7 @@ func (co Controller) getTransactionResource(c *gin.Context, id uuid.UUID) (model
 	var transaction models.Transaction
 
 	if !queryWithRetry(c, co.DB.First(&transaction, &models.Transaction{
-		Model: models.Model{
+		DefaultModel: models.DefaultModel{
 			ID: id,
 		},
 	}), "No transaction found for the specified ID") {

--- a/pkg/controllers/types.go
+++ b/pkg/controllers/types.go
@@ -10,3 +10,7 @@ import (
 type URIMonth struct {
 	Month time.Time `uri:"month" time_format:"2006-01" time_utc:"1"`
 }
+
+type QueryMonth struct {
+	Month time.Time `form:"month" time_format:"2006-01" time_utc:"1" example:"2022-07"`
+}

--- a/pkg/models/account.go
+++ b/pkg/models/account.go
@@ -8,7 +8,7 @@ import (
 
 // Account represents an asset account, e.g. a bank account.
 type Account struct {
-	Model
+	DefaultModel
 	AccountCreate
 	Budget            Budget          `json:"-"`
 	Balance           decimal.Decimal `json:"balance" gorm:"-" example:"2735.17"`

--- a/pkg/models/allocation.go
+++ b/pkg/models/allocation.go
@@ -9,7 +9,7 @@ import (
 
 // Allocation represents the allocation of money to an Envelope for a specific month.
 type Allocation struct {
-	Model
+	DefaultModel
 	AllocationCreate
 	Envelope Envelope `json:"-"`
 }

--- a/pkg/models/budget.go
+++ b/pkg/models/budget.go
@@ -14,7 +14,7 @@ import (
 // A budget is the highest level of organization in Envelope Zero, all other
 // resources reference it directly or transitively.
 type Budget struct {
-	Model
+	DefaultModel
 	BudgetCreate
 	Balance decimal.Decimal `json:"balance" gorm:"-" example:"3423.42"`
 }

--- a/pkg/models/category.go
+++ b/pkg/models/category.go
@@ -4,7 +4,7 @@ import "github.com/google/uuid"
 
 // Category represents a category of envelopes.
 type Category struct {
-	Model
+	DefaultModel
 	CategoryCreate
 	Budget Budget `json:"-"`
 }

--- a/pkg/models/database.go
+++ b/pkg/models/database.go
@@ -8,7 +8,7 @@ import (
 
 // Migrate migrates all models to the schema defined in the code.
 func Migrate(db *gorm.DB) error {
-	err := db.AutoMigrate(Budget{}, Account{}, Category{}, Envelope{}, Transaction{}, Allocation{})
+	err := db.AutoMigrate(Budget{}, Account{}, Category{}, Envelope{}, Transaction{}, Allocation{}, MonthConfig{})
 	if err != nil {
 		return fmt.Errorf("error during DB migration: %w", err)
 	}

--- a/pkg/models/envelope.go
+++ b/pkg/models/envelope.go
@@ -10,7 +10,7 @@ import (
 
 // Envelope represents an envelope in your budget.
 type Envelope struct {
-	Model
+	DefaultModel
 	EnvelopeCreate
 	Category Category `json:"-"`
 }

--- a/pkg/models/model.go
+++ b/pkg/models/model.go
@@ -7,9 +7,17 @@ import (
 	"gorm.io/gorm"
 )
 
-// Model is the base model for all other models in Envelope Zero.
-type Model struct {
-	ID        uuid.UUID       `json:"id" example:"65392deb-5e92-4268-b114-297faad6cdce"`
+// DefaultModel is the base model for most models in Envelope Zero.
+// As EnvelopeMonth uses the Envelope ID and the Month as primary key,
+// we the timestamps are managed in the Timestamps struct.
+type DefaultModel struct {
+	ID uuid.UUID `json:"id" example:"65392deb-5e92-4268-b114-297faad6cdce"`
+	Timestamps
+}
+
+// Timestamps only contains the timestamps that gorm sets automatically to enable other
+// primary keys than ID.
+type Timestamps struct {
 	CreatedAt time.Time       `json:"createdAt" example:"2022-04-02T19:28:44.491514Z"`
 	UpdatedAt time.Time       `json:"updatedAt" example:"2022-04-17T20:14:01.048145Z"`
 	DeletedAt *gorm.DeletedAt `json:"deletedAt" gorm:"index" example:"2022-04-22T21:01:05.058161Z" swaggertype:"primitive,string"`
@@ -20,7 +28,7 @@ type Model struct {
 //
 // We already store them in UTC, but somehow reading
 // them from the database returns them as +0000.
-func (m *Model) AfterFind(tx *gorm.DB) (err error) {
+func (m *DefaultModel) AfterFind(tx *gorm.DB) (err error) {
 	m.CreatedAt = m.CreatedAt.In(time.UTC)
 	m.UpdatedAt = m.UpdatedAt.In(time.UTC)
 
@@ -32,7 +40,7 @@ func (m *Model) AfterFind(tx *gorm.DB) (err error) {
 }
 
 // BeforeCreate is set to generate a UUID for the resource.
-func (m *Model) BeforeCreate(tx *gorm.DB) (err error) {
+func (m *DefaultModel) BeforeCreate(tx *gorm.DB) (err error) {
 	m.ID = uuid.New()
 	return nil
 }

--- a/pkg/models/model_test.go
+++ b/pkg/models/model_test.go
@@ -11,10 +11,12 @@ import (
 func (suite *TestSuiteStandard) TestModelTimeUTC() {
 	tz, _ := time.LoadLocation("Europe/Berlin")
 
-	model := models.Model{
-		CreatedAt: time.Date(2000, 1, 2, 3, 4, 5, 6, tz),
-		UpdatedAt: time.Date(2001, 2, 3, 4, 5, 6, 7, tz),
-		DeletedAt: &gorm.DeletedAt{Time: time.Now().In(tz)},
+	model := models.DefaultModel{
+		Timestamps: models.Timestamps{
+			CreatedAt: time.Date(2000, 1, 2, 3, 4, 5, 6, tz),
+			UpdatedAt: time.Date(2001, 2, 3, 4, 5, 6, 7, tz),
+			DeletedAt: &gorm.DeletedAt{Time: time.Now().In(tz)},
+		},
 	}
 
 	err := model.AfterFind(suite.db)

--- a/pkg/models/month_config.go
+++ b/pkg/models/month_config.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// swagger:enum OverspendMode
+type OverspendMode string
+
+const (
+	AffectEnvelope  OverspendMode = "AFFECT_ENVELOPE"
+	AffectAvailable OverspendMode = "AFFECT_AVAILABLE"
+)
+
+type MonthConfig struct {
+	Timestamps           // To include the gorm timestamps
+	EnvelopeID uuid.UUID `json:"envelopeId" gorm:"primaryKey" example:"10b9705d-3356-459e-9d5a-28d42a6c4547" `
+	Month      time.Time `json:"month" gorm:"primaryKey" example:"1969-06-01T00:00:00.000000Z"` // This is always set to 00:00 UTC on the first of the month.
+	MonthConfigCreate
+}
+
+type MonthConfigCreate struct {
+	OverspendMode OverspendMode `json:"overspendMode" example:"AFFECT_ENVELOPE" default:"AFFECT_AVAILABLE"`
+}

--- a/pkg/models/transaction.go
+++ b/pkg/models/transaction.go
@@ -10,7 +10,7 @@ import (
 
 // Transaction represents a transaction between two accounts.
 type Transaction struct {
-	Model
+	DefaultModel
 	TransactionCreate
 	Budget             Budget   `json:"-"`
 	SourceAccount      Account  `json:"-"`
@@ -35,7 +35,7 @@ type TransactionCreate struct {
 // We already store them in UTC, but somehow reading
 // them from the database returns them as +0000.
 func (t *Transaction) AfterFind(tx *gorm.DB) (err error) {
-	err = t.Model.AfterFind(tx)
+	err = t.DefaultModel.AfterFind(tx)
 	if err != nil {
 		return err
 	}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -128,6 +128,7 @@ func AttachRoutes(co controllers.Controller, group *gin.RouterGroup) {
 	co.RegisterAllocationRoutes(v1.Group("/allocations"))
 	co.RegisterMonthRoutes(v1.Group("/months"))
 	co.RegisterImportRoutes(v1.Group("/import"))
+	co.RegisterMonthConfigRoutes(v1.Group("/month-configs"))
 }
 
 type RootResponse struct {


### PR DESCRIPTION
This PR adds the **MonthConfigs** resource. With that resource, configurations for a month can be stored.

Allocations will be migrated to this resource later, see #440.

Commits:

- chore: split model into ID and Timestamps
- feat: add month-config resource and API endpoints
- docs: remove double declaration of route config
