### PR TITLE
fix: clean up MonthConfigs with DELETE /v1

### DIFF
--- a/pkg/controllers/cleanup.go
+++ b/pkg/controllers/cleanup.go
@@ -51,5 +51,11 @@ func (co Controller) DeleteAll(c *gin.Context) {
 		return
 	}
 
+	err = co.DB.Unscoped().Where("true").Delete(&models.MonthConfig{}).Error
+	if err != nil {
+		httperrors.Handler(c, err)
+		return
+	}
+
 	c.JSON(http.StatusNoContent, gin.H{})
 }

--- a/pkg/controllers/cleanup_test.go
+++ b/pkg/controllers/cleanup_test.go
@@ -2,19 +2,23 @@ package controllers_test
 
 import (
 	"net/http"
+	"testing"
+	"time"
 
 	"github.com/envelope-zero/backend/pkg/models"
 	"github.com/envelope-zero/backend/test"
 	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
 )
 
 func (suite *TestSuiteStandard) TestCleanup() {
 	_ = suite.createTestBudget(models.BudgetCreate{})
 	_ = suite.createTestAccount(models.AccountCreate{})
 	_ = suite.createTestCategory(models.CategoryCreate{})
-	_ = suite.createTestEnvelope(models.EnvelopeCreate{})
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{})
 	_ = suite.createTestAllocation(models.AllocationCreate{})
 	_ = suite.createTestTransaction(models.TransactionCreate{Amount: decimal.NewFromFloat(17.32)})
+	_ = suite.createTestMonthConfig(envelope.Data.ID, time.Now(), models.MonthConfigCreate{})
 
 	tests := []string{
 		"http://example.com/v1/budgets",
@@ -23,6 +27,7 @@ func (suite *TestSuiteStandard) TestCleanup() {
 		"http://example.com/v1/transactions",
 		"http://example.com/v1/envelopes",
 		"http://example.com/v1/allocations",
+		"http://example.com/v1/month-configs",
 	}
 
 	// Delete
@@ -31,7 +36,7 @@ func (suite *TestSuiteStandard) TestCleanup() {
 
 	// Verify
 	for _, tt := range tests {
-		suite.Run(tt, func() {
+		suite.T().Run(tt, func(t *testing.T) {
 			recorder := test.Request(suite.controller, suite.T(), http.MethodGet, tt, "")
 			suite.assertHTTPStatus(&recorder, http.StatusOK)
 
@@ -40,7 +45,7 @@ func (suite *TestSuiteStandard) TestCleanup() {
 			}
 
 			suite.decodeResponse(&recorder, &response)
-			suite.Assert().Len(response.Data, 0, "There are resources left for type %s", tt)
+			assert.Len(t, response.Data, 0, "There are resources left for type %s", tt)
 		})
 	}
 }


### PR DESCRIPTION
This adds MonthConfigs to the DELETE /v1 cleanup endpoint.
