### PR TITLE
ci: do not exclude any commits from the changelog

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,13 +36,6 @@ changelog:
       regexp: "^.*chore(deps):+.*$"
       order: 3
 
-  filters:
-    # Commit messages matching the regexp listed here will be removed from
-    # the changelog
-    exclude:
-      - "^docs:"
-      - "^test:"
-
 dockers:
   - dockerfile: Dockerfile.goreleaser
     image_templates:


### PR DESCRIPTION
With this change, all commits are included in the changelog. This makes 
the changelog less confusing when cross-referencing commits to the changelog.
