### PR TITLE
docs: fix wrong description of MonthConfigs PATCH API endpoint

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2088,14 +2088,14 @@ const docTemplate = `{
                 }
             },
             "patch": {
-                "description": "Creates a new MonthConfig",
+                "description": "Changes settings of an existing MonthConfig",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "MonthConfigs"
                 ],
-                "summary": "Create MonthConfig",
+                "summary": "Update MonthConfig",
                 "parameters": [
                     {
                         "type": "string",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2076,14 +2076,14 @@
                 }
             },
             "patch": {
-                "description": "Creates a new MonthConfig",
+                "description": "Changes settings of an existing MonthConfig",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "MonthConfigs"
                 ],
-                "summary": "Create MonthConfig",
+                "summary": "Update MonthConfig",
                 "parameters": [
                     {
                         "type": "string",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2124,7 +2124,7 @@ paths:
       tags:
       - MonthConfigs
     patch:
-      description: Creates a new MonthConfig
+      description: Changes settings of an existing MonthConfig
       parameters:
       - description: ID of the Envelope
         in: path
@@ -2157,7 +2157,7 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/httperrors.HTTPError'
-      summary: Create MonthConfig
+      summary: Update MonthConfig
       tags:
       - MonthConfigs
     post:

--- a/pkg/controllers/month_config.go
+++ b/pkg/controllers/month_config.go
@@ -244,8 +244,8 @@ func (co Controller) CreateMonthConfig(c *gin.Context) {
 	c.JSON(http.StatusCreated, MonthConfigResponse{Data: mConfigObject})
 }
 
-// @Summary     Create MonthConfig
-// @Description Creates a new MonthConfig
+// @Summary     Update MonthConfig
+// @Description Changes settings of an existing MonthConfig
 // @Tags        MonthConfigs
 // @Produce     json
 // @Success     201         {object} MonthConfigResponse


### PR DESCRIPTION
Fixes a copy-paste error for the API documentation.
