### PR TITLE
docs: correct API documentation for import endpoint

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1769,7 +1769,7 @@ const docTemplate = `{
         },
         "/v1/import": {
             "post": {
-                "description": "Imports data from other sources. Resources with the same name are ignored. Accepts CSV files in the following formats: YNAB Import (use [YNAP](https://ynap.leolabs.org/) to convert your bank statement), YNAB 4 Register export, and YNAB 4 Budget export.",
+                "description": "Imports budgets from YNAB 4",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -1790,7 +1790,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Name of the Budget to create for a YNAB 4 import. Ignored for all other imports",
+                        "description": "Name of the Budget to create",
                         "name": "budgetName",
                         "in": "query"
                     }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1757,7 +1757,7 @@
         },
         "/v1/import": {
             "post": {
-                "description": "Imports data from other sources. Resources with the same name are ignored. Accepts CSV files in the following formats: YNAB Import (use [YNAP](https://ynap.leolabs.org/) to convert your bank statement), YNAB 4 Register export, and YNAB 4 Budget export.",
+                "description": "Imports budgets from YNAB 4",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -1778,7 +1778,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Name of the Budget to create for a YNAB 4 import. Ignored for all other imports",
+                        "description": "Name of the Budget to create",
                         "name": "budgetName",
                         "in": "query"
                     }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1960,18 +1960,14 @@ paths:
     post:
       consumes:
       - multipart/form-data
-      description: 'Imports data from other sources. Resources with the same name
-        are ignored. Accepts CSV files in the following formats: YNAB Import (use
-        [YNAP](https://ynap.leolabs.org/) to convert your bank statement), YNAB 4
-        Register export, and YNAB 4 Budget export.'
+      description: Imports budgets from YNAB 4
       parameters:
       - description: File to import
         in: formData
         name: file
         required: true
         type: file
-      - description: Name of the Budget to create for a YNAB 4 import. Ignored for
-          all other imports
+      - description: Name of the Budget to create
         in: query
         name: budgetName
         type: string

--- a/pkg/controllers/import.go
+++ b/pkg/controllers/import.go
@@ -38,7 +38,7 @@ func (co Controller) OptionsImport(c *gin.Context) {
 }
 
 // @Summary     Import
-// @Description Imports data from other sources. Resources with the same name are ignored. Accepts CSV files in the following formats: YNAB Import (use [YNAP](https://ynap.leolabs.org/) to convert your bank statement), YNAB 4 Register export, and YNAB 4 Budget export.
+// @Description Imports budgets from YNAB 4
 // @Tags        Import
 // @Accept      multipart/form-data
 // @Produce     json
@@ -46,7 +46,7 @@ func (co Controller) OptionsImport(c *gin.Context) {
 // @Failure     400        {object} httperrors.HTTPError
 // @Failure     500        {object} httperrors.HTTPError
 // @Param       file       formData file   true  "File to import"
-// @Param       budgetName query    string false "Name of the Budget to create for a YNAB 4 import. Ignored for all other imports"
+// @Param       budgetName query    string false "Name of the Budget to create"
 // @Router      /v1/import [post]
 func (co Controller) Import(c *gin.Context) {
 	var query ImportQuery


### PR DESCRIPTION
Fixes API documentation that contained information about planned features.

As those are not implemented yet, they should not be documented like they were.
