### PR TITLE
feat: make ynab4 import available at /v1/import/ynab4

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1769,6 +1769,73 @@ const docTemplate = `{
         },
         "/v1/import": {
             "post": {
+                "description": "Imports budgets from YNAB 4. **Please use /v1/import/ynab4, which works exactly the same.**",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Import"
+                ],
+                "summary": "Import",
+                "deprecated": true,
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "File to import",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Name of the Budget to create",
+                        "name": "budgetName",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs. **Please use /v1/import/ynab4, which works exactly the same.**",
+                "tags": [
+                    "Import"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "deprecated": true,
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/import/ynab4": {
+            "post": {
                 "description": "Imports budgets from YNAB 4",
                 "consumes": [
                     "multipart/form-data"

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1757,6 +1757,73 @@
         },
         "/v1/import": {
             "post": {
+                "description": "Imports budgets from YNAB 4. **Please use /v1/import/ynab4, which works exactly the same.**",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Import"
+                ],
+                "summary": "Import",
+                "deprecated": true,
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "File to import",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Name of the Budget to create",
+                        "name": "budgetName",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs. **Please use /v1/import/ynab4, which works exactly the same.**",
+                "tags": [
+                    "Import"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "deprecated": true,
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/import/ynab4": {
+            "post": {
                 "description": "Imports budgets from YNAB 4",
                 "consumes": [
                     "multipart/form-data"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1945,6 +1945,54 @@ paths:
       - Envelopes
   /v1/import:
     options:
+      deprecated: true
+      description: Returns an empty response with the HTTP Header "allow" set to the
+        allowed HTTP verbs. **Please use /v1/import/ynab4, which works exactly the
+        same.**
+      responses:
+        "204":
+          description: No Content
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Allowed HTTP verbs
+      tags:
+      - Import
+    post:
+      consumes:
+      - multipart/form-data
+      deprecated: true
+      description: Imports budgets from YNAB 4. **Please use /v1/import/ynab4, which
+        works exactly the same.**
+      parameters:
+      - description: File to import
+        in: formData
+        name: file
+        required: true
+        type: file
+      - description: Name of the Budget to create
+        in: query
+        name: budgetName
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Import
+      tags:
+      - Import
+  /v1/import/ynab4:
+    options:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       responses:

--- a/pkg/controllers/import.go
+++ b/pkg/controllers/import.go
@@ -24,7 +24,21 @@ func (co Controller) RegisterImportRoutes(r *gin.RouterGroup) {
 	{
 		r.OPTIONS("", co.OptionsImport)
 		r.POST("", co.Import)
+
+		r.OPTIONS("/ynab4", co.OptionsImportYnab4)
+		r.POST("/ynab4", co.ImportYnab4)
 	}
+}
+
+// @Summary     Allowed HTTP verbs
+// @Description Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs. **Please use /v1/import/ynab4, which works exactly the same.**
+// @Tags        Import
+// @Success     204
+// @Failure     500 {object} httperrors.HTTPError
+// @Router      /v1/import [options]
+// @Deprecated  true
+func (co Controller) OptionsImport(c *gin.Context) {
+	httputil.OptionsPost(c)
 }
 
 // @Summary     Allowed HTTP verbs
@@ -32,9 +46,25 @@ func (co Controller) RegisterImportRoutes(r *gin.RouterGroup) {
 // @Tags        Import
 // @Success     204
 // @Failure     500 {object} httperrors.HTTPError
-// @Router      /v1/import [options]
-func (co Controller) OptionsImport(c *gin.Context) {
+// @Router      /v1/import/ynab4 [options]
+func (co Controller) OptionsImportYnab4(c *gin.Context) {
 	httputil.OptionsPost(c)
+}
+
+// @Summary     Import
+// @Description Imports budgets from YNAB 4. **Please use /v1/import/ynab4, which works exactly the same.**
+// @Tags        Import
+// @Accept      multipart/form-data
+// @Produce     json
+// @Success     204
+// @Failure     400        {object} httperrors.HTTPError
+// @Failure     500        {object} httperrors.HTTPError
+// @Param       file       formData file   true  "File to import"
+// @Param       budgetName query    string false "Name of the Budget to create"
+// @Router      /v1/import [post]
+// @Deprecated  true
+func (co Controller) Import(c *gin.Context) {
+	co.ImportYnab4(c)
 }
 
 // @Summary     Import
@@ -47,8 +77,8 @@ func (co Controller) OptionsImport(c *gin.Context) {
 // @Failure     500        {object} httperrors.HTTPError
 // @Param       file       formData file   true  "File to import"
 // @Param       budgetName query    string false "Name of the Budget to create"
-// @Router      /v1/import [post]
-func (co Controller) Import(c *gin.Context) {
+// @Router      /v1/import/ynab4 [post]
+func (co Controller) ImportYnab4(c *gin.Context) {
 	var query ImportQuery
 	if err := c.BindQuery(&query); err != nil {
 		httperrors.New(c, http.StatusBadRequest, "The budgetName parameter must be set")

--- a/pkg/controllers/import_test.go
+++ b/pkg/controllers/import_test.go
@@ -41,6 +41,10 @@ func (suite *TestSuiteStandard) TestOptionsImport() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/import", "")
 	suite.Assert().Equal(http.StatusNoContent, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
 	suite.Assert().Equal(recorder.Header().Get("allow"), "OPTIONS, POST")
+
+	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/import/ynab4", "")
+	suite.Assert().Equal(http.StatusNoContent, recorder.Code, "Request ID %s", recorder.Header().Get("x-request-id"))
+	suite.Assert().Equal(recorder.Header().Get("allow"), "OPTIONS, POST")
 }
 
 func (suite *TestSuiteStandard) TestImportFails() {


### PR DESCRIPTION
This makes the YNAB 4 import available at `/v1/import/ynab4` as preparation for #465.
