### PR TITLE
fix: unset envelope for subtransaction in YNAB 4 import if not defined

### DIFF
--- a/pkg/importer/parser/ynab4/parse.go
+++ b/pkg/importer/parser/ynab4/parse.go
@@ -318,6 +318,9 @@ func parseTransactions(resources *types.ParsedResources, transactions []Transact
 			if mapping, ok := envelopeIDNames[sub.CategoryID]; ok {
 				newTransaction.Envelope = mapping.Envelope
 				newTransaction.Category = mapping.Category
+			} else {
+				newTransaction.Envelope = ""
+				newTransaction.Category = ""
 			}
 
 			if sub.Amount.IsPositive() {


### PR DESCRIPTION
Fixes an error with YNAB 4 imports that incorrectly imported split transactions when the split does not have a Category or is an Income transaction.
