### PR TITLE
test(golangci-lint): remove explicit version for gofumpt

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,7 +44,6 @@ linters:
 
 linters-settings:
   gofumpt:
-    lang-version: "1.19"
     extra-rules: true
   gocyclo:
     min-complexity: 15

--- a/renovate.json
+++ b/renovate.json
@@ -24,14 +24,6 @@
       "matchStrings": [
         "# renovate:\\sdatasource=(?<datasource>.*?)\\sdepName=(?<depName>.*?)\\s.*@(?<currentValue>.*)"
       ]
-    },
-    {
-      "description": "Upgrade go minor for golangci-lint",
-      "fileMatch": ["^\\.golangci\\.yml"],
-      "matchStrings": ["lang-version: \"(?<currentValue>.*)\""],
-      "datasourceTemplate": "github-tags",
-      "depNameTemplate": "golang/go",
-      "versioningTemplate": "docker"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
By default, gofumpt uses the language version from go.mod,
which reduces the need for maintenance here.
