### PR TITLE
docs: update funcs documentation with go 1.19 doc standards

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,13 +30,8 @@ linters:
   enable:
     - gocyclo
     - godot
-    # Disabled as the latest version - 0.4.0 from 2022-09-27 is not built with go 1.19 and
-    # therefore disagrees with swag fmt about the formatting of the swagger comments.
-    # See https://github.com/mvdan/gofumpt/issues/254
-    # - gofumpt
-
-    # Disabled since goimports reformats correct 1.19 doc comments
-    # - goimports
+    - gofumpt
+    - goimports
     - govet
     - revive
     - whitespace
@@ -50,4 +45,4 @@ linters-settings:
 
   godot:
     exclude:
-      - "^ @[A-Za-z]+ "
+      - "^\t+@[A-Za-z]+\t+"

--- a/pkg/controllers/account.go
+++ b/pkg/controllers/account.go
@@ -71,6 +71,8 @@ func (co Controller) RegisterAccountRoutes(r *gin.RouterGroup) {
 	}
 }
 
+// OptionsAccountList returns the allowed HTTP verbs
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			Accounts
@@ -82,6 +84,8 @@ func (co Controller) OptionsAccountList(c *gin.Context) {
 	httputil.OptionsGetPost(c)
 }
 
+// OptionsAccountDetail returns the allowed HTTP verbs
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			Accounts
@@ -104,6 +108,8 @@ func (co Controller) OptionsAccountDetail(c *gin.Context) {
 	httputil.OptionsGetPatchDelete(c)
 }
 
+// CreateAccount creates a new account
+//
 //	@Summary		Create account
 //	@Description	Creates a new account
 //	@Tags			Accounts
@@ -135,6 +141,8 @@ func (co Controller) CreateAccount(c *gin.Context) {
 	c.JSON(http.StatusCreated, AccountResponse{Data: accountObject})
 }
 
+// GetAccounts returns a list of all accounts matching the filter parameters
+//
 //	@Summary		List accounts
 //	@Description	Returns a list of accounts
 //	@Tags			Accounts
@@ -185,6 +193,8 @@ func (co Controller) GetAccounts(c *gin.Context) {
 	c.JSON(http.StatusOK, AccountListResponse{Data: accountObjects})
 }
 
+// GetAccount returns data for a specific account
+//
 //	@Summary		Get account
 //	@Description	Returns a specific account
 //	@Tags			Accounts
@@ -210,6 +220,8 @@ func (co Controller) GetAccount(c *gin.Context) {
 	c.JSON(http.StatusOK, AccountResponse{Data: accountObject})
 }
 
+// UpdateAccount updates data for a specific account
+//
 //	@Summary		Update account
 //	@Description	Updates an account. Only values to be updated need to be specified.
 //	@Tags			Accounts
@@ -251,6 +263,8 @@ func (co Controller) UpdateAccount(c *gin.Context) {
 	c.JSON(http.StatusOK, AccountResponse{Data: accountObject})
 }
 
+// DeleteAccount deletes an account
+//
 //	@Summary		Delete account
 //	@Description	Deletes an account
 //	@Tags			Accounts

--- a/pkg/controllers/allocation.go
+++ b/pkg/controllers/allocation.go
@@ -69,6 +69,8 @@ func (co Controller) RegisterAllocationRoutes(r *gin.RouterGroup) {
 	}
 }
 
+// OptionsAllocationList returns the allowed HTTP verbs
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			Allocations
@@ -78,6 +80,8 @@ func (co Controller) OptionsAllocationList(c *gin.Context) {
 	httputil.OptionsGetPost(c)
 }
 
+// OptionsAllocationDetail returns the allowed HTTP verbs
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			Allocations
@@ -98,6 +102,8 @@ func (co Controller) OptionsAllocationDetail(c *gin.Context) {
 	httputil.OptionsGetPatchDelete(c)
 }
 
+// CreateAllocation creates a new allocation
+//
 //	@Summary		Create allocations
 //	@Description	Create a new allocation of funds to an envelope for a specific month
 //	@Tags			Allocations
@@ -132,6 +138,8 @@ func (co Controller) CreateAllocation(c *gin.Context) {
 	c.JSON(http.StatusCreated, AllocationResponse{Data: allocationObject})
 }
 
+// GetAllocations returns a list of allocations matching the search parameters
+//
 //	@Summary		Get allocations
 //	@Description	Returns a list of allocations
 //	@Tags			Allocations
@@ -180,6 +188,8 @@ func (co Controller) GetAllocations(c *gin.Context) {
 	c.JSON(http.StatusOK, AllocationListResponse{Data: allocationObjects})
 }
 
+// GetAllocation returns data about a specific allocation
+//
 //	@Summary		Get allocation
 //	@Description	Returns a specific allocation
 //	@Tags			Allocations
@@ -205,6 +215,8 @@ func (co Controller) GetAllocation(c *gin.Context) {
 	c.JSON(http.StatusOK, AllocationResponse{Data: allocationObject})
 }
 
+// UpdateAllocation updates allocation data
+//
 //	@Summary		Update allocation
 //	@Description	Update an allocation. Only values to be updated need to be specified.
 //	@Tags			Allocations
@@ -250,6 +262,8 @@ func (co Controller) UpdateAllocation(c *gin.Context) {
 	c.JSON(http.StatusOK, AllocationResponse{Data: allocationObject})
 }
 
+// DeleteAllocation deletes an allocation
+//
 //	@Summary		Delete allocation
 //	@Description	Deletes an allocation
 //	@Tags			Allocations

--- a/pkg/controllers/budget.go
+++ b/pkg/controllers/budget.go
@@ -83,6 +83,8 @@ func (co Controller) RegisterBudgetRoutes(r *gin.RouterGroup) {
 	}
 }
 
+// OptionsBudgetList returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			Budgets
@@ -93,6 +95,8 @@ func (co Controller) OptionsBudgetList(c *gin.Context) {
 	httputil.OptionsGetPost(c)
 }
 
+// OptionsBudgetDetail returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			Budgets
@@ -116,6 +120,8 @@ func (co Controller) OptionsBudgetDetail(c *gin.Context) {
 	httputil.OptionsGetPatchDelete(c)
 }
 
+// OptionsBudgetMonth returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs. **Use OPTIONS /month endpoint with month and budgetId query parameters instead.**
 //	@Tags			Budgets
@@ -147,6 +153,8 @@ func (co Controller) OptionsBudgetMonth(c *gin.Context) {
 	httputil.OptionsGet(c)
 }
 
+// OptionsBudgetMonthAllocations returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs. **Use OPTIONS /month endpoint with month and budgetId query parameters instead.**
 //	@Tags			Budgets
@@ -179,6 +187,8 @@ func (co Controller) OptionsBudgetMonthAllocations(c *gin.Context) {
 	httputil.OptionsDelete(c)
 }
 
+// CreateBudget creates a new budget
+//
 //	@Summary		Create budget
 //	@Description	Creates a new budget
 //	@Tags			Budgets
@@ -208,6 +218,8 @@ func (co Controller) CreateBudget(c *gin.Context) {
 	c.JSON(http.StatusCreated, BudgetResponse{Data: budgetObject})
 }
 
+// GetBudgets returns data for all budgets filtered by the query parameters
+//
 //	@Summary		List budgets
 //	@Description	Returns a list of budgets
 //	@Tags			Budgets
@@ -252,6 +264,8 @@ func (co Controller) GetBudgets(c *gin.Context) {
 	c.JSON(http.StatusOK, BudgetListResponse{Data: budgetObjects})
 }
 
+// GetBudget returns data for a single budget
+//
 //	@Summary		Get budget
 //	@Description	Returns a specific budget
 //	@Tags			Budgets
@@ -277,6 +291,8 @@ func (co Controller) GetBudget(c *gin.Context) {
 	c.JSON(http.StatusOK, BudgetResponse{Data: budgetObject})
 }
 
+// GetBudgetMonth returns data for a month for a specific budget
+//
 //	@Summary		Get Budget month data
 //	@Description	Returns data about a budget for a for a specific month. **Use GET /month endpoint with month and budgetId query parameters instead.**
 //	@Tags			Budgets
@@ -391,6 +407,8 @@ func (co Controller) GetBudgetMonth(c *gin.Context) {
 	}})
 }
 
+// UpdateBudget updates data for a budget
+//
 //	@Summary		Update budget
 //	@Description	Update an existing budget. Only values to be updated need to be specified.
 //	@Tags			Budgets
@@ -437,6 +455,8 @@ func (co Controller) UpdateBudget(c *gin.Context) {
 	c.JSON(http.StatusOK, BudgetResponse{Data: budgetObject})
 }
 
+// Do stuff
+//
 //	@Summary		Delete budget
 //	@Description	Deletes a budget
 //	@Tags			Budgets
@@ -465,6 +485,8 @@ func (co Controller) DeleteBudget(c *gin.Context) {
 	c.JSON(http.StatusNoContent, gin.H{})
 }
 
+// DeleteAllocationsMonth deletes all allocations for a specific month
+//
 //	@Summary		Delete allocations for a month
 //	@Description	Deletes all allocation for the specified month. **Use DELETE /month endpoint with month and budgetId query parameters instead.**
 //	@Tags			Budgets
@@ -520,6 +542,8 @@ func (co Controller) DeleteAllocationsMonth(c *gin.Context) {
 	c.JSON(http.StatusNoContent, gin.H{})
 }
 
+// SetAllocationsMonth sets all allocations for a specific month
+//
 //	@Summary		Set allocations for a month
 //	@Description	Sets allocations for a month for all envelopes that do not have an allocation yet. **Use POST /month endpoint with month and budgetId query parameters instead.**
 //	@Tags			Budgets

--- a/pkg/controllers/category.go
+++ b/pkg/controllers/category.go
@@ -68,6 +68,8 @@ func (co Controller) RegisterCategoryRoutes(r *gin.RouterGroup) {
 	}
 }
 
+// OptionsCategoryList returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			Categories
@@ -79,6 +81,8 @@ func (co Controller) OptionsCategoryList(c *gin.Context) {
 	httputil.OptionsGetPost(c)
 }
 
+// OptionsCategoryDetail returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			Categories
@@ -101,6 +105,8 @@ func (co Controller) OptionsCategoryDetail(c *gin.Context) {
 	httputil.OptionsGetPatchDelete(c)
 }
 
+// CreateCategory creates a new category
+//
 //	@Summary		Create category
 //	@Description	Creates a new category
 //	@Tags			Categories
@@ -132,6 +138,8 @@ func (co Controller) CreateCategory(c *gin.Context) {
 	c.JSON(http.StatusCreated, CategoryResponse{Data: categoryObject})
 }
 
+// GetCategories returns a list of categories filtered by the query parameters
+//
 //	@Summary		Get categories
 //	@Description	Returns a list of categories
 //	@Tags			Categories
@@ -179,6 +187,8 @@ func (co Controller) GetCategories(c *gin.Context) {
 	c.JSON(http.StatusOK, CategoryListResponse{Data: categoryObjects})
 }
 
+// GetCategory returns data for a specific category
+//
 //	@Summary		Get category
 //	@Description	Returns a specific category
 //	@Tags			Categories
@@ -204,6 +214,8 @@ func (co Controller) GetCategory(c *gin.Context) {
 	c.JSON(http.StatusOK, CategoryResponse{Data: categoryObject})
 }
 
+// UpdateCategory updates data for a specific category
+//
 //	@Summary		Update category
 //	@Description	Update an existing category. Only values to be updated need to be specified.
 //	@Tags			Categories
@@ -246,6 +258,8 @@ func (co Controller) UpdateCategory(c *gin.Context) {
 	c.JSON(http.StatusOK, CategoryResponse{Data: categoryObject})
 }
 
+// DeleteCategory deletes a specific category
+//
 //	@Summary		Delete category
 //	@Description	Deletes a category
 //	@Tags			Categories

--- a/pkg/controllers/cleanup.go
+++ b/pkg/controllers/cleanup.go
@@ -8,6 +8,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// DeleteAll permanently deletes all resources in the database
+//
 //	@Summary		Delete everything
 //	@Description	Permanently deletes all resources
 //	@Tags			v1

--- a/pkg/controllers/envelope.go
+++ b/pkg/controllers/envelope.go
@@ -74,6 +74,8 @@ func (co Controller) RegisterEnvelopeRoutes(r *gin.RouterGroup) {
 	}
 }
 
+// OptionsEnvelopeList returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			Envelopes
@@ -83,6 +85,8 @@ func (co Controller) OptionsEnvelopeList(c *gin.Context) {
 	httputil.OptionsGetPost(c)
 }
 
+// OptionsEnvelopeDetail returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			Envelopes
@@ -104,6 +108,8 @@ func (co Controller) OptionsEnvelopeDetail(c *gin.Context) {
 	httputil.OptionsGetPatchDelete(c)
 }
 
+// CreateEnvelope creates a new envelope
+//
 //	@Summary		Create envelope
 //	@Description	Creates a new envelope
 //	@Tags			Envelopes
@@ -135,6 +141,8 @@ func (co Controller) CreateEnvelope(c *gin.Context) {
 	c.JSON(http.StatusCreated, EnvelopeResponse{Data: envelopeObject})
 }
 
+// GetEnvelopes returns a list of envelopes filtered by the query parameters
+//
 //	@Summary		Get envelopes
 //	@Description	Returns a list of envelopes
 //	@Tags			Envelopes
@@ -181,6 +189,8 @@ func (co Controller) GetEnvelopes(c *gin.Context) {
 	c.JSON(http.StatusOK, EnvelopeListResponse{Data: envelopeObjects})
 }
 
+// GetEnvelope returns data about a specific envelope
+//
 //	@Summary		Get envelope
 //	@Description	Returns a specific envelope
 //	@Tags			Envelopes
@@ -206,6 +216,8 @@ func (co Controller) GetEnvelope(c *gin.Context) {
 	c.JSON(http.StatusOK, EnvelopeResponse{Data: envelopeObject})
 }
 
+// GetEnvelopeMonth returns month data for a specific envelope
+//
 //	@Summary		Get Envelope month data
 //	@Description	Returns data about an envelope for a for a specific month. **Use GET /month endpoint with month and budgetId query parameters instead.**
 //	@Tags			Envelopes
@@ -251,6 +263,8 @@ func (co Controller) GetEnvelopeMonth(c *gin.Context) {
 	c.JSON(http.StatusOK, EnvelopeMonthResponse{Data: envelopeMonth})
 }
 
+// UpdateEnvelope updates data for an envelope
+//
 //	@Summary		Update envelope
 //	@Description	Updates an existing envelope. Only values to be updated need to be specified.
 //	@Tags			Envelopes
@@ -293,6 +307,8 @@ func (co Controller) UpdateEnvelope(c *gin.Context) {
 	c.JSON(http.StatusOK, EnvelopeResponse{Data: envelopeObject})
 }
 
+// DeleteEnvelope deletes an envelope
+//
 //	@Summary		Delete envelope
 //	@Description	Deletes an envelope
 //	@Tags			Envelopes

--- a/pkg/controllers/import.go
+++ b/pkg/controllers/import.go
@@ -30,6 +30,8 @@ func (co Controller) RegisterImportRoutes(r *gin.RouterGroup) {
 	}
 }
 
+// OptionsImport returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs. **Please use /v1/import/ynab4, which works exactly the same.**
 //	@Tags			Import
@@ -41,6 +43,8 @@ func (co Controller) OptionsImport(c *gin.Context) {
 	httputil.OptionsPost(c)
 }
 
+// OptionsImportYnab4 returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			Import
@@ -51,6 +55,8 @@ func (co Controller) OptionsImportYnab4(c *gin.Context) {
 	httputil.OptionsPost(c)
 }
 
+// Import imports a YNAB 4 budget
+//
 //	@Summary		Import
 //	@Description	Imports budgets from YNAB 4. **Please use /v1/import/ynab4, which works exactly the same.**
 //	@Tags			Import
@@ -67,6 +73,8 @@ func (co Controller) Import(c *gin.Context) {
 	co.ImportYnab4(c)
 }
 
+// ImportYnab4 imports a YNAB 4 budget
+//
 //	@Summary		Import
 //	@Description	Imports budgets from YNAB 4
 //	@Tags			Import

--- a/pkg/controllers/month.go
+++ b/pkg/controllers/month.go
@@ -65,6 +65,8 @@ func (co Controller) RegisterMonthRoutes(r *gin.RouterGroup) {
 	}
 }
 
+// OptionsMonth returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs.
 //	@Tags			Months
@@ -74,6 +76,8 @@ func (co Controller) OptionsMonth(c *gin.Context) {
 	httputil.OptionsGetPostDelete(c)
 }
 
+// GetMonth returns data for a specific budget and month
+//
 //	@Summary		Get data about a month
 //	@Description	Returns data about a specific month.
 //	@Tags			Months
@@ -178,6 +182,8 @@ func (co Controller) GetMonth(c *gin.Context) {
 	c.JSON(http.StatusOK, MonthResponse{Data: month})
 }
 
+// DeleteAllocations deletes all allocations for a month
+//
 //	@Summary		Delete allocations for a month
 //	@Description	Deletes all allocation for the specified month
 //	@Tags			Months
@@ -216,6 +222,8 @@ func (co Controller) DeleteAllocations(c *gin.Context) {
 	c.JSON(http.StatusNoContent, gin.H{})
 }
 
+// SetAllocations sets all allocations for a month
+//
 //	@Summary		Set allocations for a month
 //	@Description	Sets allocations for a month for all envelopes that do not have an allocation yet
 //	@Tags			Months

--- a/pkg/controllers/month_config.go
+++ b/pkg/controllers/month_config.go
@@ -72,6 +72,8 @@ func (co Controller) RegisterMonthConfigRoutes(r *gin.RouterGroup) {
 	r.DELETE("/:envelopeId/:month", co.DeleteMonthConfig)
 }
 
+// OptionsMonthConfigList returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs.
 //	@Tags			MonthConfigs
@@ -81,6 +83,8 @@ func (co Controller) OptionsMonthConfigList(c *gin.Context) {
 	httputil.OptionsGet(c)
 }
 
+// OptionsMonthConfigDetail returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			MonthConfigs
@@ -106,6 +110,8 @@ func (co Controller) OptionsMonthConfigDetail(c *gin.Context) {
 	httputil.OptionsGetPostPatchDelete(c)
 }
 
+// GetMonthConfig returns config for a specific envelope and month
+//
 //	@Summary		Get MonthConfig
 //	@Description	Returns configuration for a specific month
 //	@Tags			MonthConfigs
@@ -142,6 +148,8 @@ func (co Controller) GetMonthConfig(c *gin.Context) {
 	c.JSON(http.StatusOK, MonthConfigResponse{Data: co.getMonthConfigObject(c, mConfig)})
 }
 
+// GetMonthConfigs returns all month configs filtered by the query parameters
+//
 //	@Summary		List MonthConfigs
 //	@Description	Returns a list of MonthConfigs
 //	@Tags			MonthConfigs
@@ -190,6 +198,8 @@ func (co Controller) GetMonthConfigs(c *gin.Context) {
 	c.JSON(http.StatusOK, MonthConfigListResponse{Data: mConfigObjects})
 }
 
+// CreateMonthConfig creates a new month config
+//
 //	@Summary		Create MonthConfig
 //	@Description	Creates a new MonthConfig
 //	@Tags			MonthConfigs
@@ -244,6 +254,8 @@ func (co Controller) CreateMonthConfig(c *gin.Context) {
 	c.JSON(http.StatusCreated, MonthConfigResponse{Data: mConfigObject})
 }
 
+// UpdateMonthConfig updates configuration data for a specific envelope and month
+//
 //	@Summary		Update MonthConfig
 //	@Description	Changes settings of an existing MonthConfig
 //	@Tags			MonthConfigs
@@ -295,6 +307,8 @@ func (co Controller) UpdateMonthConfig(c *gin.Context) {
 	c.JSON(http.StatusOK, MonthConfigResponse{Data: co.getMonthConfigObject(c, mConfig)})
 }
 
+// DeleteMonthConfig deletes configuration data for a specific envelope and month
+//
 //	@Summary		Delete MonthConfig
 //	@Description	Deletes configuration settings for a specific month
 //	@Tags			MonthConfigs

--- a/pkg/controllers/transaction.go
+++ b/pkg/controllers/transaction.go
@@ -101,6 +101,8 @@ func (co Controller) RegisterTransactionRoutes(r *gin.RouterGroup) {
 	}
 }
 
+// OptionsTransactionList returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			Transactions
@@ -110,6 +112,8 @@ func (co Controller) OptionsTransactionList(c *gin.Context) {
 	httputil.OptionsGetPost(c)
 }
 
+// OptionsTransactionDetail returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			Transactions
@@ -130,6 +134,8 @@ func (co Controller) OptionsTransactionDetail(c *gin.Context) {
 	httputil.OptionsGetPatchDelete(c)
 }
 
+// CreateTransaction creates a new transaction
+//
 //	@Summary		Create transaction
 //	@Description	Creates a new transaction
 //	@Tags			Transactions
@@ -186,6 +192,8 @@ func (co Controller) CreateTransaction(c *gin.Context) {
 	c.JSON(http.StatusCreated, TransactionResponse{Data: transactionObject})
 }
 
+// GetTransactions returns transactions filtered by the query parameters
+//
 //	@Summary		Get transactions
 //	@Description	Returns a list of transactions
 //	@Tags			Transactions
@@ -259,6 +267,8 @@ func (co Controller) GetTransactions(c *gin.Context) {
 	c.JSON(http.StatusOK, TransactionListResponse{Data: transactionObjects})
 }
 
+// GetTransaction returns a specific transaction
+//
 //	@Summary		Get transaction
 //	@Description	Returns a specific transaction
 //	@Tags			Transactions
@@ -284,6 +294,8 @@ func (co Controller) GetTransaction(c *gin.Context) {
 	c.JSON(http.StatusOK, TransactionResponse{Data: transactionObject})
 }
 
+// UpdateTransaction updates a specific transaction
+//
 //	@Summary		Update transaction
 //	@Description	Updates an existing transaction. Only values to be updated need to be specified.
 //	@Tags			Transactions
@@ -365,6 +377,8 @@ func (co Controller) UpdateTransaction(c *gin.Context) {
 	c.JSON(http.StatusOK, TransactionResponse{Data: transactionObject})
 }
 
+// DeleteTransaction deletes a specific transaction
+//
 //	@Summary		Delete transaction
 //	@Description	Deletes a transaction
 //	@Tags			Transactions

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -147,6 +147,8 @@ type RootLinks struct {
 	V1      string `json:"v1" example:"https://example.com/api/v1"`
 }
 
+// GetRoot returns the link list for the API root
+//
 //	@Summary		API root
 //	@Description	Entrypoint for the API, listing all endpoints
 //	@Tags			General
@@ -169,6 +171,8 @@ type VersionObject struct {
 	Version string `json:"version" example:"1.1.0"`
 }
 
+// GetVersion returns the API version object
+//
 //	@Summary		API version
 //	@Description	Returns the software version of the API
 //	@Tags			General
@@ -182,6 +186,8 @@ func GetVersion(c *gin.Context) {
 	})
 }
 
+// OptionsRoot returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			General
@@ -191,6 +197,8 @@ func OptionsRoot(c *gin.Context) {
 	httputil.OptionsGet(c)
 }
 
+// OptionsVersion returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			General
@@ -215,6 +223,8 @@ type V1Links struct {
 	Import       string `json:"import" example:"https://example.com/api/v1/import"`
 }
 
+// GetV1 returns the link list for v1
+//
 //	@Summary		v1 API
 //	@Description	Returns general information about the v1 API
 //	@Tags			v1
@@ -235,6 +245,8 @@ func GetV1(c *gin.Context) {
 	})
 }
 
+// OptionsV1 returns the allowed HTTP methods
+//
 //	@Summary		Allowed HTTP verbs
 //	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 //	@Tags			v1


### PR DESCRIPTION
go 1.19 introduced more features for documentation comments.

swagger switching to use tabs to indent (https://github.com/swaggo/swag/pull/1386) broke the formatting for the backend since it did not have any actual go docs beyond the swagger comments yet.

With this PR, go docs are added, resolving this issue.
