### PR TITLE
feat: add more fields to month endpoint

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3471,19 +3471,37 @@ const docTemplate = `{
         "models.CategoryEnvelopes": {
             "type": "object",
             "properties": {
+                "allocation": {
+                    "description": "Sum of allocations for the envelopes",
+                    "type": "number",
+                    "example": 90
+                },
+                "balance": {
+                    "description": "Sum of the balances of the envelopes",
+                    "type": "number",
+                    "example": -10.13
+                },
                 "envelopes": {
+                    "description": "Slice of all envelopes",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/models.EnvelopeMonth"
                     }
                 },
                 "id": {
+                    "description": "ID of the category",
                     "type": "string",
                     "example": "dafd9a74-6aeb-46b9-9f5a-cfca624fea85"
                 },
                 "name": {
+                    "description": "Name of the category",
                     "type": "string",
                     "example": "Rainy Day Funds"
+                },
+                "spent": {
+                    "description": "Sum spent for all envelopes",
+                    "type": "number",
+                    "example": 100.13
                 }
             }
         },
@@ -3557,6 +3575,11 @@ const docTemplate = `{
         "models.Month": {
             "type": "object",
             "properties": {
+                "allocation": {
+                    "description": "The sum of all allocations for this month",
+                    "type": "number",
+                    "example": 1200.5
+                },
                 "available": {
                     "description": "The amount available to budget",
                     "type": "number",
@@ -3568,7 +3591,7 @@ const docTemplate = `{
                     "example": 5231.37
                 },
                 "budgeted": {
-                    "description": "The sum of all allocations for the month",
+                    "description": "The sum of all allocations for the month. **Deprecated, please use the ` + "`" + `allocation` + "`" + ` field**",
                     "type": "number",
                     "example": 2100
                 },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -3459,19 +3459,37 @@
         "models.CategoryEnvelopes": {
             "type": "object",
             "properties": {
+                "allocation": {
+                    "description": "Sum of allocations for the envelopes",
+                    "type": "number",
+                    "example": 90
+                },
+                "balance": {
+                    "description": "Sum of the balances of the envelopes",
+                    "type": "number",
+                    "example": -10.13
+                },
                 "envelopes": {
+                    "description": "Slice of all envelopes",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/models.EnvelopeMonth"
                     }
                 },
                 "id": {
+                    "description": "ID of the category",
                     "type": "string",
                     "example": "dafd9a74-6aeb-46b9-9f5a-cfca624fea85"
                 },
                 "name": {
+                    "description": "Name of the category",
                     "type": "string",
                     "example": "Rainy Day Funds"
+                },
+                "spent": {
+                    "description": "Sum spent for all envelopes",
+                    "type": "number",
+                    "example": 100.13
                 }
             }
         },
@@ -3545,6 +3563,11 @@
         "models.Month": {
             "type": "object",
             "properties": {
+                "allocation": {
+                    "description": "The sum of all allocations for this month",
+                    "type": "number",
+                    "example": 1200.5
+                },
                 "available": {
                     "description": "The amount available to budget",
                     "type": "number",
@@ -3556,7 +3579,7 @@
                     "example": 5231.37
                 },
                 "budgeted": {
-                    "description": "The sum of all allocations for the month",
+                    "description": "The sum of all allocations for the month. **Deprecated, please use the `allocation` field**",
                     "type": "number",
                     "example": 2100
                 },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -564,16 +564,31 @@ definitions:
     type: object
   models.CategoryEnvelopes:
     properties:
+      allocation:
+        description: Sum of allocations for the envelopes
+        example: 90
+        type: number
+      balance:
+        description: Sum of the balances of the envelopes
+        example: -10.13
+        type: number
       envelopes:
+        description: Slice of all envelopes
         items:
           $ref: '#/definitions/models.EnvelopeMonth'
         type: array
       id:
+        description: ID of the category
         example: dafd9a74-6aeb-46b9-9f5a-cfca624fea85
         type: string
       name:
+        description: Name of the category
         example: Rainy Day Funds
         type: string
+      spent:
+        description: Sum spent for all envelopes
+        example: 100.13
+        type: number
     type: object
   models.EnvelopeCreate:
     properties:
@@ -627,6 +642,10 @@ definitions:
     type: object
   models.Month:
     properties:
+      allocation:
+        description: The sum of all allocations for this month
+        example: 1200.5
+        type: number
       available:
         description: The amount available to budget
         example: 217.34
@@ -636,7 +655,8 @@ definitions:
         example: 5231.37
         type: number
       budgeted:
-        description: The sum of all allocations for the month
+        description: The sum of all allocations for the month. **Deprecated, please
+          use the `allocation` field**
         example: 2100
         type: number
       categories:

--- a/pkg/controllers/month.go
+++ b/pkg/controllers/month.go
@@ -109,6 +109,7 @@ func (co Controller) GetMonth(c *gin.Context) {
 		return
 	}
 	month.Budgeted = budgeted
+	month.Allocation = budgeted
 
 	// Add income to response
 	income, err := budget.Income(co.DB, month.Month)
@@ -161,9 +162,14 @@ func (co Controller) GetMonth(c *gin.Context) {
 				return
 			}
 
-			// Update the month's balance
+			// Update the month's summarized data
 			month.Balance = month.Balance.Add(envelopeMonth.Balance)
 			month.Spent = month.Spent.Add(envelopeMonth.Spent)
+
+			// Update the category's summarized data
+			categoryEnvelopes.Balance = categoryEnvelopes.Balance.Add(envelopeMonth.Balance)
+			categoryEnvelopes.Spent = categoryEnvelopes.Spent.Add(envelopeMonth.Spent)
+			categoryEnvelopes.Allocation = categoryEnvelopes.Allocation.Add(envelopeMonth.Allocation)
 
 			// Set the allocation link. If there is no allocation, we send the collection endpoint.
 			// With this, any client will be able to see that the "Budgeted" amount is 0 and therefore

--- a/pkg/models/month.go
+++ b/pkg/models/month.go
@@ -8,19 +8,23 @@ import (
 )
 
 type CategoryEnvelopes struct {
-	ID        uuid.UUID       `json:"id" example:"dafd9a74-6aeb-46b9-9f5a-cfca624fea85"`
-	Name      string          `json:"name" example:"Rainy Day Funds" default:""`
-	Envelopes []EnvelopeMonth `json:"envelopes"`
+	ID         uuid.UUID       `json:"id" example:"dafd9a74-6aeb-46b9-9f5a-cfca624fea85"` // ID of the category
+	Name       string          `json:"name" example:"Rainy Day Funds" default:""`         // Name of the category
+	Envelopes  []EnvelopeMonth `json:"envelopes"`                                         // Slice of all envelopes
+	Balance    decimal.Decimal `json:"balance" example:"-10.13"`                          // Sum of the balances of the envelopes
+	Allocation decimal.Decimal `json:"allocation" example:"90"`                           // Sum of allocations for the envelopes
+	Spent      decimal.Decimal `json:"spent" example:"100.13"`                            // Sum spent for all envelopes
 }
 
 type Month struct {
 	ID         uuid.UUID           `json:"id" example:"1e777d24-3f5b-4c43-8000-04f65f895578"` // The ID of the Budget
 	Name       string              `json:"name" example:"Zero budget"`                        // The name of the Budget
 	Month      time.Time           `json:"month" example:"2006-05-01T00:00:00.000000Z"`       // This is always set to 00:00 UTC on the first of the month.
-	Budgeted   decimal.Decimal     `json:"budgeted" example:"2100"`                           // The sum of all allocations for the month
+	Budgeted   decimal.Decimal     `json:"budgeted" example:"2100"`                           // The sum of all allocations for the month. **Deprecated, please use the `allocation` field**
 	Income     decimal.Decimal     `json:"income" example:"2317.34"`                          // The total income for the month (sum of all incoming transactions without an Envelope)
 	Available  decimal.Decimal     `json:"available" example:"217.34"`                        // The amount available to budget
 	Balance    decimal.Decimal     `json:"balance" example:"5231.37"`                         // The sum of all envelope balances
 	Spent      decimal.Decimal     `json:"spent" example:"133.70"`                            // The amount of money spent in this month
+	Allocation decimal.Decimal     `json:"allocation" example:"1200.50"`                      // The sum of all allocations for this month
 	Categories []CategoryEnvelopes `json:"categories"`                                        // A list of envelope month calculations grouped by category
 }


### PR DESCRIPTION
This adds more fields to the /v1/month endpoint:

* `data` now has an additional `allocations` field that contains the
  sum of all allocations for the month
* All categories (in `data.categories`) now have the following
  additional fields:
  * `balance`: Sum of all allocations for envelopes in that category
  * `allocation`: Sum of all allocations for that category
  * `spent`: Sum of spend for all envelopes

Resolves #485.
