### PR TITLE
fix: disallow transfers between two on-budget accounts with an envelope set

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,18 +9,6 @@ issues:
         - errcheck
         - dupl
 
-      # Parsing logic has high cyclomatic complexity. This is okay.
-    - path: pkg/importer/parser/ynab4/parse.go
-      linters:
-        - gocyclo
-      text: "func `parseTransactions`"
-
-      # Parsing logic has high cyclomatic complexity. This is okay.
-    - path: pkg/importer/creator.go
-      linters:
-        - gocyclo
-      text: "func `Create`"
-
     - path: pkg/models/envelope.go
       linters:
         - gocyclo
@@ -41,7 +29,7 @@ linters-settings:
   gofumpt:
     extra-rules: true
   gocyclo:
-    min-complexity: 15
+    min-complexity: 20
 
   godot:
     exclude:


### PR DESCRIPTION
Transfers between two on-budget accounts must not have an envelope set.
Such a transaction would be incoming and outgoing for the envelope at
the same time, which is not possible.

Resolves #472.
