### PR TITLE
feat: wider matching

### DIFF
--- a/pkg/controllers/account.go
+++ b/pkg/controllers/account.go
@@ -165,7 +165,7 @@ func (co Controller) GetAccounts(c *gin.Context) {
 	}
 
 	// Get the set parameters in the query string
-	queryFields := httputil.GetURLFields(c.Request.URL, filter)
+	queryFields, _ := httputil.GetURLFields(c.Request.URL, filter)
 
 	// Convert the QueryFilter to a Create struct
 	create, ok := filter.ToCreate(c)

--- a/pkg/controllers/allocation.go
+++ b/pkg/controllers/allocation.go
@@ -160,7 +160,7 @@ func (co Controller) GetAllocations(c *gin.Context) {
 	}
 
 	// Get the parameters set in the query string
-	queryFields := httputil.GetURLFields(c.Request.URL, filter)
+	queryFields, _ := httputil.GetURLFields(c.Request.URL, filter)
 
 	// Convert the QueryFilter to a Create struct
 	create, ok := filter.ToCreate(c)

--- a/pkg/controllers/budget.go
+++ b/pkg/controllers/budget.go
@@ -237,7 +237,7 @@ func (co Controller) GetBudgets(c *gin.Context) {
 	_ = c.Bind(&filter)
 
 	// Get the fields that we're filtering for
-	queryFields := httputil.GetURLFields(c.Request.URL, filter)
+	queryFields, _ := httputil.GetURLFields(c.Request.URL, filter)
 
 	var budgets []models.Budget
 

--- a/pkg/controllers/budget_test.go
+++ b/pkg/controllers/budget_test.go
@@ -134,7 +134,7 @@ func (suite *TestSuiteStandard) TestGetBudgetsFilter() {
 			r := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("http://example.com/v1/budgets?%s", tt.query), "")
 			suite.assertHTTPStatus(&r, http.StatusOK)
 			suite.decodeResponse(&r, &re)
-			assert.Equal(suite.T(), tt.len, len(re.Data))
+			assert.Equal(t, tt.len, len(re.Data))
 		})
 	}
 }

--- a/pkg/controllers/category.go
+++ b/pkg/controllers/category.go
@@ -159,7 +159,7 @@ func (co Controller) GetCategories(c *gin.Context) {
 	_ = c.Bind(&filter)
 
 	// Get the fields that we are filtering for
-	queryFields := httputil.GetURLFields(c.Request.URL, filter)
+	queryFields, _ := httputil.GetURLFields(c.Request.URL, filter)
 
 	// Convert the QueryFilter to a Create struct
 	create, ok := filter.ToCreate(c)

--- a/pkg/controllers/category_test.go
+++ b/pkg/controllers/category_test.go
@@ -128,8 +128,8 @@ func (suite *TestSuiteStandard) TestGetCategoriesFilter() {
 	})
 
 	_ = suite.createTestCategory(models.CategoryCreate{
-		Name:     "Saving",
-		Note:     "For later",
+		Name:     "Groceries",
+		Note:     "For Groceries",
 		BudgetID: b2.Data.ID,
 	})
 
@@ -149,6 +149,10 @@ func (suite *TestSuiteStandard) TestGetCategoriesFilter() {
 		{"Empty Note", "note=", 0},
 		{"Empty Name", "name=", 0},
 		{"Name & Note", "name=Category Name&note=A note for this category", 1},
+		{"Fuzzy name, no note", "name=Category&note=", 0},
+		{"Fuzzy name", "name=t", 2},
+		{"Fuzzy note, no name", "name=&note=Groceries", 0},
+		{"Fuzzy note", "note=Groceries", 2},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controllers/envelope.go
+++ b/pkg/controllers/envelope.go
@@ -161,7 +161,7 @@ func (co Controller) GetEnvelopes(c *gin.Context) {
 	// The filters contain only strings, so this will always succeed
 	_ = c.Bind(&filter)
 
-	queryFields := httputil.GetURLFields(c.Request.URL, filter)
+	queryFields, _ := httputil.GetURLFields(c.Request.URL, filter)
 
 	// Convert the QueryFilter to a Create struct
 	create, ok := filter.ToCreate(c)

--- a/pkg/controllers/envelope_test.go
+++ b/pkg/controllers/envelope_test.go
@@ -121,6 +121,8 @@ func (suite *TestSuiteStandard) TestGetEnvelopesFilter() {
 		{"Empty Note", "note=", 0},
 		{"Empty Name", "name=", 0},
 		{"Name & Note", "name=Groceries&note=For the stuff bought in supermarkets", 1},
+		{"Fuzzy name", "name=es", 2},
+		{"Fuzzy note", "note=Because", 2},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controllers/month_config.go
+++ b/pkg/controllers/month_config.go
@@ -169,7 +169,7 @@ func (co Controller) GetMonthConfigs(c *gin.Context) {
 	}
 
 	// Get the set parameters in the query string
-	queryFields := httputil.GetURLFields(c.Request.URL, filter)
+	queryFields, _ := httputil.GetURLFields(c.Request.URL, filter)
 
 	// Convert the QueryFilter to a Filter struct
 	parsed, ok := filter.Parse(c)

--- a/pkg/controllers/transaction.go
+++ b/pkg/controllers/transaction.go
@@ -224,7 +224,7 @@ func (co Controller) GetTransactions(c *gin.Context) {
 	}
 
 	// Get the fields set in the filter
-	queryFields := httputil.GetURLFields(c.Request.URL, filter)
+	queryFields, _ := httputil.GetURLFields(c.Request.URL, filter)
 
 	// Convert the QueryFilter to a Create struct
 	create, ok := filter.ToCreate(c)

--- a/pkg/controllers/transaction.go
+++ b/pkg/controllers/transaction.go
@@ -40,7 +40,7 @@ type TransactionQueryFilter struct {
 	DestinationAccountID string          `form:"destination"`
 	EnvelopeID           string          `form:"envelope"`
 	Reconciled           bool            `form:"reconciled"`
-	AccountID            string          `form:"account" createField:"false"`
+	AccountID            string          `form:"account" filterField:"false"`
 }
 
 func (f TransactionQueryFilter) ToCreate(c *gin.Context) (models.TransactionCreate, bool) {

--- a/pkg/controllers/transaction_test.go
+++ b/pkg/controllers/transaction_test.go
@@ -156,6 +156,7 @@ func (suite *TestSuiteStandard) TestGetTransactionsFilter() {
 		{"Exact Amount", fmt.Sprintf("amount=%s", decimal.NewFromFloat(2.718).String()), 2},
 		{"Note", "note=Not important", 1},
 		{"No note", "note=", 1},
+		{"Fuzzy note", "note=important", 2},
 		{"Budget Match", fmt.Sprintf("budget=%s", b.Data.ID), 3},
 		{"Envelope 2", fmt.Sprintf("envelope=%s", e2.Data.ID), 1},
 		{"Non-existing Source Account", "source=3340a084-acf8-4cb4-8f86-9e7f88a86190", 0},

--- a/pkg/httputil/query.go
+++ b/pkg/httputil/query.go
@@ -25,11 +25,13 @@ func GetURLFields(url *url.URL, filter any) []any {
 		field := val.Type().Field(i).Name
 		param := val.Type().Field(i).Tag.Get("form")
 
-		// createField is a struct tag that allows to specify if the field is part
-		// of the fields to filter for on the original struct
-		createField := val.Type().Field(i).Tag.Get("createField")
+		// filterField is a struct tag that allows to specify if the field
+		// is used to filter resources directly (e.g. SourceAccountID on a TransactionQueryFilter)
+		// or if it is a meta field that is processed by explicit logic outside of
+		// GetURLFields (e.g. AccountID on a TransactionQueryFilter)
+		filterField := val.Type().Field(i).Tag.Get("filterField")
 
-		if url.Query().Has(param) && createField != "false" {
+		if url.Query().Has(param) && filterField != "false" {
 			queryFields = append(queryFields, field)
 		}
 	}

--- a/pkg/httputil/query_test.go
+++ b/pkg/httputil/query_test.go
@@ -15,11 +15,12 @@ import (
 )
 
 func TestGetURLFields(t *testing.T) {
-	url, _ := url.Parse("http://example.com/api/v1/accounts?budget=87645467-ad8a-4e16-ae7f-9d879b45f569&onBudget=false")
+	url, _ := url.Parse("http://example.com/api/v1/accounts?budget=87645467-ad8a-4e16-ae7f-9d879b45f569&onBudget=false&name=")
 
-	queryFields := httputil.GetURLFields(url, controllers.AccountQueryFilter{})
+	queryFields, setFields := httputil.GetURLFields(url, controllers.AccountQueryFilter{})
 
 	assert.Equal(t, []interface{}{"BudgetID", "OnBudget"}, queryFields)
+	assert.Equal(t, []string{"Name", "BudgetID", "OnBudget"}, setFields)
 }
 
 func TestGetBodyFields(t *testing.T) {


### PR DESCRIPTION
This PR updates the filtering logic to treat all string field filter (name & note)
as a “contains“ filter. 

For example, a note filter on “Hello”, will match all notes that contain the word
“Hello“ anywhere in the text.

- refactor: rename createField to filterField and improve documentation
- refactor: add setField return for GetURLFields
- feat: treat account name and note filter parameters like "contains"
- feat: treat budget name and note filter parameters like "contains"
- feat: treat category name and note filter parameters like "contains"
- feat: treat envelope name and note filter parameters like "contains"
- feat: treat transaction note filter parameters like "contains"

Resolves #459.
