### PR TITLE
feat: add commonly used envelopes for destination accounts to account object

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2744,6 +2744,12 @@ const docTemplate = `{
                     "default": false,
                     "example": true
                 },
+                "recentEnvelopes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Envelope"
+                    }
+                },
                 "reconciledBalance": {
                     "type": "number",
                     "example": 2539.57
@@ -3502,6 +3508,44 @@ const docTemplate = `{
                     "description": "Sum spent for all envelopes",
                     "type": "number",
                     "example": 100.13
+                }
+            }
+        },
+        "models.Envelope": {
+            "type": "object",
+            "properties": {
+                "categoryId": {
+                    "type": "string",
+                    "example": "878c831f-af99-4a71-b3ca-80deb7d793c1"
+                },
+                "createdAt": {
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "deletedAt": {
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
+                "hidden": {
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "id": {
+                    "type": "string",
+                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Groceries"
+                },
+                "note": {
+                    "type": "string",
+                    "example": "For stuff bought at supermarkets and drugstores"
+                },
+                "updatedAt": {
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2732,6 +2732,12 @@
                     "default": false,
                     "example": true
                 },
+                "recentEnvelopes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Envelope"
+                    }
+                },
                 "reconciledBalance": {
                     "type": "number",
                     "example": 2539.57
@@ -3490,6 +3496,44 @@
                     "description": "Sum spent for all envelopes",
                     "type": "number",
                     "example": 100.13
+                }
+            }
+        },
+        "models.Envelope": {
+            "type": "object",
+            "properties": {
+                "categoryId": {
+                    "type": "string",
+                    "example": "878c831f-af99-4a71-b3ca-80deb7d793c1"
+                },
+                "createdAt": {
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "deletedAt": {
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
+                "hidden": {
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "id": {
+                    "type": "string",
+                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Groceries"
+                },
+                "note": {
+                    "type": "string",
+                    "example": "For stuff bought at supermarkets and drugstores"
+                },
+                "updatedAt": {
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -41,6 +41,10 @@ definitions:
         description: 'Always false when external: true'
         example: true
         type: boolean
+      recentEnvelopes:
+        items:
+          $ref: '#/definitions/models.Envelope'
+        type: array
       reconciledBalance:
         example: 2539.57
         type: number
@@ -589,6 +593,34 @@ definitions:
         description: Sum spent for all envelopes
         example: 100.13
         type: number
+    type: object
+  models.Envelope:
+    properties:
+      categoryId:
+        example: 878c831f-af99-4a71-b3ca-80deb7d793c1
+        type: string
+      createdAt:
+        example: "2022-04-02T19:28:44.491514Z"
+        type: string
+      deletedAt:
+        example: "2022-04-22T21:01:05.058161Z"
+        type: string
+      hidden:
+        default: false
+        example: true
+        type: boolean
+      id:
+        example: 65392deb-5e92-4268-b114-297faad6cdce
+        type: string
+      name:
+        example: Groceries
+        type: string
+      note:
+        example: For stuff bought at supermarkets and drugstores
+        type: string
+      updatedAt:
+        example: "2022-04-17T20:14:01.048145Z"
+        type: string
     type: object
   models.EnvelopeCreate:
     properties:

--- a/pkg/models/account_test.go
+++ b/pkg/models/account_test.go
@@ -1,7 +1,10 @@
 package models_test
 
 import (
+	"strconv"
+
 	"github.com/envelope-zero/backend/pkg/models"
+	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 )
@@ -137,4 +140,102 @@ func (suite *TestSuiteStandard) TestAccountOnBudget() {
 	}
 
 	assert.True(suite.T(), account.OnBudget, "OnBudget is set to false even though the account is internal")
+}
+
+func (suite *TestSuiteStandard) TestAccountRecentEnvelopes() {
+	budget := models.Budget{}
+	err := suite.db.Save(&budget).Error
+	if err != nil {
+		suite.Assert().Fail("Budget could not be saved", err)
+	}
+
+	account := models.Account{
+		AccountCreate: models.AccountCreate{
+			BudgetID:       budget.ID,
+			OnBudget:       true,
+			External:       false,
+			InitialBalance: decimal.NewFromFloat(170),
+		},
+	}
+	err = suite.db.Save(&account).Error
+	if err != nil {
+		suite.Assert().Fail("Resource could not be saved", err)
+	}
+
+	externalAccount := models.Account{
+		AccountCreate: models.AccountCreate{
+			BudgetID: budget.ID,
+			External: true,
+		},
+	}
+	err = suite.db.Save(&externalAccount).Error
+	if err != nil {
+		suite.Assert().Fail("Resource could not be saved", err)
+	}
+
+	category := models.Category{
+		CategoryCreate: models.CategoryCreate{
+			BudgetID: budget.ID,
+		},
+	}
+	err = suite.db.Save(&category).Error
+	if err != nil {
+		suite.Assert().Fail("Resource could not be saved", err)
+	}
+
+	envelopeIDs := []*uuid.UUID{}
+	for i := 1; i <= 3; i++ {
+		envelope := &models.Envelope{
+			EnvelopeCreate: models.EnvelopeCreate{
+				CategoryID: category.ID,
+				Name:       strconv.Itoa(i),
+			},
+		}
+		if err = suite.db.Save(&envelope).Error; err != nil {
+			suite.Assert().Fail("Resource could not be saved", err)
+		}
+
+		envelopeIDs = append(envelopeIDs, &envelope.ID)
+	}
+
+	// Create 15 transactions:
+	//  * 2 for the first envelope
+	//  * 2 for the second envelope
+	//  * 11 for the last envelope
+	for i := 1; i <= 15; i++ {
+		eIndex := i
+		if i > 5 {
+			eIndex = 2
+		}
+		transaction := models.Transaction{
+			TransactionCreate: models.TransactionCreate{
+				BudgetID:             budget.ID,
+				EnvelopeID:           envelopeIDs[eIndex%3],
+				SourceAccountID:      account.ID,
+				DestinationAccountID: externalAccount.ID,
+				Amount:               decimal.NewFromFloat(17.45),
+			},
+		}
+		err = suite.db.Save(&transaction).Error
+		if err != nil {
+			suite.Assert().Fail("Resource could not be saved", err)
+		}
+	}
+
+	recent, err := externalAccount.RecentEnvelopes(suite.db)
+	if err != nil {
+		suite.Assert().Fail("Could not compute recent envelopes", err)
+	}
+
+	// The last envelope needs to be the first in the sort since it
+	// has been the most common one in the last 10 transactions
+	suite.Assert().Equal(*envelopeIDs[2], recent[0].ID)
+
+	// The second envelope is as common as the first, but its newest transaction
+	// is newer than the first envelope's newest transaction,
+	// so it needs to come second
+	suite.Assert().Equal(*envelopeIDs[1], recent[1].ID)
+
+	// The first envelope is the last one
+	suite.Assert().Equal(*envelopeIDs[0], recent[2].ID)
 }


### PR DESCRIPTION
An account object now always includes a `recentEnvelopes` field.

This field contains the envelopes of transactions for which the account was the destination account.

For this field, only the last 10 transactions where the account was the destination account are checked.
The envelopes are sorted by frequency of use, most used envelope first.

Resolves #460.
