### PR TITLE
feat: add date for initial balance

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2727,6 +2727,10 @@ const docTemplate = `{
                     "default": 0,
                     "example": 173.12
                 },
+                "initialBalanceDate": {
+                    "type": "string",
+                    "example": "2017-05-12T00:00:00Z"
+                },
                 "links": {
                     "$ref": "#/definitions/controllers.AccountLinks"
                 },
@@ -3452,6 +3456,10 @@ const docTemplate = `{
                     "type": "number",
                     "default": 0,
                     "example": 173.12
+                },
+                "initialBalanceDate": {
+                    "type": "string",
+                    "example": "2017-05-12T00:00:00Z"
                 },
                 "name": {
                     "type": "string",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2715,6 +2715,10 @@
                     "default": 0,
                     "example": 173.12
                 },
+                "initialBalanceDate": {
+                    "type": "string",
+                    "example": "2017-05-12T00:00:00Z"
+                },
                 "links": {
                     "$ref": "#/definitions/controllers.AccountLinks"
                 },
@@ -3440,6 +3444,10 @@
                     "type": "number",
                     "default": 0,
                     "example": 173.12
+                },
+                "initialBalanceDate": {
+                    "type": "string",
+                    "example": "2017-05-12T00:00:00Z"
                 },
                 "name": {
                     "type": "string",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -28,6 +28,9 @@ definitions:
         default: 0
         example: 173.12
         type: number
+      initialBalanceDate:
+        example: "2017-05-12T00:00:00Z"
+        type: string
       links:
         $ref: '#/definitions/controllers.AccountLinks'
       name:
@@ -552,6 +555,9 @@ definitions:
         default: 0
         example: 173.12
         type: number
+      initialBalanceDate:
+        example: "2017-05-12T00:00:00Z"
+        type: string
       name:
         example: Cash
         type: string

--- a/pkg/importer/parser/ynab4/parse.go
+++ b/pkg/importer/parser/ynab4/parse.go
@@ -262,22 +262,23 @@ func parseTransactions(resources *types.ParsedResources, transactions []Transact
 			addNoPayee = true
 		}
 
+		// Parse the date of the transaction
+		date, err := time.Parse("2006-01-02", transaction.Date)
+		if err != nil {
+			return fmt.Errorf("could not parse date, the Budget.yfull file seems to be corrupt: %w", err)
+		}
+
 		// Envelope Zero does not use a magic “Starting Balance” account, instead
 		// every account has a field for the starting balance
 		if payee == "Starting Balance" {
 			account := resources.Accounts[accountIDNames[transaction.AccountID]]
 			account.Model.InitialBalance = transaction.Amount
+			account.Model.InitialBalanceDate = &date
 
 			resources.Accounts[accountIDNames[transaction.AccountID]] = account
 
 			// Initial balance is set, no more processing needed
 			continue
-		}
-
-		// Parse the date of the transaction
-		date, err := time.Parse("2006-01-02", transaction.Date)
-		if err != nil {
-			return fmt.Errorf("could not parse date, the Budget.yfull file seems to be corrupt: %w", err)
 		}
 
 		newTransaction := types.Transaction{

--- a/pkg/models/account.go
+++ b/pkg/models/account.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"gorm.io/gorm"
@@ -16,13 +18,14 @@ type Account struct {
 }
 
 type AccountCreate struct {
-	Name           string          `json:"name" example:"Cash" default:""`
-	Note           string          `json:"note" example:"Money in my wallet" default:""`
-	BudgetID       uuid.UUID       `json:"budgetId" example:"550dc009-cea6-4c12-b2a5-03446eb7b7cf"`
-	OnBudget       bool            `json:"onBudget" example:"true" default:"false"` // Always false when external: true
-	External       bool            `json:"external" example:"false" default:"false"`
-	InitialBalance decimal.Decimal `json:"initialBalance" example:"173.12" default:"0"`
-	Hidden         bool            `json:"hidden" example:"true" default:"false"`
+	Name               string          `json:"name" example:"Cash" default:""`
+	Note               string          `json:"note" example:"Money in my wallet" default:""`
+	BudgetID           uuid.UUID       `json:"budgetId" example:"550dc009-cea6-4c12-b2a5-03446eb7b7cf"`
+	OnBudget           bool            `json:"onBudget" example:"true" default:"false"` // Always false when external: true
+	External           bool            `json:"external" example:"false" default:"false"`
+	InitialBalance     decimal.Decimal `json:"initialBalance" example:"173.12" default:"0"`
+	InitialBalanceDate *time.Time      `json:"initialBalanceDate" example:"2017-05-12T00:00:00Z"`
+	Hidden             bool            `json:"hidden" example:"true" default:"false"`
 }
 
 func (a Account) WithCalculations(db *gorm.DB) Account {


### PR DESCRIPTION
With this, the initial balance of an account can be set to a specific date so that
calculations prior to creation of the account can be correct, e.g. the sum available
to budget.

The YNAB 4 importer sets the initial balance date automatically from the YNAB 4
starting balance transactions.
