### PR TITLE
fix: return HTTP 201 with budget object instead of 204 on import

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1863,8 +1863,11 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "No Content"
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.BudgetResponse"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1851,8 +1851,11 @@
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "No Content"
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.BudgetResponse"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2102,8 +2102,10 @@ paths:
       produces:
       - application/json
       responses:
-        "204":
-          description: No Content
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/controllers.BudgetResponse'
         "400":
           description: Bad Request
           schema:

--- a/pkg/controllers/import.go
+++ b/pkg/controllers/import.go
@@ -80,7 +80,7 @@ func (co Controller) Import(c *gin.Context) {
 //	@Tags			Import
 //	@Accept			multipart/form-data
 //	@Produce		json
-//	@Success		204
+//	@Success		201			{object}	BudgetResponse
 //	@Failure		400			{object}	httperrors.HTTPError
 //	@Failure		500			{object}	httperrors.HTTPError
 //	@Param			file		formData	file	true	"File to import"
@@ -140,11 +140,15 @@ func (co Controller) ImportYnab4(c *gin.Context) {
 		return
 	}
 
-	err = importer.Create(co.DB, query.BudgetName, resources)
+	budget, err = importer.Create(co.DB, query.BudgetName, resources)
 	if err != nil {
 		httperrors.Handler(c, err)
 		return
 	}
 
-	c.JSON(http.StatusNoContent, nil)
+	b, ok := co.getBudgetObject(c, budget.ID)
+	if !ok {
+		return
+	}
+	c.JSON(http.StatusCreated, BudgetResponse{Data: b})
 }

--- a/pkg/controllers/import_test.go
+++ b/pkg/controllers/import_test.go
@@ -87,5 +87,5 @@ func (suite *TestSuiteStandard) TestImport() {
 	// Import one
 	body, headers := suite.loadTestFile("Budget.yfull")
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/import?budgetName=Test Budget", body, headers)
-	suite.Assert().Equal(http.StatusNoContent, recorder.Code, "Request ID %s, response %s", recorder.Header().Get("x-request-id"), recorder.Body.String())
+	suite.Assert().Equal(http.StatusCreated, recorder.Code, "Request ID %s, response %s", recorder.Header().Get("x-request-id"), recorder.Body.String())
 }


### PR DESCRIPTION
This fixes the HTTP response for the budget import which was erroneously set to return a HTTP status of 204.

It now returns HTTP 201 Created and the budget data. 
