### PR TITLE
feat: hidden query filters

### DIFF
--- a/pkg/controllers/account.go
+++ b/pkg/controllers/account.go
@@ -34,21 +34,23 @@ type AccountLinks struct {
 type AccountQueryFilter struct {
 	Name     string `form:"name" filterField:"false"` // Fuzzy filter for the account name
 	Note     string `form:"note" filterField:"false"` // Fuzzy filter for the note
-	BudgetID string `form:"budget"`
-	OnBudget bool   `form:"onBudget"`
-	External bool   `form:"external"`
+	BudgetID string `form:"budget"`                   // By budget ID
+	OnBudget bool   `form:"onBudget"`                 // Is the account on-budget?
+	External bool   `form:"external"`                 // Is the account external?
+	Hidden   bool   `form:"hidden"`                   // Is the account hidden?
 }
 
-func (a AccountQueryFilter) ToCreate(c *gin.Context) (models.AccountCreate, bool) {
-	budgetID, ok := httputil.UUIDFromString(c, a.BudgetID)
+func (f AccountQueryFilter) ToCreate(c *gin.Context) (models.AccountCreate, bool) {
+	budgetID, ok := httputil.UUIDFromString(c, f.BudgetID)
 	if !ok {
 		return models.AccountCreate{}, false
 	}
 
 	return models.AccountCreate{
 		BudgetID: budgetID,
-		OnBudget: a.OnBudget,
-		External: a.External,
+		OnBudget: f.OnBudget,
+		External: f.External,
+		Hidden:   f.Hidden,
 	}, true
 }
 

--- a/pkg/controllers/account_test.go
+++ b/pkg/controllers/account_test.go
@@ -98,6 +98,7 @@ func (suite *TestSuiteStandard) TestGetAccountsFilter() {
 		BudgetID: b1.Data.ID,
 		OnBudget: false,
 		External: true,
+		Hidden:   true,
 	})
 
 	_ = suite.createTestAccount(models.AccountCreate{
@@ -110,6 +111,7 @@ func (suite *TestSuiteStandard) TestGetAccountsFilter() {
 		Name:     "Name only",
 		Note:     "",
 		BudgetID: b1.Data.ID,
+		Hidden:   true,
 	})
 
 	tests := []struct {
@@ -130,6 +132,8 @@ func (suite *TestSuiteStandard) TestGetAccountsFilter() {
 		{"Off budget", "onBudget=false", 4},
 		{"External", "external=true", 2},
 		{"Internal", "external=false", 3},
+		{"Not Hidden", "hidden=false", 3},
+		{"Hidden", "hidden=true", 2},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controllers/category.go
+++ b/pkg/controllers/category.go
@@ -35,6 +35,7 @@ type CategoryQueryFilter struct {
 	Name     string `form:"name" filterField:"false"`
 	BudgetID string `form:"budget"`
 	Note     string `form:"note" filterField:"false"`
+	Hidden   bool   `form:"hidden"`
 }
 
 func (f CategoryQueryFilter) ToCreate(c *gin.Context) (models.CategoryCreate, bool) {
@@ -45,6 +46,7 @@ func (f CategoryQueryFilter) ToCreate(c *gin.Context) (models.CategoryCreate, bo
 
 	return models.CategoryCreate{
 		BudgetID: budgetID,
+		Hidden:   f.Hidden,
 	}, true
 }
 

--- a/pkg/controllers/category_test.go
+++ b/pkg/controllers/category_test.go
@@ -125,6 +125,7 @@ func (suite *TestSuiteStandard) TestGetCategoriesFilter() {
 		Name:     "Category Name",
 		Note:     "A note for this category",
 		BudgetID: b1.Data.ID,
+		Hidden:   true,
 	})
 
 	_ = suite.createTestCategory(models.CategoryCreate{
@@ -153,6 +154,8 @@ func (suite *TestSuiteStandard) TestGetCategoriesFilter() {
 		{"Fuzzy name", "name=t", 2},
 		{"Fuzzy note, no name", "name=&note=Groceries", 0},
 		{"Fuzzy note", "note=Groceries", 2},
+		{"Not hidden", "hidden=false", 2},
+		{"Hidden", "hidden=true", 1},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controllers/envelope.go
+++ b/pkg/controllers/envelope.go
@@ -41,16 +41,18 @@ type EnvelopeQueryFilter struct {
 	Name       string `form:"name" filterField:"false"`
 	CategoryID string `form:"category"`
 	Note       string `form:"note" filterField:"false"`
+	Hidden     bool   `form:"hidden"`
 }
 
-func (e EnvelopeQueryFilter) ToCreate(c *gin.Context) (models.EnvelopeCreate, bool) {
-	categoryID, ok := httputil.UUIDFromString(c, e.CategoryID)
+func (f EnvelopeQueryFilter) ToCreate(c *gin.Context) (models.EnvelopeCreate, bool) {
+	categoryID, ok := httputil.UUIDFromString(c, f.CategoryID)
 	if !ok {
 		return models.EnvelopeCreate{}, false
 	}
 
 	return models.EnvelopeCreate{
 		CategoryID: categoryID,
+		Hidden:     f.Hidden,
 	}, true
 }
 

--- a/pkg/controllers/envelope_test.go
+++ b/pkg/controllers/envelope_test.go
@@ -104,6 +104,7 @@ func (suite *TestSuiteStandard) TestGetEnvelopesFilter() {
 		Name:       "Hairdresser",
 		Note:       "Because… Hair!",
 		CategoryID: c2.Data.ID,
+		Hidden:     true,
 	})
 
 	_ = suite.createTestEnvelope(models.EnvelopeCreate{
@@ -124,6 +125,8 @@ func (suite *TestSuiteStandard) TestGetEnvelopesFilter() {
 		{"Name & Note", "name=Groceries&note=For the stuff bought in supermarkets", 1},
 		{"Fuzzy name", "name=es", 2},
 		{"Fuzzy note", "note=Because", 2},
+		{"Not hidden", "hidden=false", 2},
+		{"Hidden", "hidden=true", 1},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adds hidden query filters for all resources that have a `hidden` attribute.

- feat: add filtering for hidden accounts
- feat: add filtering for hidden categories
- feat: add filtering for hidden envelopes

Resolves #532.
