### PR TITLE
fix: add hidden query parameter to swagger

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -123,14 +123,20 @@ const docTemplate = `{
                     },
                     {
                         "type": "boolean",
-                        "description": "Filter by on/off-budget",
+                        "description": "Is the account on-budget?",
                         "name": "onBudget",
                         "in": "query"
                     },
                     {
                         "type": "boolean",
-                        "description": "Filter internal/external",
+                        "description": "Is the account external?",
                         "name": "external",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Is the account hidden?",
+                        "name": "hidden",
                         "in": "query"
                     }
                 ],
@@ -1193,6 +1199,12 @@ const docTemplate = `{
                         "description": "Filter by budget ID",
                         "name": "budget",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Is the category hidden?",
+                        "name": "hidden",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1476,6 +1488,12 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Filter by category ID",
                         "name": "category",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Is the envelope hidden?",
+                        "name": "hidden",
                         "in": "query"
                     }
                 ],

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -111,14 +111,20 @@
                     },
                     {
                         "type": "boolean",
-                        "description": "Filter by on/off-budget",
+                        "description": "Is the account on-budget?",
                         "name": "onBudget",
                         "in": "query"
                     },
                     {
                         "type": "boolean",
-                        "description": "Filter internal/external",
+                        "description": "Is the account external?",
                         "name": "external",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Is the account hidden?",
+                        "name": "hidden",
                         "in": "query"
                     }
                 ],
@@ -1181,6 +1187,12 @@
                         "description": "Filter by budget ID",
                         "name": "budget",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Is the category hidden?",
+                        "name": "hidden",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1464,6 +1476,12 @@
                         "type": "string",
                         "description": "Filter by category ID",
                         "name": "category",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Is the envelope hidden?",
+                        "name": "hidden",
                         "in": "query"
                     }
                 ],

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -915,13 +915,17 @@ paths:
         in: query
         name: budget
         type: string
-      - description: Filter by on/off-budget
+      - description: Is the account on-budget?
         in: query
         name: onBudget
         type: boolean
-      - description: Filter internal/external
+      - description: Is the account external?
         in: query
         name: external
+        type: boolean
+      - description: Is the account hidden?
+        in: query
+        name: hidden
         type: boolean
       produces:
       - application/json
@@ -1645,6 +1649,10 @@ paths:
         in: query
         name: budget
         type: string
+      - description: Is the category hidden?
+        in: query
+        name: hidden
+        type: boolean
       produces:
       - application/json
       responses:
@@ -1836,6 +1844,10 @@ paths:
         in: query
         name: category
         type: string
+      - description: Is the envelope hidden?
+        in: query
+        name: hidden
+        type: boolean
       produces:
       - application/json
       responses:

--- a/pkg/controllers/account.go
+++ b/pkg/controllers/account.go
@@ -157,8 +157,9 @@ func (co Controller) CreateAccount(c *gin.Context) {
 //	@Param			name		query	string	false	"Filter by name"
 //	@Param			note		query	string	false	"Filter by note"
 //	@Param			budget		query	string	false	"Filter by budget ID"
-//	@Param			onBudget	query	bool	false	"Filter by on/off-budget"
-//	@Param			external	query	bool	false	"Filter internal/external"
+//	@Param			onBudget	query	bool	false	"Is the account on-budget?"
+//	@Param			external	query	bool	false	"Is the account external?"
+//	@Param			hidden		query	bool	false	"Is the account hidden?"
 func (co Controller) GetAccounts(c *gin.Context) {
 	var filter AccountQueryFilter
 	if err := c.Bind(&filter); err != nil {

--- a/pkg/controllers/category.go
+++ b/pkg/controllers/category.go
@@ -153,6 +153,7 @@ func (co Controller) CreateCategory(c *gin.Context) {
 //	@Param			name	query	string	false	"Filter by name"
 //	@Param			note	query	string	false	"Filter by note"
 //	@Param			budget	query	string	false	"Filter by budget ID"
+//	@Param			hidden	query	bool	false	"Is the category hidden?"
 func (co Controller) GetCategories(c *gin.Context) {
 	var filter CategoryQueryFilter
 

--- a/pkg/controllers/envelope.go
+++ b/pkg/controllers/envelope.go
@@ -157,6 +157,7 @@ func (co Controller) CreateEnvelope(c *gin.Context) {
 //	@Param			name		query	string	false	"Filter by name"
 //	@Param			note		query	string	false	"Filter by note"
 //	@Param			category	query	string	false	"Filter by category ID"
+//	@Param			hidden		query	bool	false	"Is the envelope hidden?"
 func (co Controller) GetEnvelopes(c *gin.Context) {
 	var filter EnvelopeQueryFilter
 


### PR DESCRIPTION
This adds the missing `hidden` query parameters to the API documentation.
