### PR TITLE
fix: some boolean fields are NULL

### DIFF
--- a/pkg/models/database.go
+++ b/pkg/models/database.go
@@ -13,5 +13,22 @@ func Migrate(db *gorm.DB) error {
 		return fmt.Errorf("error during DB migration: %w", err)
 	}
 
+	/*
+	 * Workaround for https://github.com/go-gorm/gorm/issues/5968
+	 */
+	// Account
+	db.Unscoped().Model(&Account{}).Select("OnBudget").Where("accounts.on_budget IS NULL").Update("OnBudget", false)
+	db.Unscoped().Model(&Account{}).Select("External").Where("accounts.external IS NULL").Update("External", false)
+	db.Unscoped().Model(&Account{}).Select("Hidden").Where("accounts.hidden IS NULL").Update("Hidden", false)
+
+	// Category
+	db.Unscoped().Model(&Category{}).Select("Hidden").Where("categories.hidden IS NULL").Update("Hidden", false)
+
+	// Envelope
+	db.Unscoped().Model(&Envelope{}).Select("Hidden").Where("envelopes.hidden IS NULL").Update("Hidden", false)
+
+	// Transaction
+	db.Unscoped().Model(&Transaction{}).Select("Reconciled").Where("transactions.reconciled IS NULL").Update("Reconciled", false)
+
 	return nil
 }


### PR DESCRIPTION
This fixes a bug where boolean fields are NULL for columns that are
created when rows already exist. For these rows, the column is NULL,
which gorm doesn't handle well since we can only query for true of false.

This commit introduces a migration that updates those fields to the default
value, which is always false for booleans.

It's unclear if this is intended or an upstream bug in gorm, therefore I filed
https://github.com/go-gorm/gorm/issues/5968.
