### PR TITLE
fix: add labels to OCI image

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,3 +43,9 @@ dockers:
       - "ghcr.io/envelope-zero/backend:v{{ .Major }}"
       - "ghcr.io/envelope-zero/backend:v{{ .Major }}.{{ .Minor }}"
       - "ghcr.io/envelope-zero/backend:latest"
+
+    build_flag_templates:
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,13 @@ FROM scratch
 WORKDIR /
 COPY --from=builder /app/backend /backend
 ENTRYPOINT ["/backend"]
+
+# Keep "maintainer" and "org.opencontainers.image.authors" in sync
+LABEL "maintainer"="Envelope Zero Maintainers <envelope-zero@maurice-meyer.de>"
+LABEL "org.opencontainers.image.authors"="Envelope Zero Maintainers <envelope-zero@maurice-meyer.de>"
+LABEL "org.opencontainers.image.description"="Backend for Envelope Zero"
+LABEL "org.opencontainers.image.documentation"="https://github.com/envelope-zero/backend"
+LABEL "org.opencontainers.image.licenses"="AGPL-3.0-or-later"
+LABEL "org.opencontainers.image.source"="https://github.com/envelope-zero/backend"
+LABEL "org.opencontainers.image.url"="https://github.com/envelope-zero/backend"
+LABEL "org.opencontainers.image.vendor"="Envelope Zero Maintainers"


### PR DESCRIPTION
With this, we're being good OCI citizens (or something like that)
by telling people where to find the source for the image.

Plus, renovate uses the org.opencontainers.image.source label to
find the source for changelogs, so it will now also show changelogs.
