### PR TITLE
chore: remove deprecated goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,10 +11,6 @@ builds:
     ldflags:
       - -X github.com/envelope-zero/backend/v2/pkg/router.version={{.Version}}
 
-archives:
-  - replacements:
-      amd64: x86_64
-
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 


### PR DESCRIPTION
This removes an unneeded and deprecated parameter.

