### PR TITLE
chore(deps): pin codecov-action to 3.1.1

### DIFF
--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -24,7 +24,7 @@ jobs:
           go test ./... -race -covermode=atomic -coverprofile=coverage.out
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out


### PR DESCRIPTION
Updates the semver version comment to the exact version to have easier references in future updates.
