### PR TITLE
fix: transaction filter for 'account' now correctly ORed in query

### DIFF
--- a/pkg/controllers/transaction.go
+++ b/pkg/controllers/transaction.go
@@ -258,7 +258,7 @@ func (co Controller) GetTransactions(c *gin.Context) {
 			return
 		}
 
-		query = query.Where(&models.Transaction{
+		query = query.Where(co.DB.Where(&models.Transaction{
 			TransactionCreate: models.TransactionCreate{
 				SourceAccountID: accountID,
 			},
@@ -266,7 +266,7 @@ func (co Controller) GetTransactions(c *gin.Context) {
 			TransactionCreate: models.TransactionCreate{
 				DestinationAccountID: accountID,
 			},
-		})
+		}))
 	}
 
 	if !filter.AmountLessOrEqual.IsZero() {

--- a/pkg/controllers/transaction_test.go
+++ b/pkg/controllers/transaction_test.go
@@ -190,6 +190,7 @@ func (suite *TestSuiteStandard) TestGetTransactionsFilter() {
 		{"Amount more or equal to 100", "amountMoreOrEqual=100", 1},
 		{"Amount more or equal to 100 and less than 10", "amountMoreOrEqual=100&amountLessOrEqual=10", 0},
 		{"Amount more or equal to 1 and less than 3", "amountMoreOrEqual=1&amountLessOrEqual=3", 2},
+		{"Regression - For 'account', query needs to be ORed between the accounts and ANDed with all other conditions", fmt.Sprintf("note=&account=%s", a2.Data.ID), 1},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The OR must be applied only to the source and destination account ID,
not to the whole query.

Resolves #556.
