### PR TITLE
feat: always include all resource fields in month response

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2770,10 +2770,12 @@ const docTemplate = `{
                     "example": "550dc009-cea6-4c12-b2a5-03446eb7b7cf"
                 },
                 "createdAt": {
+                    "description": "Time the resource was created",
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
                     "type": "string",
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
@@ -2788,6 +2790,7 @@ const docTemplate = `{
                     "example": true
                 },
                 "id": {
+                    "description": "UUID for the resource",
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
@@ -2828,6 +2831,7 @@ const docTemplate = `{
                     "example": 2539.57
                 },
                 "updatedAt": {
+                    "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 }
@@ -2877,10 +2881,12 @@ const docTemplate = `{
                     "example": 22.01
                 },
                 "createdAt": {
+                    "description": "Time the resource was created",
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
                     "type": "string",
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
@@ -2889,6 +2895,7 @@ const docTemplate = `{
                     "example": "a0909e84-e8f9-4cb6-82a5-025dff105ff2"
                 },
                 "id": {
+                    "description": "UUID for the resource",
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
@@ -2901,6 +2908,7 @@ const docTemplate = `{
                     "example": "2021-12-01T00:00:00.000000Z"
                 },
                 "updatedAt": {
+                    "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 }
@@ -2954,6 +2962,7 @@ const docTemplate = `{
                     "example": 3423.42
                 },
                 "createdAt": {
+                    "description": "Time the resource was created",
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
@@ -2962,10 +2971,12 @@ const docTemplate = `{
                     "example": "€"
                 },
                 "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
                     "type": "string",
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "id": {
+                    "description": "UUID for the resource",
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
@@ -2981,6 +2992,7 @@ const docTemplate = `{
                     "example": "My personal expenses"
                 },
                 "updatedAt": {
+                    "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 }
@@ -3070,14 +3082,17 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "budgetId": {
+                    "description": "ID of the budget the category belongs to",
                     "type": "string",
                     "example": "52d967d3-33f4-4b04-9ba7-772e5ab9d0ce"
                 },
                 "createdAt": {
+                    "description": "Time the resource was created",
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
                     "type": "string",
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
@@ -3088,11 +3103,13 @@ const docTemplate = `{
                     }
                 },
                 "hidden": {
+                    "description": "Is the category hidden?",
                     "type": "boolean",
                     "default": false,
                     "example": true
                 },
                 "id": {
+                    "description": "UUID for the resource",
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
@@ -3100,14 +3117,17 @@ const docTemplate = `{
                     "$ref": "#/definitions/controllers.CategoryLinks"
                 },
                 "name": {
+                    "description": "Name of the category",
                     "type": "string",
                     "example": "Saving"
                 },
                 "note": {
+                    "description": "Notes about the category",
                     "type": "string",
                     "example": "All envelopes for long-term saving"
                 },
                 "updatedAt": {
+                    "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 }
@@ -3149,23 +3169,28 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "categoryId": {
+                    "description": "ID of the category the envelope belongs to",
                     "type": "string",
                     "example": "878c831f-af99-4a71-b3ca-80deb7d793c1"
                 },
                 "createdAt": {
+                    "description": "Time the resource was created",
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
                     "type": "string",
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "hidden": {
+                    "description": "Is the envelope hidden?",
                     "type": "boolean",
                     "default": false,
                     "example": true
                 },
                 "id": {
+                    "description": "UUID for the resource",
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
@@ -3173,14 +3198,17 @@ const docTemplate = `{
                     "$ref": "#/definitions/controllers.EnvelopeLinks"
                 },
                 "name": {
+                    "description": "Name of the envelope",
                     "type": "string",
                     "example": "Groceries"
                 },
                 "note": {
+                    "description": "Notes about the envelope",
                     "type": "string",
                     "example": "For stuff bought at supermarkets and drugstores"
                 },
                 "updatedAt": {
+                    "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 }
@@ -3239,10 +3267,12 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "createdAt": {
+                    "description": "Time the resource was created",
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
                     "type": "string",
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
@@ -3268,6 +3298,7 @@ const docTemplate = `{
                     "example": "AFFECT_ENVELOPE"
                 },
                 "updatedAt": {
+                    "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 }
@@ -3334,6 +3365,7 @@ const docTemplate = `{
                     "example": "55eecbd8-7c46-4b06-ada9-f287802fb05e"
                 },
                 "createdAt": {
+                    "description": "Time the resource was created",
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
@@ -3342,6 +3374,7 @@ const docTemplate = `{
                     "example": "1815-12-10T18:43:00.271152Z"
                 },
                 "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
                     "type": "string",
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
@@ -3354,6 +3387,7 @@ const docTemplate = `{
                     "example": "2649c965-7999-4873-ae16-89d5d5fa972e"
                 },
                 "id": {
+                    "description": "UUID for the resource",
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
@@ -3385,6 +3419,7 @@ const docTemplate = `{
                     "example": "fd81dc45-a3a2-468e-a6fa-b2618f30aa45"
                 },
                 "updatedAt": {
+                    "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 }
@@ -3549,19 +3584,23 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "budgetId": {
+                    "description": "ID of the budget the category belongs to",
                     "type": "string",
                     "example": "52d967d3-33f4-4b04-9ba7-772e5ab9d0ce"
                 },
                 "hidden": {
+                    "description": "Is the category hidden?",
                     "type": "boolean",
                     "default": false,
                     "example": true
                 },
                 "name": {
+                    "description": "Name of the category",
                     "type": "string",
                     "example": "Saving"
                 },
                 "note": {
+                    "description": "Notes about the category",
                     "type": "string",
                     "example": "All envelopes for long-term saving"
                 }
@@ -3580,6 +3619,21 @@ const docTemplate = `{
                     "type": "number",
                     "example": -10.13
                 },
+                "budgetId": {
+                    "description": "ID of the budget the category belongs to",
+                    "type": "string",
+                    "example": "52d967d3-33f4-4b04-9ba7-772e5ab9d0ce"
+                },
+                "createdAt": {
+                    "description": "Time the resource was created",
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
                 "envelopes": {
                     "description": "Slice of all envelopes",
                     "type": "array",
@@ -3587,20 +3641,36 @@ const docTemplate = `{
                         "$ref": "#/definitions/models.EnvelopeMonth"
                     }
                 },
+                "hidden": {
+                    "description": "Is the category hidden?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "id": {
-                    "description": "ID of the category",
+                    "description": "UUID for the resource",
                     "type": "string",
-                    "example": "dafd9a74-6aeb-46b9-9f5a-cfca624fea85"
+                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
                 "name": {
                     "description": "Name of the category",
                     "type": "string",
-                    "example": "Rainy Day Funds"
+                    "example": "Saving"
+                },
+                "note": {
+                    "description": "Notes about the category",
+                    "type": "string",
+                    "example": "All envelopes for long-term saving"
                 },
                 "spent": {
                     "description": "Sum spent for all envelopes",
                     "type": "number",
                     "example": 100.13
+                },
+                "updatedAt": {
+                    "description": "Last time the resource was updated",
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
                 }
             }
         },
@@ -3608,35 +3678,43 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "categoryId": {
+                    "description": "ID of the category the envelope belongs to",
                     "type": "string",
                     "example": "878c831f-af99-4a71-b3ca-80deb7d793c1"
                 },
                 "createdAt": {
+                    "description": "Time the resource was created",
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
                     "type": "string",
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "hidden": {
+                    "description": "Is the envelope hidden?",
                     "type": "boolean",
                     "default": false,
                     "example": true
                 },
                 "id": {
+                    "description": "UUID for the resource",
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
                 "name": {
+                    "description": "Name of the envelope",
                     "type": "string",
                     "example": "Groceries"
                 },
                 "note": {
+                    "description": "Notes about the envelope",
                     "type": "string",
                     "example": "For stuff bought at supermarkets and drugstores"
                 },
                 "updatedAt": {
+                    "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 }
@@ -3646,19 +3724,23 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "categoryId": {
+                    "description": "ID of the category the envelope belongs to",
                     "type": "string",
                     "example": "878c831f-af99-4a71-b3ca-80deb7d793c1"
                 },
                 "hidden": {
+                    "description": "Is the envelope hidden?",
                     "type": "boolean",
                     "default": false,
                     "example": true
                 },
                 "name": {
+                    "description": "Name of the envelope",
                     "type": "string",
                     "example": "Groceries"
                 },
                 "note": {
+                    "description": "Notes about the envelope",
                     "type": "string",
                     "example": "For stuff bought at supermarkets and drugstores"
                 }
@@ -3668,20 +3750,48 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "allocation": {
+                    "description": "The amount of money allocated",
                     "type": "number",
                     "example": 85.44
                 },
                 "balance": {
+                    "description": "The balance at the end of the monht",
                     "type": "number",
                     "example": 12.32
                 },
-                "id": {
-                    "description": "The ID of the Envelope",
+                "categoryId": {
+                    "description": "ID of the category the envelope belongs to",
                     "type": "string",
-                    "example": "10b9705d-3356-459e-9d5a-28d42a6c4547"
+                    "example": "878c831f-af99-4a71-b3ca-80deb7d793c1"
+                },
+                "createdAt": {
+                    "description": "Time the resource was created",
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
+                "hidden": {
+                    "description": "Is the envelope hidden?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "id": {
+                    "description": "UUID for the resource",
+                    "type": "string",
+                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
                 "links": {
-                    "$ref": "#/definitions/models.EnvelopeMonthLinks"
+                    "description": "Linked resources",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.EnvelopeMonthLinks"
+                        }
+                    ]
                 },
                 "month": {
                     "description": "This is always set to 00:00 UTC on the first of the month. **This field is deprecated and will be removed in v2**",
@@ -3689,13 +3799,24 @@ const docTemplate = `{
                     "example": "1969-06-01T00:00:00.000000Z"
                 },
                 "name": {
-                    "description": "The name of the Envelope",
+                    "description": "Name of the envelope",
                     "type": "string",
                     "example": "Groceries"
                 },
+                "note": {
+                    "description": "Notes about the envelope",
+                    "type": "string",
+                    "example": "For stuff bought at supermarkets and drugstores"
+                },
                 "spent": {
+                    "description": "The amount spent over the whole month",
                     "type": "number",
                     "example": 73.12
+                },
+                "updatedAt": {
+                    "description": "Last time the resource was updated",
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2758,10 +2758,12 @@
                     "example": "550dc009-cea6-4c12-b2a5-03446eb7b7cf"
                 },
                 "createdAt": {
+                    "description": "Time the resource was created",
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
                     "type": "string",
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
@@ -2776,6 +2778,7 @@
                     "example": true
                 },
                 "id": {
+                    "description": "UUID for the resource",
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
@@ -2816,6 +2819,7 @@
                     "example": 2539.57
                 },
                 "updatedAt": {
+                    "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 }
@@ -2865,10 +2869,12 @@
                     "example": 22.01
                 },
                 "createdAt": {
+                    "description": "Time the resource was created",
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
                     "type": "string",
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
@@ -2877,6 +2883,7 @@
                     "example": "a0909e84-e8f9-4cb6-82a5-025dff105ff2"
                 },
                 "id": {
+                    "description": "UUID for the resource",
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
@@ -2889,6 +2896,7 @@
                     "example": "2021-12-01T00:00:00.000000Z"
                 },
                 "updatedAt": {
+                    "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 }
@@ -2942,6 +2950,7 @@
                     "example": 3423.42
                 },
                 "createdAt": {
+                    "description": "Time the resource was created",
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
@@ -2950,10 +2959,12 @@
                     "example": "€"
                 },
                 "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
                     "type": "string",
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "id": {
+                    "description": "UUID for the resource",
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
@@ -2969,6 +2980,7 @@
                     "example": "My personal expenses"
                 },
                 "updatedAt": {
+                    "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 }
@@ -3058,14 +3070,17 @@
             "type": "object",
             "properties": {
                 "budgetId": {
+                    "description": "ID of the budget the category belongs to",
                     "type": "string",
                     "example": "52d967d3-33f4-4b04-9ba7-772e5ab9d0ce"
                 },
                 "createdAt": {
+                    "description": "Time the resource was created",
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
                     "type": "string",
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
@@ -3076,11 +3091,13 @@
                     }
                 },
                 "hidden": {
+                    "description": "Is the category hidden?",
                     "type": "boolean",
                     "default": false,
                     "example": true
                 },
                 "id": {
+                    "description": "UUID for the resource",
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
@@ -3088,14 +3105,17 @@
                     "$ref": "#/definitions/controllers.CategoryLinks"
                 },
                 "name": {
+                    "description": "Name of the category",
                     "type": "string",
                     "example": "Saving"
                 },
                 "note": {
+                    "description": "Notes about the category",
                     "type": "string",
                     "example": "All envelopes for long-term saving"
                 },
                 "updatedAt": {
+                    "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 }
@@ -3137,23 +3157,28 @@
             "type": "object",
             "properties": {
                 "categoryId": {
+                    "description": "ID of the category the envelope belongs to",
                     "type": "string",
                     "example": "878c831f-af99-4a71-b3ca-80deb7d793c1"
                 },
                 "createdAt": {
+                    "description": "Time the resource was created",
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
                     "type": "string",
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "hidden": {
+                    "description": "Is the envelope hidden?",
                     "type": "boolean",
                     "default": false,
                     "example": true
                 },
                 "id": {
+                    "description": "UUID for the resource",
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
@@ -3161,14 +3186,17 @@
                     "$ref": "#/definitions/controllers.EnvelopeLinks"
                 },
                 "name": {
+                    "description": "Name of the envelope",
                     "type": "string",
                     "example": "Groceries"
                 },
                 "note": {
+                    "description": "Notes about the envelope",
                     "type": "string",
                     "example": "For stuff bought at supermarkets and drugstores"
                 },
                 "updatedAt": {
+                    "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 }
@@ -3227,10 +3255,12 @@
             "type": "object",
             "properties": {
                 "createdAt": {
+                    "description": "Time the resource was created",
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
                     "type": "string",
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
@@ -3256,6 +3286,7 @@
                     "example": "AFFECT_ENVELOPE"
                 },
                 "updatedAt": {
+                    "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 }
@@ -3322,6 +3353,7 @@
                     "example": "55eecbd8-7c46-4b06-ada9-f287802fb05e"
                 },
                 "createdAt": {
+                    "description": "Time the resource was created",
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
@@ -3330,6 +3362,7 @@
                     "example": "1815-12-10T18:43:00.271152Z"
                 },
                 "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
                     "type": "string",
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
@@ -3342,6 +3375,7 @@
                     "example": "2649c965-7999-4873-ae16-89d5d5fa972e"
                 },
                 "id": {
+                    "description": "UUID for the resource",
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
@@ -3373,6 +3407,7 @@
                     "example": "fd81dc45-a3a2-468e-a6fa-b2618f30aa45"
                 },
                 "updatedAt": {
+                    "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 }
@@ -3537,19 +3572,23 @@
             "type": "object",
             "properties": {
                 "budgetId": {
+                    "description": "ID of the budget the category belongs to",
                     "type": "string",
                     "example": "52d967d3-33f4-4b04-9ba7-772e5ab9d0ce"
                 },
                 "hidden": {
+                    "description": "Is the category hidden?",
                     "type": "boolean",
                     "default": false,
                     "example": true
                 },
                 "name": {
+                    "description": "Name of the category",
                     "type": "string",
                     "example": "Saving"
                 },
                 "note": {
+                    "description": "Notes about the category",
                     "type": "string",
                     "example": "All envelopes for long-term saving"
                 }
@@ -3568,6 +3607,21 @@
                     "type": "number",
                     "example": -10.13
                 },
+                "budgetId": {
+                    "description": "ID of the budget the category belongs to",
+                    "type": "string",
+                    "example": "52d967d3-33f4-4b04-9ba7-772e5ab9d0ce"
+                },
+                "createdAt": {
+                    "description": "Time the resource was created",
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
                 "envelopes": {
                     "description": "Slice of all envelopes",
                     "type": "array",
@@ -3575,20 +3629,36 @@
                         "$ref": "#/definitions/models.EnvelopeMonth"
                     }
                 },
+                "hidden": {
+                    "description": "Is the category hidden?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "id": {
-                    "description": "ID of the category",
+                    "description": "UUID for the resource",
                     "type": "string",
-                    "example": "dafd9a74-6aeb-46b9-9f5a-cfca624fea85"
+                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
                 "name": {
                     "description": "Name of the category",
                     "type": "string",
-                    "example": "Rainy Day Funds"
+                    "example": "Saving"
+                },
+                "note": {
+                    "description": "Notes about the category",
+                    "type": "string",
+                    "example": "All envelopes for long-term saving"
                 },
                 "spent": {
                     "description": "Sum spent for all envelopes",
                     "type": "number",
                     "example": 100.13
+                },
+                "updatedAt": {
+                    "description": "Last time the resource was updated",
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
                 }
             }
         },
@@ -3596,35 +3666,43 @@
             "type": "object",
             "properties": {
                 "categoryId": {
+                    "description": "ID of the category the envelope belongs to",
                     "type": "string",
                     "example": "878c831f-af99-4a71-b3ca-80deb7d793c1"
                 },
                 "createdAt": {
+                    "description": "Time the resource was created",
                     "type": "string",
                     "example": "2022-04-02T19:28:44.491514Z"
                 },
                 "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
                     "type": "string",
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "hidden": {
+                    "description": "Is the envelope hidden?",
                     "type": "boolean",
                     "default": false,
                     "example": true
                 },
                 "id": {
+                    "description": "UUID for the resource",
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
                 "name": {
+                    "description": "Name of the envelope",
                     "type": "string",
                     "example": "Groceries"
                 },
                 "note": {
+                    "description": "Notes about the envelope",
                     "type": "string",
                     "example": "For stuff bought at supermarkets and drugstores"
                 },
                 "updatedAt": {
+                    "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
                 }
@@ -3634,19 +3712,23 @@
             "type": "object",
             "properties": {
                 "categoryId": {
+                    "description": "ID of the category the envelope belongs to",
                     "type": "string",
                     "example": "878c831f-af99-4a71-b3ca-80deb7d793c1"
                 },
                 "hidden": {
+                    "description": "Is the envelope hidden?",
                     "type": "boolean",
                     "default": false,
                     "example": true
                 },
                 "name": {
+                    "description": "Name of the envelope",
                     "type": "string",
                     "example": "Groceries"
                 },
                 "note": {
+                    "description": "Notes about the envelope",
                     "type": "string",
                     "example": "For stuff bought at supermarkets and drugstores"
                 }
@@ -3656,20 +3738,48 @@
             "type": "object",
             "properties": {
                 "allocation": {
+                    "description": "The amount of money allocated",
                     "type": "number",
                     "example": 85.44
                 },
                 "balance": {
+                    "description": "The balance at the end of the monht",
                     "type": "number",
                     "example": 12.32
                 },
-                "id": {
-                    "description": "The ID of the Envelope",
+                "categoryId": {
+                    "description": "ID of the category the envelope belongs to",
                     "type": "string",
-                    "example": "10b9705d-3356-459e-9d5a-28d42a6c4547"
+                    "example": "878c831f-af99-4a71-b3ca-80deb7d793c1"
+                },
+                "createdAt": {
+                    "description": "Time the resource was created",
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
+                "hidden": {
+                    "description": "Is the envelope hidden?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "id": {
+                    "description": "UUID for the resource",
+                    "type": "string",
+                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
                 "links": {
-                    "$ref": "#/definitions/models.EnvelopeMonthLinks"
+                    "description": "Linked resources",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.EnvelopeMonthLinks"
+                        }
+                    ]
                 },
                 "month": {
                     "description": "This is always set to 00:00 UTC on the first of the month. **This field is deprecated and will be removed in v2**",
@@ -3677,13 +3787,24 @@
                     "example": "1969-06-01T00:00:00.000000Z"
                 },
                 "name": {
-                    "description": "The name of the Envelope",
+                    "description": "Name of the envelope",
                     "type": "string",
                     "example": "Groceries"
                 },
+                "note": {
+                    "description": "Notes about the envelope",
+                    "type": "string",
+                    "example": "For stuff bought at supermarkets and drugstores"
+                },
                 "spent": {
+                    "description": "The amount spent over the whole month",
                     "type": "number",
                     "example": 73.12
+                },
+                "updatedAt": {
+                    "description": "Last time the resource was updated",
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8,9 +8,11 @@ definitions:
         example: 550dc009-cea6-4c12-b2a5-03446eb7b7cf
         type: string
       createdAt:
+        description: Time the resource was created
         example: "2022-04-02T19:28:44.491514Z"
         type: string
       deletedAt:
+        description: Time the resource was marked as deleted
         example: "2022-04-22T21:01:05.058161Z"
         type: string
       external:
@@ -22,6 +24,7 @@ definitions:
         example: true
         type: boolean
       id:
+        description: UUID for the resource
         example: 65392deb-5e92-4268-b114-297faad6cdce
         type: string
       initialBalance:
@@ -52,6 +55,7 @@ definitions:
         example: 2539.57
         type: number
       updatedAt:
+        description: Last time the resource was updated
         example: "2022-04-17T20:14:01.048145Z"
         type: string
     type: object
@@ -87,15 +91,18 @@ definitions:
         multipleOf: 1e-08
         type: number
       createdAt:
+        description: Time the resource was created
         example: "2022-04-02T19:28:44.491514Z"
         type: string
       deletedAt:
+        description: Time the resource was marked as deleted
         example: "2022-04-22T21:01:05.058161Z"
         type: string
       envelopeId:
         example: a0909e84-e8f9-4cb6-82a5-025dff105ff2
         type: string
       id:
+        description: UUID for the resource
         example: 65392deb-5e92-4268-b114-297faad6cdce
         type: string
       links:
@@ -107,6 +114,7 @@ definitions:
         example: "2021-12-01T00:00:00.000000Z"
         type: string
       updatedAt:
+        description: Last time the resource was updated
         example: "2022-04-17T20:14:01.048145Z"
         type: string
     type: object
@@ -143,15 +151,18 @@ definitions:
         example: 3423.42
         type: number
       createdAt:
+        description: Time the resource was created
         example: "2022-04-02T19:28:44.491514Z"
         type: string
       currency:
         example: €
         type: string
       deletedAt:
+        description: Time the resource was marked as deleted
         example: "2022-04-22T21:01:05.058161Z"
         type: string
       id:
+        description: UUID for the resource
         example: 65392deb-5e92-4268-b114-297faad6cdce
         type: string
       links:
@@ -163,6 +174,7 @@ definitions:
         example: My personal expenses
         type: string
       updatedAt:
+        description: Last time the resource was updated
         example: "2022-04-17T20:14:01.048145Z"
         type: string
     type: object
@@ -226,12 +238,15 @@ definitions:
   controllers.Category:
     properties:
       budgetId:
+        description: ID of the budget the category belongs to
         example: 52d967d3-33f4-4b04-9ba7-772e5ab9d0ce
         type: string
       createdAt:
+        description: Time the resource was created
         example: "2022-04-02T19:28:44.491514Z"
         type: string
       deletedAt:
+        description: Time the resource was marked as deleted
         example: "2022-04-22T21:01:05.058161Z"
         type: string
       envelopes:
@@ -240,20 +255,25 @@ definitions:
         type: array
       hidden:
         default: false
+        description: Is the category hidden?
         example: true
         type: boolean
       id:
+        description: UUID for the resource
         example: 65392deb-5e92-4268-b114-297faad6cdce
         type: string
       links:
         $ref: '#/definitions/controllers.CategoryLinks'
       name:
+        description: Name of the category
         example: Saving
         type: string
       note:
+        description: Notes about the category
         example: All envelopes for long-term saving
         type: string
       updatedAt:
+        description: Last time the resource was updated
         example: "2022-04-17T20:14:01.048145Z"
         type: string
     type: object
@@ -281,30 +301,38 @@ definitions:
   controllers.Envelope:
     properties:
       categoryId:
+        description: ID of the category the envelope belongs to
         example: 878c831f-af99-4a71-b3ca-80deb7d793c1
         type: string
       createdAt:
+        description: Time the resource was created
         example: "2022-04-02T19:28:44.491514Z"
         type: string
       deletedAt:
+        description: Time the resource was marked as deleted
         example: "2022-04-22T21:01:05.058161Z"
         type: string
       hidden:
         default: false
+        description: Is the envelope hidden?
         example: true
         type: boolean
       id:
+        description: UUID for the resource
         example: 65392deb-5e92-4268-b114-297faad6cdce
         type: string
       links:
         $ref: '#/definitions/controllers.EnvelopeLinks'
       name:
+        description: Name of the envelope
         example: Groceries
         type: string
       note:
+        description: Notes about the envelope
         example: For stuff bought at supermarkets and drugstores
         type: string
       updatedAt:
+        description: Last time the resource was updated
         example: "2022-04-17T20:14:01.048145Z"
         type: string
     type: object
@@ -345,9 +373,11 @@ definitions:
   controllers.MonthConfig:
     properties:
       createdAt:
+        description: Time the resource was created
         example: "2022-04-02T19:28:44.491514Z"
         type: string
       deletedAt:
+        description: Time the resource was marked as deleted
         example: "2022-04-22T21:01:05.058161Z"
         type: string
       envelopeId:
@@ -365,6 +395,7 @@ definitions:
         default: AFFECT_AVAILABLE
         example: AFFECT_ENVELOPE
       updatedAt:
+        description: Last time the resource was updated
         example: "2022-04-17T20:14:01.048145Z"
         type: string
     type: object
@@ -414,12 +445,14 @@ definitions:
         example: 55eecbd8-7c46-4b06-ada9-f287802fb05e
         type: string
       createdAt:
+        description: Time the resource was created
         example: "2022-04-02T19:28:44.491514Z"
         type: string
       date:
         example: "1815-12-10T18:43:00.271152Z"
         type: string
       deletedAt:
+        description: Time the resource was marked as deleted
         example: "2022-04-22T21:01:05.058161Z"
         type: string
       destinationAccountId:
@@ -429,6 +462,7 @@ definitions:
         example: 2649c965-7999-4873-ae16-89d5d5fa972e
         type: string
       id:
+        description: UUID for the resource
         example: 65392deb-5e92-4268-b114-297faad6cdce
         type: string
       links:
@@ -455,6 +489,7 @@ definitions:
         example: fd81dc45-a3a2-468e-a6fa-b2618f30aa45
         type: string
       updatedAt:
+        description: Last time the resource was updated
         example: "2022-04-17T20:14:01.048145Z"
         type: string
     type: object
@@ -576,16 +611,20 @@ definitions:
   models.CategoryCreate:
     properties:
       budgetId:
+        description: ID of the budget the category belongs to
         example: 52d967d3-33f4-4b04-9ba7-772e5ab9d0ce
         type: string
       hidden:
         default: false
+        description: Is the category hidden?
         example: true
         type: boolean
       name:
+        description: Name of the category
         example: Saving
         type: string
       note:
+        description: Notes about the category
         example: All envelopes for long-term saving
         type: string
     type: object
@@ -599,94 +638,161 @@ definitions:
         description: Sum of the balances of the envelopes
         example: -10.13
         type: number
+      budgetId:
+        description: ID of the budget the category belongs to
+        example: 52d967d3-33f4-4b04-9ba7-772e5ab9d0ce
+        type: string
+      createdAt:
+        description: Time the resource was created
+        example: "2022-04-02T19:28:44.491514Z"
+        type: string
+      deletedAt:
+        description: Time the resource was marked as deleted
+        example: "2022-04-22T21:01:05.058161Z"
+        type: string
       envelopes:
         description: Slice of all envelopes
         items:
           $ref: '#/definitions/models.EnvelopeMonth'
         type: array
+      hidden:
+        default: false
+        description: Is the category hidden?
+        example: true
+        type: boolean
       id:
-        description: ID of the category
-        example: dafd9a74-6aeb-46b9-9f5a-cfca624fea85
+        description: UUID for the resource
+        example: 65392deb-5e92-4268-b114-297faad6cdce
         type: string
       name:
         description: Name of the category
-        example: Rainy Day Funds
+        example: Saving
+        type: string
+      note:
+        description: Notes about the category
+        example: All envelopes for long-term saving
         type: string
       spent:
         description: Sum spent for all envelopes
         example: 100.13
         type: number
+      updatedAt:
+        description: Last time the resource was updated
+        example: "2022-04-17T20:14:01.048145Z"
+        type: string
     type: object
   models.Envelope:
     properties:
       categoryId:
+        description: ID of the category the envelope belongs to
         example: 878c831f-af99-4a71-b3ca-80deb7d793c1
         type: string
       createdAt:
+        description: Time the resource was created
         example: "2022-04-02T19:28:44.491514Z"
         type: string
       deletedAt:
+        description: Time the resource was marked as deleted
         example: "2022-04-22T21:01:05.058161Z"
         type: string
       hidden:
         default: false
+        description: Is the envelope hidden?
         example: true
         type: boolean
       id:
+        description: UUID for the resource
         example: 65392deb-5e92-4268-b114-297faad6cdce
         type: string
       name:
+        description: Name of the envelope
         example: Groceries
         type: string
       note:
+        description: Notes about the envelope
         example: For stuff bought at supermarkets and drugstores
         type: string
       updatedAt:
+        description: Last time the resource was updated
         example: "2022-04-17T20:14:01.048145Z"
         type: string
     type: object
   models.EnvelopeCreate:
     properties:
       categoryId:
+        description: ID of the category the envelope belongs to
         example: 878c831f-af99-4a71-b3ca-80deb7d793c1
         type: string
       hidden:
         default: false
+        description: Is the envelope hidden?
         example: true
         type: boolean
       name:
+        description: Name of the envelope
         example: Groceries
         type: string
       note:
+        description: Notes about the envelope
         example: For stuff bought at supermarkets and drugstores
         type: string
     type: object
   models.EnvelopeMonth:
     properties:
       allocation:
+        description: The amount of money allocated
         example: 85.44
         type: number
       balance:
+        description: The balance at the end of the monht
         example: 12.32
         type: number
+      categoryId:
+        description: ID of the category the envelope belongs to
+        example: 878c831f-af99-4a71-b3ca-80deb7d793c1
+        type: string
+      createdAt:
+        description: Time the resource was created
+        example: "2022-04-02T19:28:44.491514Z"
+        type: string
+      deletedAt:
+        description: Time the resource was marked as deleted
+        example: "2022-04-22T21:01:05.058161Z"
+        type: string
+      hidden:
+        default: false
+        description: Is the envelope hidden?
+        example: true
+        type: boolean
       id:
-        description: The ID of the Envelope
-        example: 10b9705d-3356-459e-9d5a-28d42a6c4547
+        description: UUID for the resource
+        example: 65392deb-5e92-4268-b114-297faad6cdce
         type: string
       links:
-        $ref: '#/definitions/models.EnvelopeMonthLinks'
+        allOf:
+        - $ref: '#/definitions/models.EnvelopeMonthLinks'
+        description: Linked resources
       month:
         description: This is always set to 00:00 UTC on the first of the month. **This
           field is deprecated and will be removed in v2**
         example: "1969-06-01T00:00:00.000000Z"
         type: string
       name:
-        description: The name of the Envelope
+        description: Name of the envelope
         example: Groceries
         type: string
+      note:
+        description: Notes about the envelope
+        example: For stuff bought at supermarkets and drugstores
+        type: string
       spent:
+        description: The amount spent over the whole month
         example: 73.12
         type: number
+      updatedAt:
+        description: Last time the resource was updated
+        example: "2022-04-17T20:14:01.048145Z"
+        type: string
     type: object
   models.EnvelopeMonthLinks:
     properties:

--- a/pkg/controllers/budget_test.go
+++ b/pkg/controllers/budget_test.go
@@ -285,7 +285,11 @@ func (suite *TestSuiteStandard) TestBudgetMonth() {
 					Income: decimal.NewFromFloat(0),
 					Envelopes: []models.EnvelopeMonth{
 						{
-							Name:       "Utilities",
+							Envelope: models.Envelope{
+								EnvelopeCreate: models.EnvelopeCreate{
+									Name: "Utilities",
+								},
+							},
 							Month:      types.NewMonth(2022, 1),
 							Spent:      decimal.NewFromFloat(-10),
 							Balance:    decimal.NewFromFloat(10.99),
@@ -303,7 +307,11 @@ func (suite *TestSuiteStandard) TestBudgetMonth() {
 					Income: decimal.NewFromFloat(0),
 					Envelopes: []models.EnvelopeMonth{
 						{
-							Name:       "Utilities",
+							Envelope: models.Envelope{
+								EnvelopeCreate: models.EnvelopeCreate{
+									Name: "Utilities",
+								},
+							},
 							Month:      types.NewMonth(2022, 2),
 							Balance:    decimal.NewFromFloat(53.11),
 							Spent:      decimal.NewFromFloat(-5),
@@ -321,7 +329,11 @@ func (suite *TestSuiteStandard) TestBudgetMonth() {
 					Income: decimal.NewFromFloat(1500),
 					Envelopes: []models.EnvelopeMonth{
 						{
-							Name:       "Utilities",
+							Envelope: models.Envelope{
+								EnvelopeCreate: models.EnvelopeCreate{
+									Name: "Utilities",
+								},
+							},
 							Month:      types.NewMonth(2022, 3),
 							Balance:    decimal.NewFromFloat(69.28),
 							Spent:      decimal.NewFromFloat(-15),

--- a/pkg/controllers/envelope_test.go
+++ b/pkg/controllers/envelope_test.go
@@ -291,7 +291,11 @@ func (suite *TestSuiteStandard) TestEnvelopeMonth() {
 		{
 			fmt.Sprintf("%s/2022-01", envelope.Data.Links.Self),
 			models.EnvelopeMonth{
-				Name:       "Utilities",
+				Envelope: models.Envelope{
+					EnvelopeCreate: models.EnvelopeCreate{
+						Name: "Utilities",
+					},
+				},
 				Month:      types.NewMonth(2022, 1),
 				Spent:      decimal.NewFromFloat(-10),
 				Balance:    decimal.NewFromFloat(10.99),
@@ -301,7 +305,11 @@ func (suite *TestSuiteStandard) TestEnvelopeMonth() {
 		{
 			fmt.Sprintf("%s/2022-02", envelope.Data.Links.Self),
 			models.EnvelopeMonth{
-				Name:       "Utilities",
+				Envelope: models.Envelope{
+					EnvelopeCreate: models.EnvelopeCreate{
+						Name: "Utilities",
+					},
+				},
 				Month:      types.NewMonth(2022, 2),
 				Balance:    decimal.NewFromFloat(53.11),
 				Spent:      decimal.NewFromFloat(-5),
@@ -311,7 +319,11 @@ func (suite *TestSuiteStandard) TestEnvelopeMonth() {
 		{
 			fmt.Sprintf("%s/2022-03", envelope.Data.Links.Self),
 			models.EnvelopeMonth{
-				Name:       "Utilities",
+				Envelope: models.Envelope{
+					EnvelopeCreate: models.EnvelopeCreate{
+						Name: "Utilities",
+					},
+				},
 				Month:      types.NewMonth(2022, 3),
 				Balance:    decimal.NewFromFloat(69.28),
 				Spent:      decimal.NewFromFloat(-15),
@@ -322,7 +334,11 @@ func (suite *TestSuiteStandard) TestEnvelopeMonth() {
 		{
 			fmt.Sprintf("%s/1998-10", envelope.Data.Links.Self),
 			models.EnvelopeMonth{
-				Name:       "Utilities",
+				Envelope: models.Envelope{
+					EnvelopeCreate: models.EnvelopeCreate{
+						Name: "Utilities",
+					},
+				},
 				Month:      types.NewMonth(1998, 10),
 				Spent:      decimal.NewFromFloat(-0),
 				Balance:    decimal.NewFromFloat(0),

--- a/pkg/models/budget.go
+++ b/pkg/models/budget.go
@@ -114,12 +114,11 @@ func (b Budget) Allocated(db *gorm.DB, month types.Month) (allocated decimal.Dec
 }
 
 type CategoryEnvelopes struct {
-	ID         uuid.UUID       `json:"id" example:"dafd9a74-6aeb-46b9-9f5a-cfca624fea85"` // ID of the category
-	Name       string          `json:"name" example:"Rainy Day Funds" default:""`         // Name of the category
-	Envelopes  []EnvelopeMonth `json:"envelopes"`                                         // Slice of all envelopes
-	Balance    decimal.Decimal `json:"balance" example:"-10.13"`                          // Sum of the balances of the envelopes
-	Allocation decimal.Decimal `json:"allocation" example:"90"`                           // Sum of allocations for the envelopes
-	Spent      decimal.Decimal `json:"spent" example:"100.13"`                            // Sum spent for all envelopes
+	Category
+	Envelopes  []EnvelopeMonth `json:"envelopes"`                // Slice of all envelopes
+	Balance    decimal.Decimal `json:"balance" example:"-10.13"` // Sum of the balances of the envelopes
+	Allocation decimal.Decimal `json:"allocation" example:"90"`  // Sum of allocations for the envelopes
+	Spent      decimal.Decimal `json:"spent" example:"100.13"`   // Sum spent for all envelopes
 }
 
 type Month struct {
@@ -175,8 +174,7 @@ func (b Budget) Month(db *gorm.DB, month types.Month, baseURL string) (Month, er
 		var categoryEnvelopes CategoryEnvelopes
 
 		// Set the basic category values
-		categoryEnvelopes.ID = category.ID
-		categoryEnvelopes.Name = category.Name
+		categoryEnvelopes.Category = category
 		categoryEnvelopes.Envelopes = make([]EnvelopeMonth, 0)
 
 		var envelopes []Envelope

--- a/pkg/models/budget_test.go
+++ b/pkg/models/budget_test.go
@@ -394,14 +394,13 @@ func (suite *TestSuiteStandard) TestMonth() {
 				Available:  decimal.NewFromFloat(-20.99),
 				Categories: []models.CategoryEnvelopes{
 					{
-						Name:       category.Name,
-						ID:         category.ID,
+						Category:   category,
 						Balance:    decimal.NewFromFloat(10.99),
 						Spent:      decimal.NewFromFloat(-10),
 						Allocation: decimal.NewFromFloat(20.99),
 						Envelopes: []models.EnvelopeMonth{
 							{
-								Name:       "Utilities",
+								Envelope:   envelope,
 								Month:      types.NewMonth(2022, 1),
 								Spent:      decimal.NewFromFloat(-10),
 								Balance:    decimal.NewFromFloat(10.99),
@@ -426,14 +425,13 @@ func (suite *TestSuiteStandard) TestMonth() {
 				Available:  decimal.NewFromFloat(-68.11),
 				Categories: []models.CategoryEnvelopes{
 					{
-						Name:       category.Name,
-						ID:         category.ID,
+						Category:   category,
 						Balance:    decimal.NewFromFloat(53.11),
 						Spent:      decimal.NewFromFloat(-5),
 						Allocation: decimal.NewFromFloat(47.12),
 						Envelopes: []models.EnvelopeMonth{
 							{
-								Name:       "Utilities",
+								Envelope:   envelope,
 								Month:      types.NewMonth(2022, 2),
 								Balance:    decimal.NewFromFloat(53.11),
 								Spent:      decimal.NewFromFloat(-5),
@@ -458,14 +456,13 @@ func (suite *TestSuiteStandard) TestMonth() {
 				Available:  decimal.NewFromFloat(1400.72),
 				Categories: []models.CategoryEnvelopes{
 					{
-						Name:       category.Name,
-						ID:         category.ID,
+						Category:   category,
 						Balance:    decimal.NewFromFloat(69.28),
 						Spent:      decimal.NewFromFloat(-15),
 						Allocation: decimal.NewFromFloat(31.17),
 						Envelopes: []models.EnvelopeMonth{
 							{
-								Name:       "Utilities",
+								Envelope:   envelope,
 								Month:      types.NewMonth(2022, 3),
 								Balance:    decimal.NewFromFloat(69.28),
 								Spent:      decimal.NewFromFloat(-15),

--- a/pkg/models/category.go
+++ b/pkg/models/category.go
@@ -6,12 +6,12 @@ import "github.com/google/uuid"
 type Category struct {
 	DefaultModel
 	CategoryCreate
-	Budget Budget `json:"-"`
+	Budget Budget `json:"-"` // The budget the category belongs to
 }
 
 type CategoryCreate struct {
-	Name     string    `json:"name" gorm:"uniqueIndex:category_budget_name" example:"Saving" default:""`
-	BudgetID uuid.UUID `json:"budgetId" gorm:"uniqueIndex:category_budget_name" example:"52d967d3-33f4-4b04-9ba7-772e5ab9d0ce"`
-	Note     string    `json:"note" example:"All envelopes for long-term saving" default:""`
-	Hidden   bool      `json:"hidden" example:"true" default:"false"`
+	Name     string    `json:"name" gorm:"uniqueIndex:category_budget_name" example:"Saving" default:""`                        // Name of the category
+	BudgetID uuid.UUID `json:"budgetId" gorm:"uniqueIndex:category_budget_name" example:"52d967d3-33f4-4b04-9ba7-772e5ab9d0ce"` // ID of the budget the category belongs to
+	Note     string    `json:"note" example:"All envelopes for long-term saving" default:""`                                    // Notes about the category
+	Hidden   bool      `json:"hidden" example:"true" default:"false"`                                                           // Is the category hidden?
 }

--- a/pkg/models/envelope.go
+++ b/pkg/models/envelope.go
@@ -18,10 +18,10 @@ type Envelope struct {
 }
 
 type EnvelopeCreate struct {
-	Name       string    `json:"name" gorm:"uniqueIndex:envelope_category_name" example:"Groceries" default:""`
-	CategoryID uuid.UUID `json:"categoryId" gorm:"uniqueIndex:envelope_category_name" example:"878c831f-af99-4a71-b3ca-80deb7d793c1"`
-	Note       string    `json:"note" example:"For stuff bought at supermarkets and drugstores" default:""`
-	Hidden     bool      `json:"hidden" example:"true" default:"false"`
+	Name       string    `json:"name" gorm:"uniqueIndex:envelope_category_name" example:"Groceries" default:""`                       // Name of the envelope
+	CategoryID uuid.UUID `json:"categoryId" gorm:"uniqueIndex:envelope_category_name" example:"878c831f-af99-4a71-b3ca-80deb7d793c1"` // ID of the category the envelope belongs to
+	Note       string    `json:"note" example:"For stuff bought at supermarkets and drugstores" default:""`                           // Notes about the envelope
+	Hidden     bool      `json:"hidden" example:"true" default:"false"`                                                               // Is the envelope hidden?
 }
 
 type EnvelopeMonthLinks struct {
@@ -30,13 +30,12 @@ type EnvelopeMonthLinks struct {
 
 // EnvelopeMonth contains data about an Envelope for a specific month.
 type EnvelopeMonth struct {
-	ID         uuid.UUID          `json:"id" example:"10b9705d-3356-459e-9d5a-28d42a6c4547"`               // The ID of the Envelope
-	Name       string             `json:"name" example:"Groceries"`                                        // The name of the Envelope
+	Envelope
 	Month      types.Month        `json:"month" example:"1969-06-01T00:00:00.000000Z" hidden:"deprecated"` // This is always set to 00:00 UTC on the first of the month. **This field is deprecated and will be removed in v2**
-	Spent      decimal.Decimal    `json:"spent" example:"73.12"`
-	Balance    decimal.Decimal    `json:"balance" example:"12.32"`
-	Allocation decimal.Decimal    `json:"allocation" example:"85.44"`
-	Links      EnvelopeMonthLinks `json:"links"`
+	Spent      decimal.Decimal    `json:"spent" example:"73.12"`                                           // The amount spent over the whole month
+	Balance    decimal.Decimal    `json:"balance" example:"12.32"`                                         // The balance at the end of the monht
+	Allocation decimal.Decimal    `json:"allocation" example:"85.44"`                                      // The amount of money allocated
+	Links      EnvelopeMonthLinks `json:"links"`                                                           // Linked resources
 }
 
 // Spent returns the amount spent for the month the time.Time instance is in.
@@ -266,8 +265,7 @@ func (e Envelope) Balance(db *gorm.DB, month types.Month) (decimal.Decimal, erro
 func (e Envelope) Month(db *gorm.DB, month types.Month) (EnvelopeMonth, uuid.UUID, error) {
 	spent := e.Spent(db, month)
 	envelopeMonth := EnvelopeMonth{
-		ID:         e.ID,
-		Name:       e.Name,
+		Envelope:   e,
 		Month:      month,
 		Spent:      spent,
 		Balance:    decimal.NewFromFloat(0),

--- a/pkg/models/model.go
+++ b/pkg/models/model.go
@@ -11,16 +11,16 @@ import (
 // As EnvelopeMonth uses the Envelope ID and the Month as primary key,
 // we the timestamps are managed in the Timestamps struct.
 type DefaultModel struct {
-	ID uuid.UUID `json:"id" example:"65392deb-5e92-4268-b114-297faad6cdce"`
+	ID uuid.UUID `json:"id" example:"65392deb-5e92-4268-b114-297faad6cdce"` // UUID for the resource
 	Timestamps
 }
 
 // Timestamps only contains the timestamps that gorm sets automatically to enable other
 // primary keys than ID.
 type Timestamps struct {
-	CreatedAt time.Time       `json:"createdAt" example:"2022-04-02T19:28:44.491514Z"`
-	UpdatedAt time.Time       `json:"updatedAt" example:"2022-04-17T20:14:01.048145Z"`
-	DeletedAt *gorm.DeletedAt `json:"deletedAt" gorm:"index" example:"2022-04-22T21:01:05.058161Z" swaggertype:"primitive,string"`
+	CreatedAt time.Time       `json:"createdAt" example:"2022-04-02T19:28:44.491514Z"`                                             // Time the resource was created
+	UpdatedAt time.Time       `json:"updatedAt" example:"2022-04-17T20:14:01.048145Z"`                                             // Last time the resource was updated
+	DeletedAt *gorm.DeletedAt `json:"deletedAt" gorm:"index" example:"2022-04-22T21:01:05.058161Z" swaggertype:"primitive,string"` // Time the resource was marked as deleted
 }
 
 // AfterFind updates the timestamps to use UTC as


### PR DESCRIPTION
With this change, all fields for categories and envelopes are
always included in queries to the month endpoint.

Resolves #552.
