### PR TITLE
feat: add search parameter for all resources with name and note

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -138,6 +138,12 @@ const docTemplate = `{
                         "description": "Is the account hidden?",
                         "name": "hidden",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search for this text in name and note",
+                        "name": "search",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -688,6 +694,12 @@ const docTemplate = `{
                         "description": "Filter by currency",
                         "name": "currency",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search for this text in name and note",
+                        "name": "search",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1205,6 +1217,12 @@ const docTemplate = `{
                         "description": "Is the category hidden?",
                         "name": "hidden",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search for this text in name and note",
+                        "name": "search",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1494,6 +1512,12 @@ const docTemplate = `{
                         "type": "boolean",
                         "description": "Is the envelope hidden?",
                         "name": "hidden",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search for this text in name and note",
+                        "name": "search",
                         "in": "query"
                     }
                 ],

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -126,6 +126,12 @@
                         "description": "Is the account hidden?",
                         "name": "hidden",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search for this text in name and note",
+                        "name": "search",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -676,6 +682,12 @@
                         "description": "Filter by currency",
                         "name": "currency",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search for this text in name and note",
+                        "name": "search",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1193,6 +1205,12 @@
                         "description": "Is the category hidden?",
                         "name": "hidden",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search for this text in name and note",
+                        "name": "search",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1482,6 +1500,12 @@
                         "type": "boolean",
                         "description": "Is the envelope hidden?",
                         "name": "hidden",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search for this text in name and note",
+                        "name": "search",
                         "in": "query"
                     }
                 ],

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1039,6 +1039,10 @@ paths:
         in: query
         name: hidden
         type: boolean
+      - description: Search for this text in name and note
+        in: query
+        name: search
+        type: string
       produces:
       - application/json
       responses:
@@ -1408,6 +1412,10 @@ paths:
         in: query
         name: currency
         type: string
+      - description: Search for this text in name and note
+        in: query
+        name: search
+        type: string
       produces:
       - application/json
       responses:
@@ -1765,6 +1773,10 @@ paths:
         in: query
         name: hidden
         type: boolean
+      - description: Search for this text in name and note
+        in: query
+        name: search
+        type: string
       produces:
       - application/json
       responses:
@@ -1960,6 +1972,10 @@ paths:
         in: query
         name: hidden
         type: boolean
+      - description: Search for this text in name and note
+        in: query
+        name: search
+        type: string
       produces:
       - application/json
       responses:

--- a/pkg/controllers/account_test.go
+++ b/pkg/controllers/account_test.go
@@ -134,6 +134,8 @@ func (suite *TestSuiteStandard) TestGetAccountsFilter() {
 		{"Internal", "external=false", 3},
 		{"Not Hidden", "hidden=false", 3},
 		{"Hidden", "hidden=true", 2},
+		{"Search for 'na", "search=na", 3},
+		{"Search for 'fi", "search=fi", 4},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controllers/budget_test.go
+++ b/pkg/controllers/budget_test.go
@@ -131,6 +131,8 @@ func (suite *TestSuiteStandard) TestGetBudgetsFilter() {
 		{"Empty Name with Note", "name=&note=This is a specific note", 1},
 		{"No currency", "currency=", 1},
 		{"No name", "name=", 1},
+		{"Search for 'stRing'", "search=stRing", 2},
+		{"Search for 'Note'", "search=Note", 3},
 	}
 
 	var re controllers.BudgetListResponse

--- a/pkg/controllers/category_test.go
+++ b/pkg/controllers/category_test.go
@@ -156,6 +156,8 @@ func (suite *TestSuiteStandard) TestGetCategoriesFilter() {
 		{"Fuzzy note", "note=Groceries", 2},
 		{"Not hidden", "hidden=false", 2},
 		{"Hidden", "hidden=true", 1},
+		{"Search for 'groceries'", "search=groceries", 2},
+		{"Search for 'FOR'", "search=FOR", 2},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controllers/envelope_test.go
+++ b/pkg/controllers/envelope_test.go
@@ -109,7 +109,7 @@ func (suite *TestSuiteStandard) TestGetEnvelopesFilter() {
 
 	_ = suite.createTestEnvelope(models.EnvelopeCreate{
 		Name:       "Stamps",
-		Note:       "Because each stamp needs to go on an envelope",
+		Note:       "Because each stamp needs to go on an envelope. Hopefully it's not hairy",
 		CategoryID: c2.Data.ID,
 	})
 
@@ -127,6 +127,9 @@ func (suite *TestSuiteStandard) TestGetEnvelopesFilter() {
 		{"Fuzzy note", "note=Because", 2},
 		{"Not hidden", "hidden=false", 2},
 		{"Hidden", "hidden=true", 1},
+		{"Search for 'hair'", "search=hair", 2},
+		{"Search for 'st'", "search=st", 2},
+		{"Search for 'STUFF'", "search=STUFF", 1},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controllers/filters.go
+++ b/pkg/controllers/filters.go
@@ -1,0 +1,34 @@
+package controllers
+
+import (
+	"fmt"
+
+	"golang.org/x/exp/slices"
+	"gorm.io/gorm"
+)
+
+func stringFilters(db, query *gorm.DB, setFields []string, name, note, search string) *gorm.DB {
+	if name != "" {
+		query = query.Where("name LIKE ?", fmt.Sprintf("%%%s%%", name))
+	} else if slices.Contains(setFields, "Name") {
+		query = query.Where("name = ''")
+	}
+
+	if note != "" {
+		query = query.Where("note LIKE ?", fmt.Sprintf("%%%s%%", note))
+	} else if slices.Contains(setFields, "Note") {
+		query = query.Where("note = ''")
+	}
+
+	if search != "" {
+		query = query.Where(
+			db.Where("note LIKE ?", fmt.Sprintf("%%%s%%", search)).Or(
+				db.Where("name LIKE ?", fmt.Sprintf("%%%s%%", search)),
+			),
+		)
+	} else if slices.Contains(setFields, "Search") {
+		query = query.Where("note = ''").Where("name = ''")
+	}
+
+	return query
+}

--- a/pkg/controllers/filters.go
+++ b/pkg/controllers/filters.go
@@ -26,8 +26,6 @@ func stringFilters(db, query *gorm.DB, setFields []string, name, note, search st
 				db.Where("name LIKE ?", fmt.Sprintf("%%%s%%", search)),
 			),
 		)
-	} else if slices.Contains(setFields, "Search") {
-		query = query.Where("note = ''").Where("name = ''")
 	}
 
 	return query


### PR DESCRIPTION
With the new 'search' query parameter for the list endpoints, all
string fields of a resource can be searched at the same time.

Resolves #554.
