### PR TITLE
feat: add note field for MonthConfig

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3770,6 +3770,11 @@ const docTemplate = `{
                     "type": "string",
                     "example": "1969-06-01T00:00:00.000000Z"
                 },
+                "note": {
+                    "description": "A note for the month config",
+                    "type": "string",
+                    "example": "Added 200€ here because we replaced Tim's expensive vase"
+                },
                 "overspendMode": {
                     "default": "AFFECT_AVAILABLE",
                     "allOf": [
@@ -3789,6 +3794,11 @@ const docTemplate = `{
         "models.MonthConfigCreate": {
             "type": "object",
             "properties": {
+                "note": {
+                    "description": "A note for the month config",
+                    "type": "string",
+                    "example": "Added 200€ here because we replaced Tim's expensive vase"
+                },
                 "overspendMode": {
                     "default": "AFFECT_AVAILABLE",
                     "allOf": [

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -3758,6 +3758,11 @@
                     "type": "string",
                     "example": "1969-06-01T00:00:00.000000Z"
                 },
+                "note": {
+                    "description": "A note for the month config",
+                    "type": "string",
+                    "example": "Added 200€ here because we replaced Tim's expensive vase"
+                },
                 "overspendMode": {
                     "default": "AFFECT_AVAILABLE",
                     "allOf": [
@@ -3777,6 +3782,11 @@
         "models.MonthConfigCreate": {
             "type": "object",
             "properties": {
+                "note": {
+                    "description": "A note for the month config",
+                    "type": "string",
+                    "example": "Added 200€ here because we replaced Tim's expensive vase"
+                },
                 "overspendMode": {
                     "default": "AFFECT_AVAILABLE",
                     "allOf": [

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -740,6 +740,10 @@ definitions:
         description: This is always set to 00:00 UTC on the first of the month.
         example: "1969-06-01T00:00:00.000000Z"
         type: string
+      note:
+        description: A note for the month config
+        example: Added 200€ here because we replaced Tim's expensive vase
+        type: string
       overspendMode:
         allOf:
         - $ref: '#/definitions/models.OverspendMode'
@@ -752,6 +756,10 @@ definitions:
     type: object
   models.MonthConfigCreate:
     properties:
+      note:
+        description: A note for the month config
+        example: Added 200€ here because we replaced Tim's expensive vase
+        type: string
       overspendMode:
         allOf:
         - $ref: '#/definitions/models.OverspendMode'

--- a/pkg/controllers/month_config_test.go
+++ b/pkg/controllers/month_config_test.go
@@ -50,19 +50,27 @@ func (suite *TestSuiteStandard) TestMonthConfigsCreate() {
 	someMonth := types.NewMonth(2020, 3)
 
 	tests := []struct {
-		name       string
-		envelopeID uuid.UUID
-		month      types.Month
-		status     int
+		name          string
+		envelopeID    uuid.UUID
+		month         types.Month
+		note          string
+		overspendMode models.OverspendMode
+		status        int
 	}{
-		{"Standard create", envelope.Data.ID, someMonth, http.StatusCreated},
-		{"duplicate config for same envelope and month", envelope.Data.ID, someMonth, http.StatusBadRequest},
-		{"No envelope", uuid.New(), someMonth, http.StatusNotFound},
+		{"Standard create", envelope.Data.ID, someMonth, "test note", models.AffectAvailable, http.StatusCreated},
+		{"duplicate config for same envelope and month", envelope.Data.ID, someMonth, "", models.AffectAvailable, http.StatusBadRequest},
+		{"No envelope", uuid.New(), someMonth, "", models.AffectAvailable, http.StatusNotFound},
 	}
 
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
-			_ = suite.createTestMonthConfig(tt.envelopeID, tt.month, models.MonthConfigCreate{}, tt.status)
+			response := suite.createTestMonthConfig(tt.envelopeID, tt.month, models.MonthConfigCreate{Note: tt.note, OverspendMode: tt.overspendMode}, tt.status)
+
+			// Verify that fields are set correctly
+			if tt.status == http.StatusCreated {
+				assert.Equal(t, tt.overspendMode, response.Data.OverspendMode)
+				assert.Equal(t, tt.note, response.Data.Note)
+			}
 		})
 	}
 }

--- a/pkg/models/month_config.go
+++ b/pkg/models/month_config.go
@@ -30,6 +30,7 @@ type MonthConfig struct {
 
 type MonthConfigCreate struct {
 	OverspendMode OverspendMode `json:"overspendMode" example:"AFFECT_ENVELOPE" default:"AFFECT_AVAILABLE"`
+	Note          string        `json:"note" example:"Added 200€ here because we replaced Tim's expensive vase" default:""` // A note for the month config
 }
 
 // AfterSave also sets the links so that we do not need to


### PR DESCRIPTION
This adds a note field for the MonthConfig model.

Resolves #630.