### PR TITLE
fix: import hashes should be a hex string of the bytes

### DIFF
--- a/pkg/importer/helpers/sha256.go
+++ b/pkg/importer/helpers/sha256.go
@@ -1,0 +1,11 @@
+package helpers
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+// Sha256String calculates the SHA256 hash of a given string and returns its string representation.
+func Sha256String(input string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(input)))
+}

--- a/pkg/importer/helpers/sha256_test.go
+++ b/pkg/importer/helpers/sha256_test.go
@@ -1,0 +1,13 @@
+package helpers_test
+
+import (
+	"testing"
+
+	"github.com/envelope-zero/backend/v2/pkg/importer/helpers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSha256(t *testing.T) {
+	s := helpers.Sha256String("Envelope Zero")
+	assert.Equal(t, "dbac4a4ba50e42b6e04b43c2c9b3619e3668dc0a8caf050b584bdafaebee1787", s, "SHA256 checksum calculation is wrong!")
+}

--- a/pkg/models/database.go
+++ b/pkg/models/database.go
@@ -2,6 +2,8 @@ package models
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"gorm.io/gorm"
 )
@@ -13,21 +15,19 @@ func Migrate(db *gorm.DB) error {
 		return fmt.Errorf("error during DB migration: %w", err)
 	}
 
-	/*
-	 * Workaround for https://github.com/go-gorm/gorm/issues/5968
-	 */
 	queries := []*gorm.DB{
+		/*
+		 * Workaround for https://github.com/go-gorm/gorm/issues/5968
+		 * Remove with 3.0.0
+		 */
 		// Account
 		db.Unscoped().Model(&Account{}).Select("OnBudget").Where("accounts.on_budget IS NULL").Update("OnBudget", false),
 		db.Unscoped().Model(&Account{}).Select("External").Where("accounts.external IS NULL").Update("External", false),
 		db.Unscoped().Model(&Account{}).Select("Hidden").Where("accounts.hidden IS NULL").Update("Hidden", false),
-
 		// Category
 		db.Unscoped().Model(&Category{}).Select("Hidden").Where("categories.hidden IS NULL").Update("Hidden", false),
-
 		// Envelope
 		db.Unscoped().Model(&Envelope{}).Select("Hidden").Where("envelopes.hidden IS NULL").Update("Hidden", false),
-
 		// Transaction
 		db.Unscoped().Model(&Transaction{}).Select("Reconciled").Where("transactions.reconciled IS NULL").Update("Reconciled", false),
 		db.Unscoped().Model(&Transaction{}).Select("ReconciledSource").Where("transactions.reconciled_source IS NULL").Update("ReconciledSource", false),
@@ -40,5 +40,71 @@ func Migrate(db *gorm.DB) error {
 		}
 	}
 
+	/*
+	 * Complex migrations
+	 */
+
+	// Migration for https://github.com/envelope-zero/backend/issues/628.
+	// Remove with 3.0.0
+	err = migrateImportHashString(db)
+	if err != nil {
+		return fmt.Errorf("error during migrateImportHashString: %w", err)
+	}
+
 	return nil
+}
+
+// migrateImportHashString migrates the string representation of the SHA256 hash as byte array
+// to a hex string representation of the hash to use the common way of representing SHA256 hashes.
+// See https://github.com/envelope-zero/backend/issues/628.
+func migrateImportHashString(db *gorm.DB) (err error) {
+	var accounts []Account
+	err = db.Unscoped().Where("import_hash LIKE '[%'").Find(&accounts).Error
+	if err != nil {
+		return err
+	}
+
+	for _, account := range accounts {
+		// The string looks like this: "[40 52 207 7 118 61 80 107 178 242 5 47 211 161 180 135 104 222 118 28 56 12 33 63 179 78 39 173 206 11 77 3]"
+		// With trimming and splitting it, we get a slice containing every individual number
+		bytes := strings.Split(strings.TrimRight(strings.TrimLeft(account.ImportHash, "["), "]"), " ")
+
+		// Assemble the slice back to a string. We pad with zeroes so that every byte takes two characters
+		var b strings.Builder
+		for _, part := range bytes {
+			// Need to convert to int first so that it's interpreted correctly
+			charAsInt, _ := strconv.Atoi(part)
+			b.WriteString(fmt.Sprintf("%02x", byte(charAsInt)))
+		}
+
+		// Save the record back to the DB
+		account.ImportHash = b.String()
+		db.Unscoped().Save(&account)
+	}
+
+	var transactions []Transaction
+	err = db.Unscoped().Where("import_hash LIKE '[%'").Find(&transactions).Error
+	if err != nil {
+		return err
+	}
+
+	for _, transaction := range transactions {
+		// The string looks like this: "[40 52 207 7 118 61 80 107 178 242 5 47 211 161 180 135 104 222 118 28 56 12 33 63 179 78 39 173 206 11 77 3]"
+		// With trimming and splitting it, we get a slice containing every individual number
+		bytes := strings.Split(strings.TrimRight(strings.TrimLeft(transaction.ImportHash, "["), "]"), " ")
+
+		// Assemble the slice back to a string. We pad with zeroes so that every byte takes two characters
+		var b strings.Builder
+		for _, part := range bytes {
+			// Need to convert to int first so that it's interpreted correctly
+			charAsInt, _ := strconv.Atoi(part)
+			b.WriteString(fmt.Sprintf("%02x", byte(charAsInt)))
+		}
+
+		// Save the record back to the DB
+		transaction.ImportHash = b.String()
+		db.Unscoped().Save(&transaction)
+	}
+
+	return
 }


### PR DESCRIPTION
This fixes a bug where the import hash was the string representation
of a slice containing the bytes for the SHA256 hash.

Import hashes are now always the hexadecimal string representation
of the SHA256 hash.

Resolves #628.
