### PR TITLE
fix: ignore deleted resources in calculation of balance for envelope

### DIFF
--- a/pkg/models/envelope.go
+++ b/pkg/models/envelope.go
@@ -114,6 +114,7 @@ func (e Envelope) Balance(db *gorm.DB, month types.Month) (decimal.Decimal, erro
 		Joins("JOIN accounts destination_account ON transactions.destination_account_id = destination_account.id AND destination_account.deleted_at IS NULL").
 		Where("transactions.date < date(?)", month.AddDate(0, 1)).
 		Where("transactions.envelope_id = ?", e.ID).
+		Where("transactions.deleted_at IS NULL").
 		Select("transactions.amount AS Amount, transactions.date AS Date, source_account.on_budget AS SourceAccountOnBudget, destination_account.on_budget AS DestinationAccountOnBudget").
 		Find(&rawTransactions).Error
 	if err != nil {
@@ -133,6 +134,7 @@ func (e Envelope) Balance(db *gorm.DB, month types.Month) (decimal.Decimal, erro
 		Table("allocations").
 		Where("allocations.month < date(?)", month.AddDate(0, 1)).
 		Where("allocations.envelope_id = ?", e.ID).
+		Where("allocations.deleted_at IS NULL").
 		Find(&rawAllocations).Error
 	if err != nil {
 		return decimal.Zero, nil
@@ -150,6 +152,7 @@ func (e Envelope) Balance(db *gorm.DB, month types.Month) (decimal.Decimal, erro
 		Table("month_configs").
 		Where("month_configs.month < date(?)", month.AddDate(0, 1)).
 		Where("month_configs.envelope_id = ?", e.ID).
+		Where("month_configs.deleted_at IS NULL").
 		Find(&rawConfigs).Error
 	if err != nil {
 		return decimal.Zero, nil

--- a/pkg/models/envelope_test.go
+++ b/pkg/models/envelope_test.go
@@ -236,6 +236,17 @@ func (suite *TestSuiteStandard) TestEnvelopeMonthBalance() {
 		Date:                 time.Time(january.AddDate(0, 1)),
 	})
 
+	// Deleted transaction to verify that deleted transactions are not used in the calculation
+	deletedTransaction := suite.createTestTransaction(models.TransactionCreate{
+		BudgetID:             budget.ID,
+		EnvelopeID:           &envelope.ID,
+		Amount:               decimal.NewFromFloat(30),
+		SourceAccountID:      internalAccount.ID,
+		DestinationAccountID: externalAccount.ID,
+		Date:                 time.Time(january.AddDate(0, 1)),
+	})
+	suite.db.Delete(&deletedTransaction)
+
 	tests := []struct {
 		month    types.Month
 		envelope models.Envelope


### PR DESCRIPTION
This fixes a bug where deleted resources were included in the balance
calculation for an envelope, yielding wrong results.
