### PR TITLE
fix: do not allow allocations with amount 0

### DIFF
--- a/pkg/controllers/allocation_test.go
+++ b/pkg/controllers/allocation_test.go
@@ -2,6 +2,7 @@ package controllers_test
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
 	"testing"
 	"time"
@@ -18,6 +19,11 @@ import (
 func (suite *TestSuiteStandard) createTestAllocation(c models.AllocationCreate, expectedStatus ...int) controllers.AllocationResponse {
 	if c.EnvelopeID == uuid.Nil {
 		c.EnvelopeID = suite.createTestEnvelope(models.EnvelopeCreate{Name: "Transaction Test Envelope"}).Data.ID
+	}
+
+	// If no amount is set, set a random one
+	if c.Amount.IsZero() {
+		c.Amount = decimal.NewFromFloat(float64(rand.Intn(100000)) / 100.0)
 	}
 
 	// Default to 200 OK as expected status

--- a/pkg/controllers/month.go
+++ b/pkg/controllers/month.go
@@ -197,6 +197,11 @@ func (co Controller) SetAllocations(c *gin.Context) {
 			amount = models.Envelope{DefaultModel: models.DefaultModel{ID: allocation.EnvelopeID}}.Spent(co.DB, pastMonth).Neg()
 		}
 
+		// Do not create allocations for an amount of 0
+		if amount.IsZero() {
+			continue
+		}
+
 		if !queryWithRetry(c, co.DB.Create(&models.Allocation{
 			AllocationCreate: models.AllocationCreate{
 				EnvelopeID: allocation.EnvelopeID,

--- a/pkg/httperrors/errors.go
+++ b/pkg/httperrors/errors.go
@@ -103,6 +103,8 @@ func Handler(c *gin.Context, err error, notFoundMsg ...string) {
 	} else if reflect.TypeOf(err) == reflect.TypeOf(&sqlite.Error{}) {
 		code, msg := DBErrorMessage(err)
 		New(c, code, msg)
+	} else if strings.Contains(err.Error(), "Allocation amounts must be non-zero") {
+		New(c, http.StatusBadRequest, err.Error())
 
 		// Database connection has not been opened or has been closed already
 	} else if strings.Contains(err.Error(), "sql: database is closed") {

--- a/pkg/models/database.go
+++ b/pkg/models/database.go
@@ -32,6 +32,9 @@ func Migrate(db *gorm.DB) error {
 		db.Unscoped().Model(&Transaction{}).Select("Reconciled").Where("transactions.reconciled IS NULL").Update("Reconciled", false),
 		db.Unscoped().Model(&Transaction{}).Select("ReconciledSource").Where("transactions.reconciled_source IS NULL").Update("ReconciledSource", false),
 		db.Unscoped().Model(&Transaction{}).Select("ReconciledDestination").Where("transactions.reconciled_destination IS NULL").Update("ReconciledDestination", false),
+
+		// Delete allocations with an amount of 0
+		db.Unscoped().Model(&Allocation{}).Where("amount IS '0'").Delete(&Allocation{}),
 	}
 	for _, query := range queries {
 		err = query.Error


### PR DESCRIPTION
Allocations with an amount of 0 are useless and we don't need them.
Therefore, we disallow them.

Existing ones are deleted in a migration, too.
