### PR TITLE
test: move assertHTTPStatus to a function

### DIFF
--- a/pkg/controllers/account_test.go
+++ b/pkg/controllers/account_test.go
@@ -24,7 +24,7 @@ func (suite *TestSuiteStandard) createTestAccount(c models.AccountCreate, expect
 	}
 
 	r := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/accounts", c)
-	suite.assertHTTPStatus(&r, expectedStatus...)
+	assertHTTPStatus(suite.T(), &r, expectedStatus...)
 
 	var a controllers.AccountResponse
 	suite.decodeResponse(&r, &a)
@@ -36,7 +36,7 @@ func (suite *TestSuiteStandard) TestAccounts() {
 	suite.CloseDB()
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts", "")
-	suite.assertHTTPStatus(&recorder, http.StatusInternalServerError)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusInternalServerError)
 	assert.Contains(suite.T(), test.DecodeError(suite.T(), recorder.Body.Bytes()), "There is a problem with the database connection")
 }
 
@@ -58,7 +58,7 @@ func (suite *TestSuiteStandard) TestGetAccounts() {
 
 	var response controllers.AccountListResponse
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts", "")
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 	suite.decodeResponse(&recorder, &response)
 
 	assert.Len(suite.T(), response.Data, 1)
@@ -66,10 +66,10 @@ func (suite *TestSuiteStandard) TestGetAccounts() {
 
 func (suite *TestSuiteStandard) TestGetAccountsInvalidQuery() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts?onBudget=NotABoolean", "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts?budget=8593-not-a-uuid", "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestGetAccountsFilter() {
@@ -142,7 +142,7 @@ func (suite *TestSuiteStandard) TestGetAccountsFilter() {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			var re controllers.BudgetListResponse
 			r := test.Request(suite.controller, t, http.MethodGet, fmt.Sprintf("/v1/accounts?%s", tt.query), "")
-			suite.assertHTTPStatus(&r, http.StatusOK)
+			assertHTTPStatus(suite.T(), &r, http.StatusOK)
 			suite.decodeResponse(&r, &re)
 
 			var accountNames []string
@@ -164,7 +164,7 @@ func (suite *TestSuiteStandard) TestGetAccountsFilter() {
 
 func (suite *TestSuiteStandard) TestNoAccountNotFound() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts/39633f90-3d9f-4b1e-ac24-c341c432a6e3", "")
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestAccountInvalidIDs() {
@@ -172,31 +172,31 @@ func (suite *TestSuiteStandard) TestAccountInvalidIDs() {
 	 *  GET
 	 */
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts/-56", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts/notANumber", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts/23", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	/*
 	 * PATCH
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/accounts/-274", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/accounts/stringRandom", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	/*
 	 * DELETE
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/accounts/-274", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/accounts/stringRandom", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateAccount() {
@@ -205,22 +205,22 @@ func (suite *TestSuiteStandard) TestCreateAccount() {
 
 func (suite *TestSuiteStandard) TestCreateAccountNoBudget() {
 	r := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/accounts", models.Account{})
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateBrokenAccount() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/accounts", `{ "createdAt": "New Account", "note": "More tests for accounts to ensure less brokenness something" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateAccountNoBody() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/accounts", "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateAccountNonExistingBudget() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/accounts", models.AccountCreate{BudgetID: uuid.New()})
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestGetAccount() {
@@ -243,7 +243,7 @@ func (suite *TestSuiteStandard) TestUpdateAccount() {
 		"note":     "",
 		"onBudget": false,
 	})
-	suite.assertHTTPStatus(&r, http.StatusOK)
+	assertHTTPStatus(suite.T(), &r, http.StatusOK)
 
 	var u controllers.AccountResponse
 	suite.decodeResponse(&r, &u)
@@ -260,7 +260,7 @@ func (suite *TestSuiteStandard) TestUpdateAccountBrokenJSON() {
 	})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodPatch, a.Data.Links.Self, `{ "name": 2" }`)
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateAccountInvalidType() {
@@ -272,7 +272,7 @@ func (suite *TestSuiteStandard) TestUpdateAccountInvalidType() {
 	r := test.Request(suite.controller, suite.T(), http.MethodPatch, a.Data.Links.Self, map[string]any{
 		"name": 2,
 	})
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateAccountInvalidBudgetID() {
@@ -283,12 +283,12 @@ func (suite *TestSuiteStandard) TestUpdateAccountInvalidBudgetID() {
 
 	// Sets the BudgetID to uuid.Nil
 	r := test.Request(suite.controller, suite.T(), http.MethodPatch, a.Data.Links.Self, models.AccountCreate{})
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateNonExistingAccount() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/accounts/9b81de41-eead-451d-bc6b-31fceedd236c", models.AccountCreate{Name: "This account does not exist"})
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteAccountsAndEmptyList() {
@@ -299,7 +299,7 @@ func (suite *TestSuiteStandard) TestDeleteAccountsAndEmptyList() {
 
 	for _, a := range l.Data {
 		r = test.Request(suite.controller, suite.T(), http.MethodDelete, a.Links.Self, "")
-		suite.assertHTTPStatus(&r, http.StatusNoContent)
+		assertHTTPStatus(suite.T(), &r, http.StatusNoContent)
 	}
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/accounts", "")
@@ -312,14 +312,14 @@ func (suite *TestSuiteStandard) TestDeleteAccountsAndEmptyList() {
 
 func (suite *TestSuiteStandard) TestDeleteNonExistingAccount() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/accounts/77b70a75-4bb3-4d1d-90cf-5b7a61f452f5", "")
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteAccountWithBody() {
 	a := suite.createTestAccount(models.AccountCreate{Name: "Delete me now!"})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodDelete, a.Data.Links.Self, models.AccountCreate{Name: "Some other account"})
-	suite.assertHTTPStatus(&r, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &r, http.StatusNoContent)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, a.Data.Links.Self, "")
 }

--- a/pkg/controllers/budget_test.go
+++ b/pkg/controllers/budget_test.go
@@ -23,7 +23,7 @@ func (suite *TestSuiteStandard) createTestBudget(c models.BudgetCreate, expected
 	}
 
 	r := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", c)
-	suite.assertHTTPStatus(&r, expectedStatus...)
+	assertHTTPStatus(suite.T(), &r, expectedStatus...)
 
 	var a controllers.BudgetResponse
 	suite.decodeResponse(&r, &a)
@@ -40,7 +40,7 @@ func (suite *TestSuiteStandard) TestBudgets() {
 	suite.CloseDB()
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/budgets", "")
-	suite.assertHTTPStatus(&recorder, http.StatusInternalServerError)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusInternalServerError)
 	assert.Contains(suite.T(), test.DecodeError(suite.T(), recorder.Body.Bytes()), "There is a problem with the database connection")
 }
 
@@ -65,20 +65,20 @@ func (suite *TestSuiteStandard) TestOptionsBudgetMonth() {
 	budgetLink := suite.createTestBudget(models.BudgetCreate{}).Data.Links.Month
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodOptions, strings.Replace(budgetLink, "YYYY-MM", "1970-01", 1), "")
-	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
 	assert.Equal(suite.T(), recorder.Header().Get("allow"), "OPTIONS, GET")
 
 	// Bad Request for invalid UUID
 	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/budgets/nouuid/2022-01", "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 
 	// Bad Request for invalid month
 	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, budgetLink, "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 
 	// Not found for non-existing budget
 	recorder = test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v1/budgets/5b95e1a9-522d-4a36-9074-32f7c2ff0513/1980-06", "")
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestGetBudgets() {
@@ -139,7 +139,7 @@ func (suite *TestSuiteStandard) TestGetBudgetsFilter() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			r := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("http://example.com/v1/budgets?%s", tt.query), "")
-			suite.assertHTTPStatus(&r, http.StatusOK)
+			assertHTTPStatus(suite.T(), &r, http.StatusOK)
 			suite.decodeResponse(&r, &re)
 			assert.Equal(t, tt.len, len(re.Data))
 		})
@@ -149,7 +149,7 @@ func (suite *TestSuiteStandard) TestGetBudgetsFilter() {
 func (suite *TestSuiteStandard) TestNoBudgetNotFound() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/budgets/65064e6f-04b4-46e0-8bbc-88c96c6b21bd", "")
 
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestBudgetInvalidIDs() {
@@ -157,39 +157,39 @@ func (suite *TestSuiteStandard) TestBudgetInvalidIDs() {
 	 *  GET
 	 */
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/budgets/-56", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/budgets/notANumber", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/budgets/23", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/budgets/d19a622f-broken-uuid/2022-01", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	/*
 	 * PATCH
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/budgets/-274", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/budgets/stringRandom", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	/*
 	 * DELETE
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/budgets/-274", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/budgets/stringRandom", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateBudget() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", `{ "name": "New Budget", "note": "More tests something something" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusCreated)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusCreated)
 
 	var budgetObject, savedObject controllers.BudgetResponse
 	suite.decodeResponse(&recorder, &budgetObject)
@@ -202,12 +202,12 @@ func (suite *TestSuiteStandard) TestCreateBudget() {
 
 func (suite *TestSuiteStandard) TestCreateBrokenBudget() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", `{ "createdAt": "New Budget", "note": "More tests something something" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateBudgetNoBody() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 // TestBudgetMonth verifies that the monthly calculations are correct.
@@ -354,7 +354,7 @@ func (suite *TestSuiteStandard) TestBudgetMonth() {
 	var budgetMonth controllers.BudgetMonthResponse
 	for _, tt := range tests {
 		r := test.Request(suite.controller, suite.T(), http.MethodGet, tt.path, "")
-		suite.assertHTTPStatus(&r, http.StatusOK)
+		assertHTTPStatus(suite.T(), &r, http.StatusOK)
 		suite.decodeResponse(&r, &budgetMonth)
 
 		// Verify income calculation
@@ -393,7 +393,7 @@ func (suite *TestSuiteStandard) TestBudgetMonthBudgeted() {
 	var budgetMonth controllers.BudgetMonthResponse
 
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("%s/2022-01", budget.Data.Links.Self), "")
-	suite.assertHTTPStatus(&r, http.StatusOK)
+	assertHTTPStatus(suite.T(), &r, http.StatusOK)
 	suite.decodeResponse(&r, &budgetMonth)
 
 	assert.True(suite.T(), budgetMonth.Data.Budgeted.Equal(decimal.NewFromFloat(40)), "Calculation of budgeted sum for a month is off. Should be 40, is %s", budgetMonth.Data.Budgeted)
@@ -402,7 +402,7 @@ func (suite *TestSuiteStandard) TestBudgetMonthBudgeted() {
 // TestBudgetMonthNonExistent verifies that month requests for non-existing budgets return a HTTP 404 Not Found.
 func (suite *TestSuiteStandard) TestBudgetMonthNonExistent() {
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/budgets/65064e6f-04b4-46e0-8bbc-88c96c6b21bd/2022-01", "")
-	suite.assertHTTPStatus(&r, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &r, http.StatusNotFound)
 }
 
 // TestBudgetMonthZero tests that we return a HTTP Bad Request when requesting data for the zero timestamp.
@@ -410,7 +410,7 @@ func (suite *TestSuiteStandard) TestBudgetMonthZero() {
 	budget := suite.createTestBudget(models.BudgetCreate{})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("%s/0001-01", budget.Data.Links.Self), "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 }
 
 // TestBudgetMonthInvalid tests that we return a HTTP Bad Request when requesting data for the zero timestamp.
@@ -418,12 +418,12 @@ func (suite *TestSuiteStandard) TestBudgetMonthInvalid() {
 	budget := suite.createTestBudget(models.BudgetCreate{})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("%s/December-2020", budget.Data.Links.Self), "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateBudget() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", `{ "name": "New Budget", "note": "More tests something something" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusCreated)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusCreated)
 
 	var budget controllers.BudgetResponse
 	suite.decodeResponse(&recorder, &budget)
@@ -432,7 +432,7 @@ func (suite *TestSuiteStandard) TestUpdateBudget() {
 		"name": "Updated new budget",
 		"note": "",
 	})
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 
 	var updatedBudget controllers.BudgetResponse
 	suite.decodeResponse(&recorder, &updatedBudget)
@@ -443,18 +443,18 @@ func (suite *TestSuiteStandard) TestUpdateBudget() {
 
 func (suite *TestSuiteStandard) TestUpdateBudgetBrokenJSON() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", `{ "name": "New Budget", "note": "More tests something something" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusCreated)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusCreated)
 
 	var budget controllers.BudgetResponse
 	suite.decodeResponse(&recorder, &budget)
 
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPatch, budget.Data.Links.Self, `{ "name": 2" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateBudgetInvalidType() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", `{ "name": "New Budget", "note": "More tests something something" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusCreated)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusCreated)
 
 	var budget controllers.BudgetResponse
 	suite.decodeResponse(&recorder, &budget)
@@ -462,39 +462,39 @@ func (suite *TestSuiteStandard) TestUpdateBudgetInvalidType() {
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPatch, budget.Data.Links.Self, map[string]any{
 		"name": 2,
 	})
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateNonExistingBudget() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/budgets/a29bd123-beec-47de-a9cd-b6f7483fe00f", `{ "name": "2" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteBudget() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", `{ "name": "Delete me now!" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusCreated)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusCreated)
 
 	var budget controllers.BudgetResponse
 	suite.decodeResponse(&recorder, &budget)
 
 	recorder = test.Request(suite.controller, suite.T(), http.MethodDelete, budget.Data.Links.Self, "")
-	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
 }
 
 func (suite *TestSuiteStandard) TestDeleteNonExistingBudget() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/budgets/c3d34346-609a-4734-9364-98f5b0100150", "")
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteBudgetWithBody() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets", `{ "name": "Delete me now!" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusCreated)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusCreated)
 
 	var budget controllers.BudgetResponse
 	suite.decodeResponse(&recorder, &budget)
 
 	recorder = test.Request(suite.controller, suite.T(), http.MethodDelete, budget.Data.Links.Self, `{ "name": "test name 23" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
 }
 
 func (suite *TestSuiteStandard) TestDeleteAllocationsMonth() {
@@ -517,14 +517,14 @@ func (suite *TestSuiteStandard) TestDeleteAllocationsMonth() {
 
 	// Clear allocations
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, strings.Replace(budget.Data.Links.MonthAllocations, "YYYY-MM", "2022-01", 1), "")
-	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
 
 	// Verify that allocations are deleted
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, allocation1.Data.Links.Self, "")
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, allocation2.Data.Links.Self, "")
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteAllocationsMonthFailures() {
@@ -532,15 +532,15 @@ func (suite *TestSuiteStandard) TestDeleteAllocationsMonthFailures() {
 
 	// Bad Request for invalid UUID
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/budgets/nouuid/2022-01/allocations", "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 
 	// Bad Request for invalid months
 	recorder = test.Request(suite.controller, suite.T(), http.MethodDelete, budgetAllocationsLink, "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 
 	// Not found for non-existing budget
 	recorder = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/budgets/059cdead-249f-4f94-8d29-16a80c6b4a09/2032-03/allocations", "")
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestSetAllocationsMonthBudgeted() {
@@ -563,19 +563,19 @@ func (suite *TestSuiteStandard) TestSetAllocationsMonthBudgeted() {
 
 	// Update in budgeted mode allocations
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, strings.Replace(budget.Data.Links.MonthAllocations, "YYYY-MM", "2022-02", 1), controllers.BudgetAllocationMode{Mode: controllers.AllocateLastMonthBudget})
-	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
 
 	// Verify the allocation for the first envelope
 	requestString := strings.Replace(envelope1.Data.Links.Month, "YYYY-MM", "2022-02", 1)
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, requestString, "")
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 	var envelope1Month controllers.EnvelopeMonthResponse
 	suite.decodeResponse(&recorder, &envelope1Month)
 	suite.Assert().True(allocation1.Data.Amount.Equal(envelope1Month.Data.Allocation), "Expected: %s, got %s, Request ID: %s", allocation1.Data.Amount, envelope1Month.Data.Allocation, recorder.Header().Get("x-request-id"))
 
 	// Verify the allocation for the second envelope
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(envelope2.Data.Links.Month, "YYYY-MM", "2022-02", 1), "")
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 	var envelope2Month controllers.EnvelopeMonthResponse
 	suite.decodeResponse(&recorder, &envelope2Month)
 	suite.Assert().True(allocation2.Data.Amount.Equal(envelope2Month.Data.Allocation), "Expected: %s, got %s, Request ID: %s", allocation2.Data.Amount, envelope2Month.Data.Allocation, recorder.Header().Get("x-request-id"))
@@ -613,19 +613,19 @@ func (suite *TestSuiteStandard) TestSetAllocationsMonthSpend() {
 
 	// Update in budgeted mode allocations
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, strings.Replace(budget.Data.Links.MonthAllocations, "YYYY-MM", "2022-02", 1), controllers.BudgetAllocationMode{Mode: controllers.AllocateLastMonthSpend})
-	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
 
 	// Verify the allocation for the first envelope
 	requestString := strings.Replace(envelope1.Data.Links.Month, "YYYY-MM", "2022-02", 1)
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, requestString, "")
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 	var envelope1Month controllers.EnvelopeMonthResponse
 	suite.decodeResponse(&recorder, &envelope1Month)
 	suite.Assert().True(transaction1.Data.Amount.Equal(envelope1Month.Data.Allocation), "Expected: %s, got %s, Request ID: %s", transaction1.Data.Amount, envelope1Month.Data.Allocation, recorder.Header().Get("x-request-id"))
 
 	// Verify the allocation for the second envelope
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(envelope2.Data.Links.Month, "YYYY-MM", "2022-02", 1), "")
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 	var envelope2Month controllers.EnvelopeMonthResponse
 	suite.decodeResponse(&recorder, &envelope2Month)
 	suite.Assert().True(envelope2Month.Data.Allocation.Equal(decimal.NewFromFloat(0)), "Expected: 0, got %s, Request ID: %s", envelope2Month.Data.Allocation, recorder.Header().Get("x-request-id"))
@@ -636,23 +636,23 @@ func (suite *TestSuiteStandard) TestSetAllocationsMonthFailures() {
 
 	// Bad Request for invalid UUID
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets/nouuid/2022-01/allocations", "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 
 	// Bad Request for invalid months
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, budgetAllocationsLink, "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 
 	// Not found for non-existing budget
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/budgets/059cdead-249f-4f94-8d29-16a80c6b4a09/2032-03/allocations", "")
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 
 	// Bad Request for invalid json in body
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, strings.Replace(budgetAllocationsLink, "YYYY-MM", "2022-01", 1), `{ "mode": INVALID_JSON" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 
 	// Bad Request for invalid mode
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, strings.Replace(budgetAllocationsLink, "YYYY-MM", "2022-01", 1), `{ "mode": "UNKNOWN_MODE" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 // TestBudgetBalanceDoubleRegression verifies that the Budget balance is only added once.

--- a/pkg/controllers/category_test.go
+++ b/pkg/controllers/category_test.go
@@ -28,7 +28,7 @@ func (suite *TestSuiteStandard) createTestCategory(c models.CategoryCreate, expe
 	}
 
 	r := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/categories", c)
-	suite.assertHTTPStatus(&r, expectedStatus...)
+	assertHTTPStatus(suite.T(), &r, expectedStatus...)
 
 	var category controllers.CategoryResponse
 	suite.decodeResponse(&r, &category)
@@ -40,7 +40,7 @@ func (suite *TestSuiteStandard) TestCategories() {
 	suite.CloseDB()
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/categories", "")
-	suite.assertHTTPStatus(&recorder, http.StatusInternalServerError)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusInternalServerError)
 	assert.Contains(suite.T(), test.DecodeError(suite.T(), recorder.Body.Bytes()), "There is a problem with the database connection")
 }
 
@@ -112,7 +112,7 @@ func (suite *TestSuiteStandard) TestGetCategoriesInvalidQuery() {
 	for _, tt := range tests {
 		suite.T().Run(tt, func(t *testing.T) {
 			recorder := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("http://example.com/v1/categories?%s", tt), "")
-			suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+			assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 		})
 	}
 }
@@ -164,7 +164,7 @@ func (suite *TestSuiteStandard) TestGetCategoriesFilter() {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			var re controllers.CategoryListResponse
 			r := test.Request(suite.controller, t, http.MethodGet, fmt.Sprintf("/v1/categories?%s", tt.query), "")
-			suite.assertHTTPStatus(&r, http.StatusOK)
+			assertHTTPStatus(suite.T(), &r, http.StatusOK)
 			suite.decodeResponse(&r, &re)
 
 			assert.Equal(t, tt.len, len(re.Data), "Request ID: %s", r.Result().Header.Get("x-request-id"))
@@ -176,13 +176,13 @@ func (suite *TestSuiteStandard) TestGetCategory() {
 	category := suite.createTestCategory(models.CategoryCreate{Name: "Catch me if you can!"})
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, category.Data.Links.Self, "")
 
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 }
 
 func (suite *TestSuiteStandard) TestNoCategoryNotFound() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/categories/4e743e94-6a4b-44d6-aba5-d77c87103ff7", "")
 
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestCategoryInvalidIDs() {
@@ -190,31 +190,31 @@ func (suite *TestSuiteStandard) TestCategoryInvalidIDs() {
 	 *  GET
 	 */
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/categories/-56", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/categories/notANumber", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/categories/23", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	/*
 	 * PATCH
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/categories/-274", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/categories/stringRandom", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	/*
 	 * DELETE
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/categories/-274", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/categories/stringRandom", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateCategory() {
@@ -223,17 +223,17 @@ func (suite *TestSuiteStandard) TestCreateCategory() {
 
 func (suite *TestSuiteStandard) TestCreateBrokenCategory() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/categories", `{ "createdAt": "New Category", "note": "More tests for categories to ensure less brokenness something" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateBudgetDoesNotExist() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/categories", `{ "budgetId": "f8c74664-9b79-4e15-8d3d-4618f3e3c230" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestCreateCategoryNoBody() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/categories", "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateCategoryDuplicateName() {
@@ -245,7 +245,7 @@ func (suite *TestSuiteStandard) TestCreateCategoryDuplicateName() {
 		BudgetID: c.Data.BudgetID,
 		Name:     c.Data.Name,
 	})
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateCategory() {
@@ -255,7 +255,7 @@ func (suite *TestSuiteStandard) TestUpdateCategory() {
 		"name": "Updated new category for testing",
 		"note": "",
 	})
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 
 	var updatedCategory controllers.CategoryResponse
 	suite.decodeResponse(&recorder, &updatedCategory)
@@ -268,7 +268,7 @@ func (suite *TestSuiteStandard) TestUpdateCategoryBrokenJSON() {
 	category := suite.createTestCategory(models.CategoryCreate{Name: "New category", Note: "Mor(r)e tests"})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, category.Data.Links.Self, `{ "name": 2" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateCategoryInvalidType() {
@@ -277,7 +277,7 @@ func (suite *TestSuiteStandard) TestUpdateCategoryInvalidType() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, category.Data.Links.Self, map[string]any{
 		"name": 2,
 	})
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateCategoryInvalidBudgetID() {
@@ -285,29 +285,29 @@ func (suite *TestSuiteStandard) TestUpdateCategoryInvalidBudgetID() {
 
 	// Sets the BudgetID to uuid.Nil
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, category.Data.Links.Self, models.CategoryCreate{})
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateNonExistingCategory() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/categories/f9288848-517e-4b8c-9f14-b3d849ca275b", `{ "name": "2" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteCategory() {
 	category := suite.createTestCategory(models.CategoryCreate{Name: "Delete me now!"})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, category.Data.Links.Self, "")
-	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
 }
 
 func (suite *TestSuiteStandard) TestDeleteNonExistingCategory() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/categories/a2aa0569-5ac5-42e1-8563-7c61194cc7d9", "")
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteCategoryWithBody() {
 	category := suite.createTestCategory(models.CategoryCreate{Name: "Delete me now!"})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, category.Data.Links.Self, `{ "name": "test name 23" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
 }

--- a/pkg/controllers/cleanup_test.go
+++ b/pkg/controllers/cleanup_test.go
@@ -33,13 +33,13 @@ func (suite *TestSuiteStandard) TestCleanup() {
 
 	// Delete
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1", "")
-	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
 
 	// Verify
 	for _, tt := range tests {
 		suite.T().Run(tt, func(t *testing.T) {
 			recorder := test.Request(suite.controller, suite.T(), http.MethodGet, tt, "")
-			suite.assertHTTPStatus(&recorder, http.StatusOK)
+			assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 
 			var response struct {
 				Data []any `json:"data"`

--- a/pkg/controllers/envelope_test.go
+++ b/pkg/controllers/envelope_test.go
@@ -30,7 +30,7 @@ func (suite *TestSuiteStandard) createTestEnvelope(c models.EnvelopeCreate, expe
 	}
 
 	r := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/envelopes", c)
-	suite.assertHTTPStatus(&r, expectedStatus...)
+	assertHTTPStatus(suite.T(), &r, expectedStatus...)
 
 	var e controllers.EnvelopeResponse
 	suite.decodeResponse(&r, &e)
@@ -42,7 +42,7 @@ func (suite *TestSuiteStandard) TestEnvelopes() {
 	suite.CloseDB()
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/envelopes", "")
-	suite.assertHTTPStatus(&recorder, http.StatusInternalServerError)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusInternalServerError)
 	assert.Contains(suite.T(), test.DecodeError(suite.T(), recorder.Body.Bytes()), "There is a problem with the database connection")
 }
 
@@ -85,7 +85,7 @@ func (suite *TestSuiteStandard) TestGetEnvelopesInvalidQuery() {
 	for _, tt := range tests {
 		suite.T().Run(tt, func(t *testing.T) {
 			recorder := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("http://example.com/v1/envelopes?%s", tt), "")
-			suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+			assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 		})
 	}
 }
@@ -136,7 +136,7 @@ func (suite *TestSuiteStandard) TestGetEnvelopesFilter() {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			var re controllers.EnvelopeListResponse
 			r := test.Request(suite.controller, t, http.MethodGet, fmt.Sprintf("/v1/envelopes?%s", tt.query), "")
-			suite.assertHTTPStatus(&r, http.StatusOK)
+			assertHTTPStatus(suite.T(), &r, http.StatusOK)
 			suite.decodeResponse(&r, &re)
 
 			assert.Equal(t, tt.len, len(re.Data), "Request ID: %s", r.Result().Header.Get("x-request-id"))
@@ -148,13 +148,13 @@ func (suite *TestSuiteStandard) TestGetEnvelope() {
 	envelope := suite.createTestEnvelope(models.EnvelopeCreate{})
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, envelope.Data.Links.Self, "")
 
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 }
 
 func (suite *TestSuiteStandard) TestNoEnvelopeNotFound() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/envelopes/828f2483-dabd-4267-a223-e34b5f171978", "")
 
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestEnvelopeInvalidIDs() {
@@ -162,34 +162,34 @@ func (suite *TestSuiteStandard) TestEnvelopeInvalidIDs() {
 	 *  GET
 	 */
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/envelopes/-56", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/envelopes/notANumber", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/envelopes/23", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/envelopes/d19a622f-broken-uuid/2017-09", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	/*
 	 * PATCH
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/envelopes/-274", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/envelopes/stringRandom", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	/*
 	 * DELETE
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/envelopes/-274", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/envelopes/stringRandom", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateEnvelope() {
@@ -198,22 +198,22 @@ func (suite *TestSuiteStandard) TestCreateEnvelope() {
 
 func (suite *TestSuiteStandard) TestCreateEnvelopeNoCategory() {
 	r := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/envelopes", models.Envelope{})
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateBrokenEnvelope() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/envelopes", `{ "createdAt": "New Envelope", "note": "More tests for envelopes to ensure less brokenness something" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateEnvelopeNonExistingCategory() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/envelopes", `{ "categoryId": "5f0cd7b9-9788-4871-96f8-c816c9ae338a" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestCreateEnvelopeNoBody() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/envelopes", "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateEnvelopeDuplicateName() {
@@ -225,7 +225,7 @@ func (suite *TestSuiteStandard) TestCreateEnvelopeDuplicateName() {
 		CategoryID: e.Data.CategoryID,
 		Name:       e.Data.Name,
 	})
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 // TestEnvelopeMonth verifies that the monthly calculations are correct.
@@ -355,7 +355,7 @@ func (suite *TestSuiteStandard) TestEnvelopeMonth() {
 	var envelopeMonth controllers.EnvelopeMonthResponse
 	for _, tt := range tests {
 		r := test.Request(suite.controller, suite.T(), http.MethodGet, tt.path, "")
-		suite.assertHTTPStatus(&r, http.StatusOK)
+		assertHTTPStatus(suite.T(), &r, http.StatusOK)
 
 		suite.decodeResponse(&r, &envelopeMonth)
 		assert.Equal(suite.T(), tt.envelopeMonth.Name, envelopeMonth.Data.Name)
@@ -371,19 +371,19 @@ func (suite *TestSuiteStandard) TestEnvelopeMonthInvalid() {
 
 	// Test that non-parseable requests produce an error
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("%s/Stonks!", envelope.Data.Links.Self), "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestEnvelopeMonthNoEnvelope() {
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, "https://example.com/v1/envelopes/510ffa95-e445-43cc-8abc-da8e2c20ea5c/2022-04", "")
-	suite.assertHTTPStatus(&r, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &r, http.StatusNotFound)
 }
 
 // TestEnvelopeMonthZero tests that we return a HTTP Bad Request when requesting data for the zero timestamp.
 func (suite *TestSuiteStandard) TestEnvelopeMonthZero() {
 	e := suite.createTestEnvelope(models.EnvelopeCreate{})
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("%s/0001-01", e.Data.Links.Self), "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateEnvelope() {
@@ -393,7 +393,7 @@ func (suite *TestSuiteStandard) TestUpdateEnvelope() {
 		"name": "Updated new envelope for testing",
 		"note": "",
 	})
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 
 	var updatedEnvelope controllers.EnvelopeResponse
 	suite.decodeResponse(&recorder, &updatedEnvelope)
@@ -405,7 +405,7 @@ func (suite *TestSuiteStandard) TestUpdateEnvelope() {
 func (suite *TestSuiteStandard) TestUpdateEnvelopeBrokenJSON() {
 	envelope := suite.createTestEnvelope(models.EnvelopeCreate{Name: "New envelope", Note: "Keks is a cuddly cat"})
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, envelope.Data.Links.Self, `{ "name": 2" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateEnvelopeInvalidType() {
@@ -413,7 +413,7 @@ func (suite *TestSuiteStandard) TestUpdateEnvelopeInvalidType() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, envelope.Data.Links.Self, map[string]any{
 		"name": 2,
 	})
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateEnvelopeInvalidCategoryID() {
@@ -421,27 +421,27 @@ func (suite *TestSuiteStandard) TestUpdateEnvelopeInvalidCategoryID() {
 
 	// Sets the CategoryID to uuid.Nil
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, envelope.Data.Links.Self, models.EnvelopeCreate{})
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateNonExistingEnvelope() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/envelopes/dcf472ba-a64e-4f0f-900e-a789319e432c", `{ "name": "2" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteEnvelope() {
 	e := suite.createTestEnvelope(models.EnvelopeCreate{Name: "Delete me!"})
 	r := test.Request(suite.controller, suite.T(), http.MethodDelete, e.Data.Links.Self, "")
-	suite.assertHTTPStatus(&r, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &r, http.StatusNoContent)
 }
 
 func (suite *TestSuiteStandard) TestDeleteNonExistingEnvelope() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/envelopes/21a300da-d8b4-478d-8e85-95cb7982cbca", "")
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteEnvelopeWithBody() {
 	envelope := suite.createTestEnvelope(models.EnvelopeCreate{Name: "Delete this envelope"})
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, envelope.Data.Links.Self, `{ "name": "test name 23" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
 }

--- a/pkg/controllers/month_config_test.go
+++ b/pkg/controllers/month_config_test.go
@@ -26,7 +26,7 @@ func (suite *TestSuiteStandard) createTestMonthConfig(envelopeID uuid.UUID, mont
 
 	path := fmt.Sprintf("http://example.com/v1/month-configs/%s/%s", envelopeID, month.String())
 	r := test.Request(suite.controller, suite.T(), http.MethodPost, path, c)
-	suite.assertHTTPStatus(&r, expectedStatus...)
+	assertHTTPStatus(suite.T(), &r, expectedStatus...)
 
 	var mc controllers.MonthConfigResponse
 	suite.decodeResponse(&r, &mc)
@@ -266,7 +266,7 @@ func (suite *TestSuiteStandard) TestUpdateMonthConfig() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, mConfig.Data.Links.Self, models.MonthConfigCreate{
 		OverspendMode: "AFFECT_ENVELOPE",
 	})
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 
 	var updatedMonthConfig controllers.MonthConfigResponse
 	suite.decodeResponse(&recorder, &updatedMonthConfig)
@@ -308,5 +308,5 @@ func (suite *TestSuiteStandard) TestUpdateMonthConfigBrokenJSON() {
 	mConfig := suite.createTestMonthConfig(uuid.Nil, types.NewMonth(time.Now().Year(), time.Now().Month()), models.MonthConfigCreate{})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, mConfig.Data.Links.Self, `{ test`)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }

--- a/pkg/controllers/month_test.go
+++ b/pkg/controllers/month_test.go
@@ -23,7 +23,7 @@ func (suite *TestSuiteStandard) TestMonth() {
 	budget := suite.createTestBudget(models.BudgetCreate{})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-01", -1), "")
-	suite.assertHTTPStatus(&r, http.StatusOK)
+	assertHTTPStatus(suite.T(), &r, http.StatusOK)
 }
 
 // TestEnvelopeNoAllocationLink verifies that for an Envelope with no allocation for a specific month,
@@ -36,7 +36,7 @@ func (suite *TestSuiteStandard) TestEnvelopeNoAllocationLink() {
 	_ = suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.Data.ID})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-01", 1), "")
-	suite.assertHTTPStatus(&r, http.StatusOK)
+	assertHTTPStatus(suite.T(), &r, http.StatusOK)
 	suite.decodeResponse(&r, &month)
 	suite.Assert().NotEmpty(month.Data.Categories[0].Envelopes)
 	suite.Assert().Equal("https://example.com/v1/allocations", month.Data.Categories[0].Envelopes[0].Links.Allocation)
@@ -51,7 +51,7 @@ func (suite *TestSuiteStandard) TestEnvelopeAllocationLink() {
 	allocation := suite.createTestAllocation(models.AllocationCreate{Amount: decimal.New(1, 1), EnvelopeID: envelope.Data.ID, Month: types.NewMonth(2022, 1)})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-01", 1), "")
-	suite.assertHTTPStatus(&r, http.StatusOK)
+	assertHTTPStatus(suite.T(), &r, http.StatusOK)
 	suite.decodeResponse(&r, &month)
 	suite.Assert().NotEmpty(month.Data.Categories[0].Envelopes)
 	suite.Assert().Equal(allocation.Data.Links.Self, month.Data.Categories[0].Envelopes[0].Links.Allocation)
@@ -64,7 +64,7 @@ func (suite *TestSuiteStandard) TestMonthNotNil() {
 	budget := suite.createTestBudget(models.BudgetCreate{})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-01", 1), "")
-	suite.assertHTTPStatus(&r, http.StatusOK)
+	assertHTTPStatus(suite.T(), &r, http.StatusOK)
 	suite.decodeResponse(&r, &month)
 	if !suite.Assert().NotNil(month.Data.Categories) {
 		suite.Assert().FailNow("Categories field is nil, cannot continue")
@@ -75,7 +75,7 @@ func (suite *TestSuiteStandard) TestMonthNotNil() {
 	_ = suite.createTestCategory(models.CategoryCreate{BudgetID: budget.Data.ID})
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-01", 1), "")
-	suite.assertHTTPStatus(&r, http.StatusOK)
+	assertHTTPStatus(suite.T(), &r, http.StatusOK)
 	suite.decodeResponse(&r, &month)
 	suite.Assert().NotNil(month.Data.Categories[0].Envelopes)
 	suite.Assert().Empty(month.Data.Categories[0].Envelopes)
@@ -83,18 +83,18 @@ func (suite *TestSuiteStandard) TestMonthNotNil() {
 
 func (suite *TestSuiteStandard) TestMonthInvalidRequest() {
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/months?month=-56", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/months?budget=noUUID", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	budget := suite.createTestBudget(models.BudgetCreate{})
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "0001-01", 1), "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 	suite.Assert().Equal("The month query parameter must be set", test.DecodeError(suite.T(), r.Body.Bytes()))
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/months?budget=6a463cc8-1938-474a-8aeb-0482b82ffb6f&month=2000-12", "")
-	suite.assertHTTPStatus(&r, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &r, http.StatusNotFound)
 	suite.Assert().Equal("No budget found for the specified ID", test.DecodeError(suite.T(), r.Body.Bytes()))
 }
 
@@ -104,7 +104,7 @@ func (suite *TestSuiteStandard) TestMonthDBFail() {
 	suite.CloseDB()
 
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.GroupedMonth, "YYYY-MM", "2022-01", 1), "")
-	suite.assertHTTPStatus(&r, http.StatusInternalServerError)
+	assertHTTPStatus(suite.T(), &r, http.StatusInternalServerError)
 }
 
 func (suite *TestSuiteStandard) TestDeleteMonth() {
@@ -127,14 +127,14 @@ func (suite *TestSuiteStandard) TestDeleteMonth() {
 
 	// Clear allocations
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, strings.Replace(budget.Data.Links.MonthAllocations, "YYYY-MM", "2022-01", 1), "")
-	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
 
 	// Verify that allocations are deleted
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, allocation1.Data.Links.Self, "")
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, allocation2.Data.Links.Self, "")
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteMonthFailures() {
@@ -142,15 +142,15 @@ func (suite *TestSuiteStandard) TestDeleteMonthFailures() {
 
 	// Bad Request for invalid UUID
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/months?budget=nouuid&month=2022-01", "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 
 	// Bad Request for invalid months
 	recorder = test.Request(suite.controller, suite.T(), http.MethodDelete, budgetAllocationsLink, "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 
 	// Not found for non-existing budget
 	recorder = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/months?budget=059cdead-249f-4f94-8d29-16a80c6b4a09&month=2032-03", "")
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestSetMonthBudgeted() {
@@ -173,19 +173,19 @@ func (suite *TestSuiteStandard) TestSetMonthBudgeted() {
 
 	// Update in budgeted mode allocations
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, strings.Replace(budget.Data.Links.MonthAllocations, "YYYY-MM", "2022-02", 1), controllers.BudgetAllocationMode{Mode: controllers.AllocateLastMonthBudget})
-	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
 
 	// Verify the allocation for the first envelope
 	requestString := strings.Replace(envelope1.Data.Links.Month, "YYYY-MM", "2022-02", 1)
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, requestString, "")
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 	var envelope1Month controllers.EnvelopeMonthResponse
 	suite.decodeResponse(&recorder, &envelope1Month)
 	suite.Assert().True(allocation1.Data.Amount.Equal(envelope1Month.Data.Allocation), "Expected: %s, got %s, Request ID: %s", allocation1.Data.Amount, envelope1Month.Data.Allocation, recorder.Header().Get("x-request-id"))
 
 	// Verify the allocation for the second envelope
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(envelope2.Data.Links.Month, "YYYY-MM", "2022-02", 1), "")
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 	var envelope2Month controllers.EnvelopeMonthResponse
 	suite.decodeResponse(&recorder, &envelope2Month)
 	suite.Assert().True(allocation2.Data.Amount.Equal(envelope2Month.Data.Allocation), "Expected: %s, got %s, Request ID: %s", allocation2.Data.Amount, envelope2Month.Data.Allocation, recorder.Header().Get("x-request-id"))
@@ -223,19 +223,19 @@ func (suite *TestSuiteStandard) TestSetMonthSpend() {
 
 	// Update in budgeted mode allocations
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, strings.Replace(budget.Data.Links.MonthAllocations, "YYYY-MM", "2022-02", 1), controllers.BudgetAllocationMode{Mode: controllers.AllocateLastMonthSpend})
-	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
 
 	// Verify the allocation for the first envelope
 	requestString := strings.Replace(envelope1.Data.Links.Month, "YYYY-MM", "2022-02", 1)
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, requestString, "")
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 	var envelope1Month controllers.EnvelopeMonthResponse
 	suite.decodeResponse(&recorder, &envelope1Month)
 	suite.Assert().True(transaction1.Data.Amount.Equal(envelope1Month.Data.Allocation), "Expected: %s, got %s, Request ID: %s", transaction1.Data.Amount, envelope1Month.Data.Allocation, recorder.Header().Get("x-request-id"))
 
 	// Verify the allocation for the second envelope
 	recorder = test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(envelope2.Data.Links.Month, "YYYY-MM", "2022-02", 1), "")
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 	var envelope2Month controllers.EnvelopeMonthResponse
 	suite.decodeResponse(&recorder, &envelope2Month)
 	suite.Assert().True(envelope2Month.Data.Allocation.Equal(decimal.NewFromFloat(0)), "Expected: 0, got %s, Request ID: %s", envelope2Month.Data.Allocation, recorder.Header().Get("x-request-id"))
@@ -246,21 +246,21 @@ func (suite *TestSuiteStandard) TestSetMonthFailures() {
 
 	// Bad Request for invalid UUID
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/months?budget=nouuid&month=2022-01", "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 
 	// Bad Request for invalid months
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, budgetAllocationsLink, "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 
 	// Not found for non-existing budget
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/months?budget=059cdead-249f-4f94-8d29-16a80c6b4a09&month=2032-03", "")
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 
 	// Bad Request for invalid json in body
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, strings.Replace(budgetAllocationsLink, "YYYY-MM", "2022-01", 1), `{ "mode": INVALID_JSON" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 
 	// Bad Request for invalid mode
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPost, strings.Replace(budgetAllocationsLink, "YYYY-MM", "2022-01", 1), `{ "mode": "UNKNOWN_MODE" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }

--- a/pkg/controllers/test_helpers_test.go
+++ b/pkg/controllers/test_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http/httptest"
 	"reflect"
+	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -16,8 +17,8 @@ import (
 // This is in nanoseconds, so we multiply by 1000000000 for seconds.
 const tolerance time.Duration = 1000000000 * 60
 
-func (suite *TestSuiteStandard) assertHTTPStatus(r *httptest.ResponseRecorder, expectedStatus ...int) {
-	assert.Contains(suite.T(), expectedStatus, r.Code, "HTTP status is wrong. Request ID: '%s' Response body: %s", r.Result().Header.Get("x-request-id"), r.Body.String())
+func assertHTTPStatus(t *testing.T, r *httptest.ResponseRecorder, expectedStatus ...int) {
+	assert.Contains(t, expectedStatus, r.Code, "HTTP status is wrong. Request ID: '%s' Response body: %s", r.Result().Header.Get("x-request-id"), r.Body.String())
 }
 
 // decodeResponse decodes an HTTP response into a target struct.

--- a/pkg/controllers/test_list_test.go
+++ b/pkg/controllers/test_list_test.go
@@ -21,6 +21,6 @@ func (suite *TestSuiteStandard) TestMethodNotAllowed() {
 	for _, tt := range methodNotAllowedTests {
 		recorder := test.Request(suite.controller, suite.T(), tt.method, tt.path, "")
 
-		suite.assertHTTPStatus(&recorder, http.StatusMethodNotAllowed)
+		assertHTTPStatus(suite.T(), &recorder, http.StatusMethodNotAllowed)
 	}
 }

--- a/pkg/controllers/transaction_test.go
+++ b/pkg/controllers/transaction_test.go
@@ -37,7 +37,7 @@ func (suite *TestSuiteStandard) createTestTransaction(c models.TransactionCreate
 	}
 
 	r := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/transactions", c)
-	suite.assertHTTPStatus(&r, expectedStatus...)
+	assertHTTPStatus(suite.T(), &r, expectedStatus...)
 
 	var tr controllers.TransactionResponse
 	suite.decodeResponse(&r, &tr)
@@ -49,7 +49,7 @@ func (suite *TestSuiteStandard) TestTransactions() {
 	suite.CloseDB()
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/transactions", "")
-	suite.assertHTTPStatus(&recorder, http.StatusInternalServerError)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusInternalServerError)
 	assert.Contains(suite.T(), test.DecodeError(suite.T(), recorder.Body.Bytes()), "There is a problem with the database connection")
 }
 
@@ -94,7 +94,7 @@ func (suite *TestSuiteStandard) TestGetTransactionsInvalidQuery() {
 	for _, tt := range tests {
 		suite.T().Run(tt, func(t *testing.T) {
 			recorder := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("http://example.com/v1/transactions?%s", tt), "")
-			suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+			assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 		})
 	}
 }
@@ -197,7 +197,7 @@ func (suite *TestSuiteStandard) TestGetTransactionsFilter() {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			var re controllers.TransactionListResponse
 			r := test.Request(suite.controller, t, http.MethodGet, fmt.Sprintf("/v1/transactions?%s", tt.query), "")
-			suite.assertHTTPStatus(&r, http.StatusOK)
+			assertHTTPStatus(suite.T(), &r, http.StatusOK)
 			suite.decodeResponse(&r, &re)
 
 			assert.Equal(t, tt.len, len(re.Data), "Request ID: %s", r.Result().Header.Get("x-request-id"))
@@ -208,7 +208,7 @@ func (suite *TestSuiteStandard) TestGetTransactionsFilter() {
 func (suite *TestSuiteStandard) TestNoTransactionNotFound() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/transactions/048b061f-3b6b-45ab-b0e9-0f38d2fff0c8", "")
 
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestTransactionInvalidIDs() {
@@ -216,31 +216,31 @@ func (suite *TestSuiteStandard) TestTransactionInvalidIDs() {
 	 *  GET
 	 */
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/transactions/-56", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/transactions/notANumber", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/transactions/23", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	/*
 	 * PATCH
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/transactions/-274", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/transactions/stringRandom", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	/*
 	 * DELETE
 	 */
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/transactions/-274", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	r = test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/transactions/stringRandom", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateTransaction() {
@@ -255,7 +255,7 @@ func (suite *TestSuiteStandard) TestTransactionSorting() {
 	tJanuary := suite.createTestTransaction(models.TransactionCreate{Note: "Should be third in the list", Amount: decimal.NewFromFloat(1253.17), Date: time.Date(2022, 1, 15, 0, 0, 0, 0, time.UTC)})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/transactions", "")
-	suite.assertHTTPStatus(&r, http.StatusOK)
+	assertHTTPStatus(suite.T(), &r, http.StatusOK)
 
 	var transactions controllers.TransactionListResponse
 	suite.decodeResponse(&r, &transactions)
@@ -282,7 +282,7 @@ func (suite *TestSuiteStandard) TestCreateTransactionMissingReference() {
 			EnvelopeID:           &envelope.Data.ID,
 		},
 	})
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	// Missing Envelope
 	r = test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/transactions", models.Transaction{
@@ -292,7 +292,7 @@ func (suite *TestSuiteStandard) TestCreateTransactionMissingReference() {
 			DestinationAccountID: account.Data.ID,
 		},
 	})
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	// Missing Source Account
 	r = test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/transactions", models.Transaction{
@@ -302,7 +302,7 @@ func (suite *TestSuiteStandard) TestCreateTransactionMissingReference() {
 			EnvelopeID:           &envelope.Data.ID,
 		},
 	})
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	// Missing Destination Account
 	r = test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/transactions", models.Transaction{
@@ -312,17 +312,17 @@ func (suite *TestSuiteStandard) TestCreateTransactionMissingReference() {
 			EnvelopeID:      &envelope.Data.ID,
 		},
 	})
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateTransactionNoAmount() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/transactions", `{ "note": "More tests something something" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateBrokenTransaction() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/transactions", `{ "createdAt": "New Transaction", "note": "More tests for transactions to ensure less brokenness something" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateNegativeAmountTransaction() {
@@ -340,12 +340,12 @@ func (suite *TestSuiteStandard) TestCreateNegativeAmountTransaction() {
 		Note:                 "Negative amounts are not allowed, this must fail",
 	})
 
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateNonExistingBudgetTransaction() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/transactions", `{ "budgetId": "978e95a0-90f2-4dee-91fd-ee708c30301c", "amount": 32.12, "note": "The budget with this id must exist, so this must fail" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestCreateNoEnvelopeTransactionTransfer() {
@@ -357,7 +357,7 @@ func (suite *TestSuiteStandard) TestCreateNoEnvelopeTransactionTransfer() {
 	}
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/transactions", c)
-	suite.assertHTTPStatus(&recorder, http.StatusCreated)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusCreated)
 }
 
 func (suite *TestSuiteStandard) TestCreateNoEnvelopeTransactionOutgoing() {
@@ -369,7 +369,7 @@ func (suite *TestSuiteStandard) TestCreateNoEnvelopeTransactionOutgoing() {
 	}
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/transactions", c)
-	suite.assertHTTPStatus(&recorder, http.StatusCreated)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusCreated)
 }
 
 func (suite *TestSuiteStandard) TestCreateTransferOnBudgetWithEnvelope() {
@@ -383,7 +383,7 @@ func (suite *TestSuiteStandard) TestCreateTransferOnBudgetWithEnvelope() {
 	}
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/transactions", c)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateTransferOnBudgetWithEnvelope() {
@@ -396,14 +396,14 @@ func (suite *TestSuiteStandard) TestUpdateTransferOnBudgetWithEnvelope() {
 	}
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/transactions", c)
-	suite.assertHTTPStatus(&recorder, http.StatusCreated)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusCreated)
 
 	var transaction controllers.TransactionResponse
 	suite.decodeResponse(&recorder, &transaction)
 
 	c.EnvelopeID = &eID
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPatch, transaction.Data.Links.Self, c)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestCreateNonExistingEnvelopeTransactionTransfer() {
@@ -418,12 +418,12 @@ func (suite *TestSuiteStandard) TestCreateNonExistingEnvelopeTransactionTransfer
 	}
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/transactions", c)
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestCreateTransactionNoBody() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/transactions", "")
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestGetTransaction() {
@@ -439,7 +439,7 @@ func (suite *TestSuiteStandard) TestUpdateTransaction() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, transaction.Data.Links.Self, map[string]any{
 		"note": "",
 	})
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 
 	var updatedTransaction controllers.TransactionResponse
 	suite.decodeResponse(&recorder, &updatedTransaction)
@@ -453,14 +453,14 @@ func (suite *TestSuiteStandard) TestUpdateTransactionSourceDestinationEqual() {
 	r := test.Request(suite.controller, suite.T(), http.MethodPatch, transaction.Data.Links.Self, map[string]any{
 		"destinationAccountId": transaction.Data.SourceAccountID,
 	})
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateTransactionBrokenJSON() {
 	transaction := suite.createTestTransaction(models.TransactionCreate{Amount: decimal.NewFromFloat(5883.53)})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, transaction.Data.Links.Self, `{ "amount": 2" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateTransactionInvalidType() {
@@ -469,7 +469,7 @@ func (suite *TestSuiteStandard) TestUpdateTransactionInvalidType() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, transaction.Data.Links.Self, map[string]any{
 		"amount": false,
 	})
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateTransactionInvalidBudgetID() {
@@ -477,24 +477,24 @@ func (suite *TestSuiteStandard) TestUpdateTransactionInvalidBudgetID() {
 
 	// Sets the BudgetID to uuid.Nil
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, transaction.Data.Links.Self, models.TransactionCreate{})
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateTransactionNegativeAmount() {
 	transaction := suite.createTestTransaction(models.TransactionCreate{Amount: decimal.NewFromFloat(382.18)})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, transaction.Data.Links.Self, `{ "amount": -58.23 }`)
-	suite.assertHTTPStatus(&recorder, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestUpdateTransactionEmptySourceDestinationAccount() {
 	transaction := suite.createTestTransaction(models.TransactionCreate{Amount: decimal.NewFromFloat(382.18)})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, transaction.Data.Links.Self, models.TransactionCreate{SourceAccountID: uuid.New()})
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 
 	recorder = test.Request(suite.controller, suite.T(), http.MethodPatch, transaction.Data.Links.Self, models.TransactionCreate{DestinationAccountID: uuid.New()})
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestUpdateNoEnvelopeTransactionOutgoing() {
@@ -511,7 +511,7 @@ func (suite *TestSuiteStandard) TestUpdateNoEnvelopeTransactionOutgoing() {
 	transaction := suite.createTestTransaction(c)
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, transaction.Data.Links.Self, `{ "envelopeId": null }`)
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 }
 
 func (suite *TestSuiteStandard) TestUpdateEnvelopeTransactionOutgoing() {
@@ -527,7 +527,7 @@ func (suite *TestSuiteStandard) TestUpdateEnvelopeTransactionOutgoing() {
 
 	transaction := suite.createTestTransaction(c)
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, transaction.Data.Links.Self, fmt.Sprintf("{ \"envelopeId\": \"%s\" }", &envelope.Data.ID))
-	suite.assertHTTPStatus(&recorder, http.StatusOK)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusOK)
 }
 
 func (suite *TestSuiteStandard) TestUpdateNonExistingEnvelopeTransactionOutgoing() {
@@ -543,35 +543,35 @@ func (suite *TestSuiteStandard) TestUpdateNonExistingEnvelopeTransactionOutgoing
 
 	transaction := suite.createTestTransaction(c)
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, transaction.Data.Links.Self, `{ "envelopeId": "e6fa8eb5-5f2c-4292-8ef9-02f0c2af1ce4" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestUpdateNonExistingTransaction() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v1/transactions/6ae3312c-23cf-4225-9a81-4f218ba41b00", `{ "note": "2" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteTransaction() {
 	transaction := suite.createTestTransaction(models.TransactionCreate{Amount: decimal.NewFromFloat(123.12)})
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, transaction.Data.Links.Self, "")
-	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
 }
 
 func (suite *TestSuiteStandard) TestDeleteNonExistingTransaction() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/transactions/4bcb6d09-ced1-41e8-a3fe-bf4f16c5e501", "")
-	suite.assertHTTPStatus(&recorder, http.StatusNotFound)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestDeleteTransactionWithBody() {
 	transaction := suite.createTestTransaction(models.TransactionCreate{Amount: decimal.NewFromFloat(17.21)})
 	recorder := test.Request(suite.controller, suite.T(), http.MethodDelete, transaction.Data.Links.Self, `{ "amount": "23.91" }`)
-	suite.assertHTTPStatus(&recorder, http.StatusNoContent)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
 }
 
 func (suite *TestSuiteStandard) TestDeleteNullTransaction() {
 	r := test.Request(suite.controller, suite.T(), http.MethodDelete, "http://example.com/v1/transactions/00000000-0000-0000-0000-000000000000", "")
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 }
 
 func (suite *TestSuiteStandard) TestTransactionSourceDestinationExternal() {
@@ -584,7 +584,7 @@ func (suite *TestSuiteStandard) TestTransactionSourceDestinationExternal() {
 			Amount:               decimal.NewFromFloat(12),
 		},
 	})
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	// Check the error
 	err := test.DecodeError(suite.T(), r.Body.Bytes())
@@ -598,7 +598,7 @@ func (suite *TestSuiteStandard) TestTransactionSourceDestinationExternal() {
 		"sourceAccountId":      suite.createTestAccount(models.AccountCreate{External: true}).Data.ID,
 		"destinationAccountId": suite.createTestAccount(models.AccountCreate{External: true}).Data.ID,
 	})
-	suite.assertHTTPStatus(&r, http.StatusBadRequest)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
 
 	// Check the error
 	err = test.DecodeError(suite.T(), r.Body.Bytes())


### PR DESCRIPTION
Move `assertHTTPStatus` to a function so that it does not require the suite.
This is needed for table tests to use the correct `*testing.T` when they are
reporting errors.
