### PR TITLE
refactor: move calculations to gorm hook methods

### DIFF
--- a/pkg/controllers/account_test.go
+++ b/pkg/controllers/account_test.go
@@ -204,23 +204,34 @@ func (suite *TestSuiteStandard) TestCreateAccount() {
 }
 
 func (suite *TestSuiteStandard) TestCreateAccountNoBudget() {
-	r := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/accounts", models.Account{})
-	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
-}
+	tests := []struct {
+		name   string
+		status int
+		create models.AccountCreate
+	}{
+		{
+			"No Budget",
+			http.StatusBadRequest,
+			models.AccountCreate{},
+		},
+		{
+			"Non-existing Budget",
+			http.StatusNotFound,
+			models.AccountCreate{BudgetID: uuid.New()},
+		},
+	}
 
-func (suite *TestSuiteStandard) TestCreateBrokenAccount() {
-	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/accounts", `{ "createdAt": "New Account", "note": "More tests for accounts to ensure less brokenness something" }`)
-	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			r := test.Request(suite.controller, t, http.MethodPost, "http://example.com/v1/accounts", models.Account{AccountCreate: tt.create})
+			assertHTTPStatus(t, &r, tt.status)
+		})
+	}
 }
 
 func (suite *TestSuiteStandard) TestCreateAccountNoBody() {
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/accounts", "")
 	assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
-}
-
-func (suite *TestSuiteStandard) TestCreateAccountNonExistingBudget() {
-	recorder := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v1/accounts", models.AccountCreate{BudgetID: uuid.New()})
-	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
 func (suite *TestSuiteStandard) TestGetAccount() {

--- a/pkg/controllers/budget.go
+++ b/pkg/controllers/budget.go
@@ -629,11 +629,5 @@ func (co Controller) getBudgetResource(c *gin.Context, id uuid.UUID) (models.Bud
 		return models.Budget{}, false
 	}
 
-	budget, err := budget.WithCalculations(co.DB)
-	if err != nil {
-		httperrors.Handler(c, err)
-		return models.Budget{}, false
-	}
-
 	return budget, true
 }

--- a/pkg/controllers/budget_test.go
+++ b/pkg/controllers/budget_test.go
@@ -81,6 +81,30 @@ func (suite *TestSuiteStandard) TestOptionsBudgetMonth() {
 	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
 }
 
+func (suite *TestSuiteStandard) TestGetBudget() {
+	budget := suite.createTestBudget(models.BudgetCreate{})
+
+	tests := []struct {
+		name     string
+		id       uuid.UUID
+		response int
+	}{
+		{"Existing budget", budget.Data.ID, http.StatusOK},
+		{"ID nil", uuid.Nil, http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			recorder := test.Request(suite.controller, t, http.MethodGet, fmt.Sprintf("http://example.com/v1/budgets/%s", tt.id), "")
+
+			var response controllers.BudgetResponse
+			suite.decodeResponse(&recorder, &response)
+
+			assert.Equal(t, tt.response, recorder.Code, "Wrong response code, Request ID: %s, Object: %v", recorder.Result().Header.Get("x-request-id"), response)
+		})
+	}
+}
+
 func (suite *TestSuiteStandard) TestGetBudgets() {
 	_ = suite.createTestBudget(models.BudgetCreate{})
 

--- a/pkg/models/account.go
+++ b/pkg/models/account.go
@@ -37,7 +37,7 @@ type AccountCreate struct {
 }
 
 func (a Account) WithCalculations(db *gorm.DB) (Account, error) {
-	balance, _, err := a.GetBalanceMonth(db, types.NewMonth(1, 1))
+	balance, _, err := a.GetBalanceMonth(db, types.Month{})
 	if err != nil {
 		return Account{}, err
 	}

--- a/pkg/models/budget_test.go
+++ b/pkg/models/budget_test.go
@@ -246,7 +246,8 @@ func (suite *TestSuiteStandard) TestBudgetCalculations() {
 		suite.Assert().Fail("Resource could not be saved", err)
 	}
 
-	budget, err = budget.WithCalculations(suite.db)
+	// Explicitly call AfterFind since we want the calculations to be done
+	err = budget.AfterFind(suite.db)
 	assert.Nil(suite.T(), err)
 
 	shouldBalance := decimal.NewFromFloat(7269.38)


### PR DESCRIPTION
This reduces the length of the method chain that we are calling.
It should not impact performance.
