### PR TITLE
refactor: move getXObject into a generic function

### DIFF
--- a/pkg/controllers/account.go
+++ b/pkg/controllers/account.go
@@ -241,7 +241,7 @@ func (co Controller) UpdateAccount(c *gin.Context) {
 		return
 	}
 
-	account, ok := co.getAccountResource(c, id)
+	account, ok := getResourceByID[models.Account](c, co, id)
 	if !ok {
 		return
 	}
@@ -283,7 +283,8 @@ func (co Controller) DeleteAccount(c *gin.Context) {
 		return
 	}
 
-	account, ok := co.getAccountResource(c, id)
+	account, ok := getResourceByID[models.Account](c, co, id)
+
 	if !ok {
 		return
 	}
@@ -295,28 +296,9 @@ func (co Controller) DeleteAccount(c *gin.Context) {
 	c.JSON(http.StatusNoContent, gin.H{})
 }
 
-// getAccountResource is the internal helper to verify permissions and return an account.
-func (co Controller) getAccountResource(c *gin.Context, id uuid.UUID) (models.Account, bool) {
-	if id == uuid.Nil {
-		httperrors.New(c, http.StatusBadRequest, "no account ID specified")
-		return models.Account{}, false
-	}
-
-	var account models.Account
-
-	if !queryWithRetry(c, co.DB.Where(&models.Account{
-		DefaultModel: models.DefaultModel{
-			ID: id,
-		},
-	}).First(&account), "No account found for the specified ID") {
-		return models.Account{}, false
-	}
-
-	return account, true
-}
-
 func (co Controller) getAccountObject(c *gin.Context, id uuid.UUID) (Account, bool) {
-	account, ok := co.getAccountResource(c, id)
+	account, ok := getResourceByID[models.Account](c, co, id)
+
 	if !ok {
 		return Account{}, false
 	}

--- a/pkg/controllers/account.go
+++ b/pkg/controllers/account.go
@@ -123,7 +123,7 @@ func (co Controller) CreateAccount(c *gin.Context) {
 	}
 
 	// Check if the budget that the account shoud belong to exists
-	_, ok := co.getBudgetResource(c, account.BudgetID)
+	_, ok := getResourceByID[models.Budget](c, co, account.BudgetID)
 	if !ok {
 		return
 	}

--- a/pkg/controllers/allocation.go
+++ b/pkg/controllers/allocation.go
@@ -91,7 +91,7 @@ func (co Controller) OptionsAllocationDetail(c *gin.Context) {
 		return
 	}
 
-	_, ok := co.getAllocationResource(c, id)
+	_, ok := getResourceByID[models.Allocation](c, co, id)
 	if !ok {
 		return
 	}
@@ -196,7 +196,7 @@ func (co Controller) GetAllocation(c *gin.Context) {
 		return
 	}
 
-	allocationObject, ok := co.getAllocationResource(c, id)
+	allocationObject, ok := getResourceByID[models.Allocation](c, co, id)
 	if !ok {
 		return
 	}
@@ -225,7 +225,7 @@ func (co Controller) UpdateAllocation(c *gin.Context) {
 		return
 	}
 
-	allocation, ok := co.getAllocationResource(c, id)
+	allocation, ok := getResourceByID[models.Allocation](c, co, id)
 	if !ok {
 		return
 	}
@@ -265,7 +265,7 @@ func (co Controller) DeleteAllocation(c *gin.Context) {
 		return
 	}
 
-	allocation, ok := co.getAllocationResource(c, id)
+	allocation, ok := getResourceByID[models.Allocation](c, co, id)
 	if !ok {
 		return
 	}
@@ -276,24 +276,4 @@ func (co Controller) DeleteAllocation(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusNoContent, gin.H{})
-}
-
-// getAllocationResource verifies that the request URI is valid for the transaction and returns it.
-func (co Controller) getAllocationResource(c *gin.Context, id uuid.UUID) (models.Allocation, bool) {
-	if id == uuid.Nil {
-		httperrors.New(c, http.StatusBadRequest, "no allocation ID specified")
-		return models.Allocation{}, false
-	}
-
-	var allocation models.Allocation
-
-	if !queryWithRetry(c, co.DB.First(&allocation, &models.Allocation{
-		DefaultModel: models.DefaultModel{
-			ID: id,
-		},
-	}), "No allocation found for the specified ID") {
-		return models.Allocation{}, false
-	}
-
-	return allocation, true
 }

--- a/pkg/controllers/allocation.go
+++ b/pkg/controllers/allocation.go
@@ -118,7 +118,7 @@ func (co Controller) CreateAllocation(c *gin.Context) {
 		return
 	}
 
-	_, ok := co.getEnvelopeResource(c, allocation.EnvelopeID)
+	_, ok := getResourceByID[models.Envelope](c, co, allocation.EnvelopeID)
 	if !ok {
 		return
 	}

--- a/pkg/controllers/category.go
+++ b/pkg/controllers/category.go
@@ -119,7 +119,7 @@ func (co Controller) CreateCategory(c *gin.Context) {
 		return
 	}
 
-	_, ok := co.getBudgetResource(c, category.BudgetID)
+	_, ok := getResourceByID[models.Budget](c, co, category.BudgetID)
 	if !ok {
 		return
 	}

--- a/pkg/controllers/category.go
+++ b/pkg/controllers/category.go
@@ -235,7 +235,7 @@ func (co Controller) UpdateCategory(c *gin.Context) {
 		return
 	}
 
-	category, ok := co.getCategoryResource(c, id)
+	category, ok := getResourceByID[models.Category](c, co, id)
 	if !ok {
 		return
 	}
@@ -276,7 +276,7 @@ func (co Controller) DeleteCategory(c *gin.Context) {
 		return
 	}
 
-	category, ok := co.getCategoryResource(c, id)
+	category, ok := getResourceByID[models.Category](c, co, id)
 	if !ok {
 		return
 	}
@@ -286,25 +286,6 @@ func (co Controller) DeleteCategory(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusNoContent, gin.H{})
-}
-
-func (co Controller) getCategoryResource(c *gin.Context, id uuid.UUID) (models.Category, bool) {
-	if id == uuid.Nil {
-		httperrors.New(c, http.StatusBadRequest, "No category ID specified")
-		return models.Category{}, false
-	}
-
-	var category models.Category
-
-	if !queryWithRetry(c, co.DB.Where(&models.Category{
-		DefaultModel: models.DefaultModel{
-			ID: id,
-		},
-	}).First(&category), "No category found for the specified ID") {
-		return models.Category{}, false
-	}
-
-	return category, true
 }
 
 // getCategoryResources returns all categories for the requested budget.
@@ -323,7 +304,7 @@ func (co Controller) getCategoryResources(c *gin.Context, id uuid.UUID) ([]model
 }
 
 func (co Controller) getCategoryObject(c *gin.Context, id uuid.UUID) (Category, bool) {
-	resource, ok := co.getCategoryResource(c, id)
+	resource, ok := getResourceByID[models.Category](c, co, id)
 	if !ok {
 		return Category{}, false
 	}

--- a/pkg/controllers/envelope.go
+++ b/pkg/controllers/envelope.go
@@ -89,7 +89,7 @@ func (co Controller) OptionsEnvelopeDetail(c *gin.Context) {
 		return
 	}
 
-	_, ok := co.getEnvelopeResource(c, id)
+	_, ok := getResourceByID[models.Envelope](c, co, id)
 	if !ok {
 		return
 	}
@@ -201,7 +201,7 @@ func (co Controller) GetEnvelope(c *gin.Context) {
 		return
 	}
 
-	envelopeObject, ok := co.getEnvelopeResource(c, id)
+	envelopeObject, ok := getResourceByID[models.Envelope](c, co, id)
 	if !ok {
 		return
 	}
@@ -236,7 +236,7 @@ func (co Controller) GetEnvelopeMonth(c *gin.Context) {
 		return
 	}
 
-	envelope, ok := co.getEnvelopeResource(c, id)
+	envelope, ok := getResourceByID[models.Envelope](c, co, id)
 	if !ok {
 		httperrors.Handler(c, err)
 		return
@@ -277,7 +277,7 @@ func (co Controller) UpdateEnvelope(c *gin.Context) {
 		return
 	}
 
-	envelope, ok := co.getEnvelopeResource(c, id)
+	envelope, ok := getResourceByID[models.Envelope](c, co, id)
 	if !ok {
 		return
 	}
@@ -319,7 +319,7 @@ func (co Controller) DeleteEnvelope(c *gin.Context) {
 		return
 	}
 
-	envelope, ok := co.getEnvelopeResource(c, id)
+	envelope, ok := getResourceByID[models.Envelope](c, co, id)
 	if !ok {
 		return
 	}
@@ -329,24 +329,4 @@ func (co Controller) DeleteEnvelope(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusNoContent, gin.H{})
-}
-
-// getEnvelopeResource verifies that the envelope from the URL parameters exists and returns it.
-func (co Controller) getEnvelopeResource(c *gin.Context, id uuid.UUID) (models.Envelope, bool) {
-	if id == uuid.Nil {
-		httperrors.New(c, http.StatusBadRequest, "no envelope ID specified")
-		return models.Envelope{}, false
-	}
-
-	var envelope models.Envelope
-
-	if !queryWithRetry(c, co.DB.Where(&models.Envelope{
-		DefaultModel: models.DefaultModel{
-			ID: id,
-		},
-	}).First(&envelope), "No envelope found for the specified ID") {
-		return models.Envelope{}, false
-	}
-
-	return envelope, true
 }

--- a/pkg/controllers/envelope.go
+++ b/pkg/controllers/envelope.go
@@ -117,7 +117,7 @@ func (co Controller) CreateEnvelope(c *gin.Context) {
 		return
 	}
 
-	_, ok := co.getCategoryResource(c, envelope.CategoryID)
+	_, ok := getResourceByID[models.Category](c, co, envelope.CategoryID)
 	if !ok {
 		return
 	}

--- a/pkg/controllers/generics.go
+++ b/pkg/controllers/generics.go
@@ -1,0 +1,30 @@
+package controllers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/envelope-zero/backend/v2/pkg/httperrors"
+	"github.com/envelope-zero/backend/v2/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// getResourceByID gets a resources of a specified type by its ID.
+//
+// When the ID is not specified (which is equal to an all-zeroes UUID), it returns an HTTP 400.
+// When no resource exists for the specified ID, an HTTP 404 is returned with an appropriate message.
+func getResourceByID[T models.Model](c *gin.Context, co Controller, id uuid.UUID) (resource T, success bool) {
+	if id == uuid.Nil {
+		httperrors.New(c, http.StatusBadRequest, "No %s ID specified", resource.Self())
+		return
+	}
+
+	if !queryWithRetry(c, co.DB.Where(
+		map[string]interface{}{"ID": id},
+	).First(&resource), fmt.Sprintf("No %s found for the specified ID", resource.Self())) {
+		return
+	}
+
+	return resource, true
+}

--- a/pkg/controllers/month.go
+++ b/pkg/controllers/month.go
@@ -42,7 +42,7 @@ func (co Controller) parseMonthQuery(c *gin.Context) (types.Month, models.Budget
 		return types.Month{}, models.Budget{}, false
 	}
 
-	budget, ok := co.getBudgetResource(c, budgetID)
+	budget, ok := getResourceByID[models.Budget](c, co, budgetID)
 	if !ok {
 		return types.Month{}, models.Budget{}, false
 	}

--- a/pkg/controllers/month_config.go
+++ b/pkg/controllers/month_config.go
@@ -124,7 +124,7 @@ func (co Controller) GetMonthConfig(c *gin.Context) {
 		return
 	}
 
-	_, ok := co.getEnvelopeResource(c, envelopeID)
+	_, ok := getResourceByID[models.Envelope](c, co, envelopeID)
 	if !ok {
 		return
 	}
@@ -220,7 +220,7 @@ func (co Controller) CreateMonthConfig(c *gin.Context) {
 	mConfig.EnvelopeID = envelopeID
 	mConfig.Month = types.MonthOf(month.Month)
 
-	_, ok := co.getEnvelopeResource(c, mConfig.EnvelopeID)
+	_, ok := getResourceByID[models.Envelope](c, co, mConfig.EnvelopeID)
 	if !ok {
 		return
 	}
@@ -265,7 +265,7 @@ func (co Controller) UpdateMonthConfig(c *gin.Context) {
 		return
 	}
 
-	_, ok := co.getEnvelopeResource(c, envelopeID)
+	_, ok := getResourceByID[models.Envelope](c, co, envelopeID)
 	if !ok {
 		return
 	}
@@ -317,7 +317,7 @@ func (co Controller) DeleteMonthConfig(c *gin.Context) {
 		return
 	}
 
-	_, ok := co.getEnvelopeResource(c, envelopeID)
+	_, ok := getResourceByID[models.Envelope](c, co, envelopeID)
 	if !ok {
 		return
 	}

--- a/pkg/controllers/month_test.go
+++ b/pkg/controllers/month_test.go
@@ -95,7 +95,7 @@ func (suite *TestSuiteStandard) TestMonthInvalidRequest() {
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v1/months?budget=6a463cc8-1938-474a-8aeb-0482b82ffb6f&month=2000-12", "")
 	assertHTTPStatus(suite.T(), &r, http.StatusNotFound)
-	suite.Assert().Equal("No budget found for the specified ID", test.DecodeError(suite.T(), r.Body.Bytes()))
+	suite.Assert().Equal("No Budget found for the specified ID", test.DecodeError(suite.T(), r.Body.Bytes()))
 }
 
 func (suite *TestSuiteStandard) TestMonthDBFail() {

--- a/pkg/controllers/transaction.go
+++ b/pkg/controllers/transaction.go
@@ -487,8 +487,7 @@ func (co Controller) checkTransaction(c *gin.Context, transaction models.Transac
 			httperrors.New(c, http.StatusBadRequest, "Transfers between two on-budget accounts must not have an envelope set. Such a transaction would be incoming and outgoing for this envelope at the same time, which is not possible")
 			return false
 		}
-
-		_, ok = co.getEnvelopeResource(c, *transaction.EnvelopeID)
+		_, ok = getResourceByID[models.Envelope](c, co, *transaction.EnvelopeID)
 	}
 
 	return

--- a/pkg/controllers/transaction.go
+++ b/pkg/controllers/transaction.go
@@ -161,13 +161,13 @@ func (co Controller) CreateTransaction(c *gin.Context) {
 	}
 
 	// Check the source account
-	sourceAccount, ok := co.getAccountResource(c, transaction.SourceAccountID)
+	sourceAccount, ok := getResourceByID[models.Account](c, co, transaction.SourceAccountID)
 	if !ok {
 		return
 	}
 
 	// Check the destination account
-	destinationAccount, ok := co.getAccountResource(c, transaction.DestinationAccountID)
+	destinationAccount, ok := getResourceByID[models.Account](c, co, transaction.DestinationAccountID)
 	if !ok {
 		return
 	}
@@ -373,7 +373,8 @@ func (co Controller) UpdateTransaction(c *gin.Context) {
 	if data.SourceAccountID != uuid.Nil {
 		sourceAccountID = data.SourceAccountID
 	}
-	sourceAccount, ok := co.getAccountResource(c, sourceAccountID)
+	sourceAccount, ok := getResourceByID[models.Account](c, co, sourceAccountID)
+
 	if !ok {
 		return
 	}
@@ -383,7 +384,8 @@ func (co Controller) UpdateTransaction(c *gin.Context) {
 	if data.DestinationAccountID != uuid.Nil {
 		destinationAccountID = data.DestinationAccountID
 	}
-	destinationAccount, ok := co.getAccountResource(c, destinationAccountID)
+	destinationAccount, ok := getResourceByID[models.Account](c, co, destinationAccountID)
+
 	if !ok {
 		return
 	}

--- a/pkg/controllers/transaction.go
+++ b/pkg/controllers/transaction.go
@@ -347,7 +347,7 @@ func (co Controller) UpdateTransaction(c *gin.Context) {
 		return
 	}
 
-	transaction, ok := co.getTransactionResource(c, id)
+	transaction, ok := getResourceByID[models.Transaction](c, co, id)
 	if !ok {
 		return
 	}
@@ -426,7 +426,7 @@ func (co Controller) DeleteTransaction(c *gin.Context) {
 		return
 	}
 
-	transaction, ok := co.getTransactionResource(c, id)
+	transaction, ok := getResourceByID[models.Transaction](c, co, id)
 	if !ok {
 		return
 	}
@@ -436,26 +436,6 @@ func (co Controller) DeleteTransaction(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusNoContent, gin.H{})
-}
-
-// getTransactionResource verifies that the request URI is valid for the transaction and returns it.
-func (co Controller) getTransactionResource(c *gin.Context, id uuid.UUID) (models.Transaction, bool) {
-	if id == uuid.Nil {
-		httperrors.New(c, http.StatusBadRequest, "no transaction ID specified")
-		return models.Transaction{}, false
-	}
-
-	var transaction models.Transaction
-
-	if !queryWithRetry(c, co.DB.First(&transaction, &models.Transaction{
-		DefaultModel: models.DefaultModel{
-			ID: id,
-		},
-	}), "No transaction found for the specified ID") {
-		return models.Transaction{}, false
-	}
-
-	return transaction, true
 }
 
 // checkTransaction verifies that the transaction is correct

--- a/pkg/controllers/transaction.go
+++ b/pkg/controllers/transaction.go
@@ -155,7 +155,7 @@ func (co Controller) CreateTransaction(c *gin.Context) {
 	}
 
 	// Check if the budget that the transaction shoud belong to exists
-	_, ok := co.getBudgetResource(c, transaction.BudgetID)
+	_, ok := getResourceByID[models.Budget](c, co, transaction.BudgetID)
 	if !ok {
 		return
 	}

--- a/pkg/models/account.go
+++ b/pkg/models/account.go
@@ -36,6 +36,10 @@ type AccountCreate struct {
 	ImportHash         string          `json:"importHash" example:"867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70" default:""` // The SHA256 hash of a unique combination of values to use in duplicate detection
 }
 
+func (a Account) Self() string {
+	return "Account"
+}
+
 func (a Account) WithCalculations(db *gorm.DB) (Account, error) {
 	balance, _, err := a.GetBalanceMonth(db, types.Month{})
 	if err != nil {

--- a/pkg/models/allocation.go
+++ b/pkg/models/allocation.go
@@ -27,6 +27,10 @@ type AllocationCreate struct {
 	EnvelopeID uuid.UUID       `json:"envelopeId" gorm:"uniqueIndex:allocation_month_envelope" example:"a0909e84-e8f9-4cb6-82a5-025dff105ff2"`
 }
 
+func (a Allocation) Self() string {
+	return "Allocation"
+}
+
 // BeforeSave verifies that the amount is non-zero.
 // To remove an allocation, it has to be deleted instead of
 // set to 0.

--- a/pkg/models/budget.go
+++ b/pkg/models/budget.go
@@ -30,6 +30,10 @@ type Budget struct {
 	} `json:"links" gorm:"-"`
 }
 
+func (b Budget) Self() string {
+	return "Budget"
+}
+
 type BudgetCreate struct {
 	Name     string `json:"name" example:"Morre's Budget" default:""`
 	Note     string `json:"note" example:"My personal expenses" default:""`
@@ -44,6 +48,10 @@ type BudgetMonth struct {
 	Income    decimal.Decimal `json:"income" example:"2317.34"`
 	Available decimal.Decimal `json:"available" example:"217.34"`
 	Envelopes []EnvelopeMonth `json:"envelopes"`
+}
+
+func (b BudgetMonth) Self() string {
+	return "BudgetMonth"
 }
 
 func (b *Budget) AfterFind(tx *gorm.DB) (err error) {

--- a/pkg/models/category.go
+++ b/pkg/models/category.go
@@ -26,6 +26,10 @@ type CategoryCreate struct {
 	Hidden   bool      `json:"hidden" example:"true" default:"false"`                                                           // Is the category hidden?
 }
 
+func (c Category) Self() string {
+	return "Category"
+}
+
 func (c *Category) AfterFind(tx *gorm.DB) (err error) {
 	c.links(tx)
 	return

--- a/pkg/models/envelope.go
+++ b/pkg/models/envelope.go
@@ -32,6 +32,10 @@ type EnvelopeCreate struct {
 	Hidden     bool      `json:"hidden" example:"true" default:"false"`                                                               // Is the envelope hidden?
 }
 
+func (e Envelope) Self() string {
+	return "Envelope"
+}
+
 func (e *Envelope) AfterFind(tx *gorm.DB) (err error) {
 	e.links(tx)
 	return

--- a/pkg/models/model.go
+++ b/pkg/models/model.go
@@ -7,6 +7,10 @@ import (
 	"gorm.io/gorm"
 )
 
+type Model interface {
+	Self() string
+}
+
 // DefaultModel is the base model for most models in Envelope Zero.
 // As EnvelopeMonth uses the Envelope ID and the Month as primary key,
 // we the timestamps are managed in the Timestamps struct.

--- a/pkg/models/transaction.go
+++ b/pkg/models/transaction.go
@@ -42,6 +42,10 @@ type TransactionCreate struct {
 	ImportHash string `json:"importHash" example:"867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70" default:""` // The SHA256 hash of a unique combination of values to use in duplicate detection
 }
 
+func (t Transaction) Self() string {
+	return "Transaction"
+}
+
 // AfterFind updates the timestamps to use UTC as
 // timezone, not +0000. Yes, this is different.
 //


### PR DESCRIPTION
This reduces redundant code.

Part of #618.
