### PR TITLE
chore(deps): make renovate use some presets for grouping and package replacement

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,10 @@
 {
+  "extends": [
+    "group:recommended",
+    "replacements:all",
+    "workarounds:all",
+    ":ignoreModulesAndTests"
+  ],
   "dependencyDashboard": true,
   "pre-commit": {
     "enabled": true


### PR DESCRIPTION
This updates the renovate config to make use of useful templates for package grouping and replacements.
