### PR TITLE
fix(importer/ynab-import): fix initial bugs

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3225,13 +3225,13 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
-                "model": {
-                    "$ref": "#/definitions/models.Transaction"
-                },
                 "sourceAccountName": {
                     "description": "Name of the source account if the ID is not known",
                     "type": "string",
                     "example": "Employer"
+                },
+                "transaction": {
+                    "$ref": "#/definitions/models.TransactionCreate"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -3213,13 +3213,13 @@
                         "type": "string"
                     }
                 },
-                "model": {
-                    "$ref": "#/definitions/models.Transaction"
-                },
                 "sourceAccountName": {
                     "description": "Name of the source account if the ID is not known",
                     "type": "string",
                     "example": "Employer"
+                },
+                "transaction": {
+                    "$ref": "#/definitions/models.TransactionCreate"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -258,12 +258,12 @@ definitions:
         items:
           type: string
         type: array
-      model:
-        $ref: '#/definitions/models.Transaction'
       sourceAccountName:
         description: Name of the source account if the ID is not known
         example: Employer
         type: string
+      transaction:
+        $ref: '#/definitions/models.TransactionCreate'
     type: object
   models.AccountCreate:
     properties:

--- a/pkg/controllers/import.go
+++ b/pkg/controllers/import.go
@@ -248,7 +248,7 @@ func duplicateTransactions(co Controller, transactions []importer.TransactionPre
 		var duplicates []models.Transaction
 		co.DB.Find(&duplicates, models.Transaction{
 			TransactionCreate: models.TransactionCreate{
-				ImportHash: transaction.Model.ImportHash,
+				ImportHash: transaction.Transaction.ImportHash,
 			},
 		})
 

--- a/pkg/controllers/import_test.go
+++ b/pkg/controllers/import_test.go
@@ -159,7 +159,7 @@ func (suite *TestSuiteStandard) TestYnabImportPreviewDuplicateDetection() {
 
 	transaction := suite.createTestTransaction(models.TransactionCreate{
 		SourceAccountID: account.Data.ID,
-		ImportHash:      preview.Data[0].Model.ImportHash,
+		ImportHash:      preview.Data[0].Transaction.ImportHash,
 		Amount:          decimal.NewFromFloat(1.13),
 	})
 

--- a/pkg/importer/parser/ynab-import/parse_test.go
+++ b/pkg/importer/parser/ynab-import/parse_test.go
@@ -32,6 +32,10 @@ func TestParse(t *testing.T) {
 			transactions, err := Parse(f, models.Account{})
 			assert.Nil(t, err, "Parsing failed")
 			assert.Len(t, transactions, tt.length, "Wrong number of transactions has been parsed")
+
+			for _, transaction := range transactions {
+				assert.True(t, transaction.Transaction.Amount.IsPositive(), "Transaction amount is not positive: %s", transaction.Transaction.Amount)
+			}
 		})
 	}
 }

--- a/pkg/importer/types.go
+++ b/pkg/importer/types.go
@@ -48,8 +48,8 @@ type Transaction struct {
 
 // TransactionPreview is used to preview transactions that will be imported to allow for editing.
 type TransactionPreview struct {
-	Model                   models.Transaction
-	SourceAccountName       string      `json:"sourceAccountName" example:"Employer"`           // Name of the source account if the ID is not known
-	DestinationAccountName  string      `json:"destinationAccountName" example:"Deutsche Bahn"` // Name of the destination account if the ID is not known
-	DuplicateTransactionIDs []uuid.UUID `json:"duplicateTransactionIds"`                        // IDs of transactions that this transaction duplicates
+	Transaction             models.TransactionCreate `json:"transaction"`
+	SourceAccountName       string                   `json:"sourceAccountName" example:"Employer"`           // Name of the source account if the ID is not known
+	DestinationAccountName  string                   `json:"destinationAccountName" example:"Deutsche Bahn"` // Name of the destination account if the ID is not known
+	DuplicateTransactionIDs []uuid.UUID              `json:"duplicateTransactionIds"`                        // IDs of transactions that this transaction duplicates
 }


### PR DESCRIPTION
This fixes multiple bugs in the YNAB import preview endpoint and parsing.

- return a list of TransactionCreate resources, not Transaction resources
- name the TransactionCreate resource "transaction" in the list
- only use positive amounts
