### PR TITLE
feat(importer/ynab-import): automatically use existing accounts with matching names

### DIFF
--- a/testdata/importer/ynab-import/account-find-test.csv
+++ b/testdata/importer/ynab-import/account-find-test.csv
@@ -1,0 +1,4 @@
+Date,Payee,Memo,Outflow,Inflow
+04/01/2019,Edeka,Test,59.97,
+04/01/2019,Deutsche Bahn,Train ticket,80.00,
+04/25/2019,Some Company,Salary April 2019,,2350


### PR DESCRIPTION
This automatically sets existing accounts when their names match and are unique. Therefore, transaction imports become easier.
