### PR TITLE
docs: remove comment indicating that other database backends are supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ image:
   repository: ghcr.io/envelope-zero/backend
   tag: v0.2.1
 
-# Only set this when you want to use sqlite as database backend.
-# In this case, you need to make sure the database is regularly backed up!
+# All data is stored to a sqlite database in /data.
+# Make sure to persist and backup this directory.
 persistence:
   enabled: true
   mountPath: /data


### PR DESCRIPTION
- The [readme states](https://github.com/envelope-zero/backend/blob/1ecdf9059848322827eb72e6280087dc53520f5a/README.md#L53) `Only set this when you want to use sqlite as database backend.` which sounds like different database backends are possible.
- But the code looks like only sqlite is supported: https://github.com/envelope-zero/backend/blob/1ecdf9059848322827eb72e6280087dc53520f5a/pkg/database/database.go#L30