### PR TITLE
ci: fix copy-paste "needs" error

### DIFF
--- a/.github/workflows/bump-patch.yml
+++ b/.github/workflows/bump-patch.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   tag:
     runs-on: ubuntu-latest
-    needs: test
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout


### PR DESCRIPTION
This removes the `needs` that was erroneously copy-pasted.
