### PR TITLE
refactor: only run update on parent category when archival state changes to unarchived

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 tmp
 gorm.db
+gorm.db-journal
 coverage.out
 /backend
 dist/

--- a/pkg/models/envelope.go
+++ b/pkg/models/envelope.go
@@ -44,7 +44,7 @@ func (e *Envelope) BeforeUpdate(tx *gorm.DB) (err error) {
 	//
 	// This checks for the envelope's ID to not be nil since there is a call during migration
 	// where it is nil. Remove this with v3.0.0 when these migrations are removed, too.
-	if e.ID != uuid.Nil && !e.Hidden {
+	if tx.Statement.Changed("Hidden") && e.ID != uuid.Nil && e.Hidden {
 		var category Category
 		err = tx.First(&category, e.CategoryID).Error
 		if err != nil {

--- a/pkg/models/envelope_test.go
+++ b/pkg/models/envelope_test.go
@@ -284,8 +284,8 @@ func (suite *TestSuiteStandard) TestEnvelopeUnarchiveUnarchivesCategory() {
 	})
 
 	// Unarchive the envelope
-	envelope.Hidden = false
-	suite.db.Save(&envelope)
+	data := models.Envelope{EnvelopeCreate: models.EnvelopeCreate{Hidden: false}}
+	suite.db.Model(&envelope).Select("hidden").Updates(data)
 
 	// Reload the category
 	suite.db.First(&category, category.ID)


### PR DESCRIPTION
This modified the code added with 00ff02f4087d0229bc5e9588bc6e201b7cbcba1f so that
it only runs when the `hidden` field changes to `false`.

This should improve performance for all operations where that is not the case.
