### PR TITLE
feat: add rename rule to transaction preview

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3646,7 +3646,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "destinationAccountName": {
-                    "description": "Name of the destination account if the ID is not known",
+                    "description": "Name of the destination account from the CSV file",
                     "type": "string",
                     "example": "Deutsche Bahn"
                 },
@@ -3657,8 +3657,13 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "renameRuleId": {
+                    "description": "ID of the rename rule that was applied to this transaction preview",
+                    "type": "string",
+                    "example": "042d101d-f1de-4403-9295-59dc0ea58677"
+                },
                 "sourceAccountName": {
-                    "description": "Name of the source account if the ID is not known",
+                    "description": "Name of the source account from the CSV file",
                     "type": "string",
                     "example": "Employer"
                 },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -3634,7 +3634,7 @@
             "type": "object",
             "properties": {
                 "destinationAccountName": {
-                    "description": "Name of the destination account if the ID is not known",
+                    "description": "Name of the destination account from the CSV file",
                     "type": "string",
                     "example": "Deutsche Bahn"
                 },
@@ -3645,8 +3645,13 @@
                         "type": "string"
                     }
                 },
+                "renameRuleId": {
+                    "description": "ID of the rename rule that was applied to this transaction preview",
+                    "type": "string",
+                    "example": "042d101d-f1de-4403-9295-59dc0ea58677"
+                },
                 "sourceAccountName": {
-                    "description": "Name of the source account if the ID is not known",
+                    "description": "Name of the source account from the CSV file",
                     "type": "string",
                     "example": "Employer"
                 },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -284,7 +284,7 @@ definitions:
   importer.TransactionPreview:
     properties:
       destinationAccountName:
-        description: Name of the destination account if the ID is not known
+        description: Name of the destination account from the CSV file
         example: Deutsche Bahn
         type: string
       duplicateTransactionIds:
@@ -292,8 +292,12 @@ definitions:
         items:
           type: string
         type: array
+      renameRuleId:
+        description: ID of the rename rule that was applied to this transaction preview
+        example: 042d101d-f1de-4403-9295-59dc0ea58677
+        type: string
       sourceAccountName:
-        description: Name of the source account if the ID is not known
+        description: Name of the source account from the CSV file
         example: Employer
         type: string
       transaction:

--- a/pkg/importer/types.go
+++ b/pkg/importer/types.go
@@ -49,7 +49,8 @@ type Transaction struct {
 // TransactionPreview is used to preview transactions that will be imported to allow for editing.
 type TransactionPreview struct {
 	Transaction             models.TransactionCreate `json:"transaction"`
-	SourceAccountName       string                   `json:"sourceAccountName" example:"Employer"`           // Name of the source account if the ID is not known
-	DestinationAccountName  string                   `json:"destinationAccountName" example:"Deutsche Bahn"` // Name of the destination account if the ID is not known
-	DuplicateTransactionIDs []uuid.UUID              `json:"duplicateTransactionIds"`                        // IDs of transactions that this transaction duplicates
+	SourceAccountName       string                   `json:"sourceAccountName" example:"Employer"`                        // Name of the source account from the CSV file
+	DestinationAccountName  string                   `json:"destinationAccountName" example:"Deutsche Bahn"`              // Name of the destination account from the CSV file
+	DuplicateTransactionIDs []uuid.UUID              `json:"duplicateTransactionIds"`                                     // IDs of transactions that this transaction duplicates
+	RenameRuleID            uuid.UUID                `json:"renameRuleId" example:"042d101d-f1de-4403-9295-59dc0ea58677"` // ID of the rename rule that was applied to this transaction preview
 }


### PR DESCRIPTION
This adds the ID of the rename rule that mapped a transaction
preview to an account to the transaction preview.
