### PR TITLE
ci: satisfy required semantic-pr check on merge group

### DIFF
--- a/.github/workflows/semantic-pr-merge-group.yml
+++ b/.github/workflows/semantic-pr-merge-group.yml
@@ -1,0 +1,11 @@
+name: "[Skip] Lint PR"
+
+on:
+  merge_group:
+
+jobs:
+  semantic-pull-request:
+    name: Semantic Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Looking good!"

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,7 +1,6 @@
 name: "Lint PR"
 
 on:
-  merge_group:
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
We can't run semantic PR checks in the merge group since it's missing the
PR context.

This adds a fake check to fix that
