### PR TITLE
test: use createTestX methods of suite

### DIFF
--- a/pkg/models/budget_test.go
+++ b/pkg/models/budget_test.go
@@ -174,11 +174,7 @@ func (suite *TestSuiteStandard) TestBudgetCalculations() {
 }
 
 func (suite *TestSuiteStandard) TestMonthIncomeNoTransactions() {
-	budget := models.Budget{}
-	err := suite.db.Save(&budget).Error
-	if err != nil {
-		suite.Assert().Fail("Resource could not be saved", err)
-	}
+	budget := suite.createTestBudget(models.BudgetCreate{})
 
 	income, err := budget.Income(suite.db, types.NewMonth(2022, 3))
 	assert.Nil(suite.T(), err)
@@ -186,31 +182,21 @@ func (suite *TestSuiteStandard) TestMonthIncomeNoTransactions() {
 }
 
 func (suite *TestSuiteStandard) TestBudgetIncomeDBFail() {
-	budget := models.Budget{}
-
-	err := suite.db.Save(&budget).Error
-	if err != nil {
-		suite.Assert().Fail("Resource could not be saved", err)
-	}
+	budget := suite.createTestBudget(models.BudgetCreate{})
 
 	suite.CloseDB()
 
-	_, err = budget.Income(suite.db, types.NewMonth(1995, 2))
+	_, err := budget.Income(suite.db, types.NewMonth(1995, 2))
 	suite.Assert().NotNil(err)
 	suite.Assert().Equal("sql: database is closed", err.Error())
 }
 
 func (suite *TestSuiteStandard) TestBudgetBudgetedDBFail() {
-	budget := models.Budget{}
-
-	err := suite.db.Save(&budget).Error
-	if err != nil {
-		suite.Assert().Fail("Resource could not be saved", err)
-	}
+	budget := suite.createTestBudget(models.BudgetCreate{})
 
 	suite.CloseDB()
 
-	_, err = budget.Allocated(suite.db, types.NewMonth(200, 2))
+	_, err := budget.Allocated(suite.db, types.NewMonth(200, 2))
 	suite.Assert().NotNil(err)
 	suite.Assert().Equal("sql: database is closed", err.Error())
 }

--- a/pkg/models/envelope_test.go
+++ b/pkg/models/envelope_test.go
@@ -12,89 +12,49 @@ import (
 )
 
 func (suite *TestSuiteStandard) TestEnvelopeMonthSum() {
-	budget := models.Budget{}
-	err := suite.db.Save(&budget).Error
-	if err != nil {
-		suite.Assert().Fail("Resource could not be saved", err)
-	}
+	budget := suite.createTestBudget(models.BudgetCreate{})
 
-	internalAccount := &models.Account{
-		AccountCreate: models.AccountCreate{
-			Name:     "Internal Source Account",
-			BudgetID: budget.ID,
-			OnBudget: true,
-		},
-	}
-	err = suite.db.Create(internalAccount).Error
-	if err != nil {
-		suite.Assert().Fail("Resource could not be saved", err)
-	}
+	internalAccount := suite.createTestAccount(models.AccountCreate{
+		Name:     "Internal Source Account",
+		BudgetID: budget.ID,
+		OnBudget: true,
+	})
 
-	externalAccount := &models.Account{
-		AccountCreate: models.AccountCreate{
-			Name:     "External Destination Account",
-			BudgetID: budget.ID,
-			External: true,
-		},
-	}
-	err = suite.db.Create(&externalAccount).Error
-	if err != nil {
-		suite.Assert().Fail("Resource could not be saved", err)
-	}
+	externalAccount := suite.createTestAccount(models.AccountCreate{
+		Name:     "External Destination Account",
+		BudgetID: budget.ID,
+		External: true,
+	})
 
-	category := models.Category{
-		CategoryCreate: models.CategoryCreate{
-			BudgetID: budget.ID,
-		},
-	}
-	err = suite.db.Save(&category).Error
-	if err != nil {
-		suite.Assert().Fail("Resource could not be saved", err)
-	}
+	category := suite.createTestCategory(models.CategoryCreate{
+		BudgetID: budget.ID,
+	})
 
-	envelope := &models.Envelope{
-		EnvelopeCreate: models.EnvelopeCreate{
-			Name:       "Testing envelope",
-			CategoryID: category.ID,
-		},
-	}
-	err = suite.db.Create(&envelope).Error
-	if err != nil {
-		suite.Assert().Fail("Resource could not be saved", err)
-	}
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{
+		Name:       "Testing envelope",
+		CategoryID: category.ID,
+	})
 
 	january := types.NewMonth(2022, 1)
 
 	spent := decimal.NewFromFloat(17.32)
-	transaction := &models.Transaction{
-		TransactionCreate: models.TransactionCreate{
-			BudgetID:             budget.ID,
-			EnvelopeID:           &envelope.ID,
-			Amount:               spent,
-			SourceAccountID:      internalAccount.ID,
-			DestinationAccountID: externalAccount.ID,
-			Date:                 time.Time(january),
-		},
-	}
-	err = suite.db.Create(&transaction).Error
-	if err != nil {
-		suite.Assert().Fail("Resource could not be saved", err)
-	}
+	transaction := suite.createTestTransaction(models.TransactionCreate{
+		BudgetID:             budget.ID,
+		EnvelopeID:           &envelope.ID,
+		Amount:               spent,
+		SourceAccountID:      internalAccount.ID,
+		DestinationAccountID: externalAccount.ID,
+		Date:                 time.Time(january),
+	})
 
-	transactionIn := &models.Transaction{
-		TransactionCreate: models.TransactionCreate{
-			BudgetID:             budget.ID,
-			EnvelopeID:           &envelope.ID,
-			Amount:               spent,
-			SourceAccountID:      externalAccount.ID,
-			DestinationAccountID: internalAccount.ID,
-			Date:                 time.Time(january.AddDate(0, 1)),
-		},
-	}
-	err = suite.db.Create(&transactionIn).Error
-	if err != nil {
-		suite.Assert().Fail("Resource could not be saved", err)
-	}
+	_ = suite.createTestTransaction(models.TransactionCreate{
+		BudgetID:             budget.ID,
+		EnvelopeID:           &envelope.ID,
+		Amount:               spent,
+		SourceAccountID:      externalAccount.ID,
+		DestinationAccountID: internalAccount.ID,
+		Date:                 time.Time(january.AddDate(0, 1)),
+	})
 
 	envelopeMonth, _, err := envelope.Month(suite.db, january)
 	assert.Nil(suite.T(), err)
@@ -115,57 +75,31 @@ func (suite *TestSuiteStandard) TestEnvelopeMonthSum() {
 }
 
 func (suite *TestSuiteStandard) TestCreateTransactionNoEnvelope() {
-	budget := models.Budget{}
-	err := suite.db.Save(&budget).Error
-	if err != nil {
-		suite.Assert().Fail("Resource could not be saved", err)
-	}
+	budget := suite.createTestBudget(models.BudgetCreate{})
 
-	internalAccount := &models.Account{
-		AccountCreate: models.AccountCreate{
-			Name:     "Internal Source Account",
-			BudgetID: budget.ID,
-		},
-	}
-	err = suite.db.Create(internalAccount).Error
-	if err != nil {
-		suite.Assert().Fail("Resource could not be saved", err)
-	}
+	internalAccount := suite.createTestAccount(models.AccountCreate{
+		Name:     "Internal Source Account",
+		BudgetID: budget.ID,
+	})
 
-	externalAccount := &models.Account{
-		AccountCreate: models.AccountCreate{
-			Name:     "External Destination Account",
-			BudgetID: budget.ID,
-			External: true,
-		},
-	}
-	err = suite.db.Create(&externalAccount).Error
-	if err != nil {
-		suite.Assert().Fail("Resource could not be saved", err)
-	}
+	externalAccount := suite.createTestAccount(models.AccountCreate{
+		Name:     "External Destination Account",
+		BudgetID: budget.ID,
+		External: true,
+	})
 
-	category := models.Category{
-		CategoryCreate: models.CategoryCreate{
-			BudgetID: budget.ID,
-		},
-	}
-	err = suite.db.Save(&category).Error
-	if err != nil {
-		suite.Assert().Fail("Resource could not be saved", err)
-	}
+	_ = suite.createTestCategory(models.CategoryCreate{
+		BudgetID: budget.ID,
+	})
 
-	transaction := &models.Transaction{
-		TransactionCreate: models.TransactionCreate{
-			BudgetID:             budget.ID,
-			Amount:               decimal.NewFromFloat(17.32),
-			SourceAccountID:      internalAccount.ID,
-			DestinationAccountID: externalAccount.ID,
-			Date:                 time.Date(2022, 1, 15, 0, 0, 0, 0, time.UTC),
-		},
-	}
-	err = suite.db.Create(&transaction).Error
-
-	assert.Nil(suite.T(), err, "Transactions must be able to be created without an envelope (to enable internal transfers without an Envelope and income transactions)")
+	// Transactions must be able to be created without an envelope (to enable internal transfers without an Envelope and income transactions)
+	_ = suite.createTestTransaction(models.TransactionCreate{
+		BudgetID:             budget.ID,
+		Amount:               decimal.NewFromFloat(17.32),
+		SourceAccountID:      internalAccount.ID,
+		DestinationAccountID: externalAccount.ID,
+		Date:                 time.Date(2022, 1, 15, 0, 0, 0, 0, time.UTC),
+	})
 }
 
 // TestEnvelopeMonthBalance verifies that the monthly balance calculation for


### PR DESCRIPTION
This uses the createTestX methods of the suite for model tests to make
test code shorter and less redundant.

Resolves #512.
