### PR TITLE
fix: availability date is now enforced to not be earlier than the month of the transaction

### DIFF
--- a/pkg/models/account_test.go
+++ b/pkg/models/account_test.go
@@ -59,6 +59,7 @@ func (suite *TestSuiteStandard) TestAccountCalculations() {
 		SourceAccountID:      externalAccount.ID,
 		DestinationAccountID: account.ID,
 		Amount:               decimal.NewFromFloat(100),
+		Date:                 time.Now(),
 		AvailableFrom:        types.MonthOf(time.Now()).AddDate(0, 1),
 		Note:                 "Future Income Transaction",
 	})

--- a/pkg/models/transaction.go
+++ b/pkg/models/transaction.go
@@ -90,6 +90,8 @@ func (t *Transaction) BeforeSave(tx *gorm.DB) (err error) {
 	// Default the AvailableForBudget date to the transaction date
 	if t.AvailableFrom.IsZero() {
 		t.AvailableFrom = types.MonthOf(t.Date)
+	} else if t.AvailableFrom.Before(types.MonthOf(t.Date)) {
+		return fmt.Errorf("availability month must not be earlier than the month of the transaction, transaction date: %s, available month %s", t.Date, t.AvailableFrom)
 	}
 
 	// Enforce ReconciledSource = false when source account is external


### PR DESCRIPTION
Resolves #768.
