### PR TITLE
fix: income now recognized in RecentEnvelopes and transaction import

### DIFF
--- a/pkg/models/account.go
+++ b/pkg/models/account.go
@@ -207,10 +207,12 @@ func (a Account) GetBalanceMonth(db *gorm.DB, month types.Month) (balance, avail
 // The list is sorted by decending frequency of the envelope being used.
 func (a *Account) SetRecentEnvelopes(db *gorm.DB) error {
 	var envelopes []Envelope
+
+	// TODO: For v2, just return the IDs and use `null` for income
 	err := db.
 		Table("transactions").
-		Select("envelopes.*, count(envelopes.id) AS count").
-		Joins("JOIN envelopes ON envelopes.id = transactions.envelope_id AND envelopes.deleted_at IS NULL").
+		Select("envelopes.*, count(*) AS count").
+		Joins("LEFT JOIN envelopes ON envelopes.id = transactions.envelope_id AND envelopes.deleted_at IS NULL").
 		Order("count DESC, date(transactions.date) DESC").
 		Where(&Transaction{
 			TransactionCreate: TransactionCreate{


### PR DESCRIPTION
The RecentEnvelopes field for Account resources and the proposed Envelope for
ImportPreviews now also consider income transactions.

Income is represented as the nil UUID in the Envelope ID, meaning that the
RecentEnvelopes field will contain an entry with all zero-values for Income.

This will be improved in API v2 to replace the ID for income with a `null` value.

Resolves #773.
