### PR TITLE
fix: set Transaction Envelope ID to nil if it is the zero UUID

### DIFF
--- a/pkg/controllers/transaction.go
+++ b/pkg/controllers/transaction.go
@@ -7,6 +7,7 @@ import (
 	"github.com/envelope-zero/backend/v3/pkg/httperrors"
 	"github.com/envelope-zero/backend/v3/pkg/models"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 )
 
@@ -95,7 +96,7 @@ func (co Controller) checkTransaction(c *gin.Context, transaction models.Transac
 	}
 
 	// Check envelope being set for transfer between on-budget accounts
-	if transaction.EnvelopeID != nil {
+	if transaction.EnvelopeID != nil && *transaction.EnvelopeID != uuid.Nil {
 		if source.OnBudget && destination.OnBudget {
 			// TODO: Verify this state in the model hooks
 			return httperrors.ErrorStatus{Err: errors.New("transfers between two on-budget accounts must not have an envelope set. Such a transaction would be incoming and outgoing for this envelope at the same time, which is not possible"), Status: http.StatusBadRequest}

--- a/pkg/controllers/transaction_test.go
+++ b/pkg/controllers/transaction_test.go
@@ -321,6 +321,16 @@ func (suite *TestSuiteStandard) TestCreateTransaction() {
 	_ = suite.createTestTransaction(models.TransactionCreate{Note: "More tests something something", Amount: decimal.NewFromFloat(1253.17)})
 }
 
+// TestTransactionEnvelopeNilUUID is a regression test to ensure that when the API receives a
+// nil UUID "00000000-0000-0000-0000-000000000000" for the envelope, we do not check for the
+// envelopes existence in checkTransaction()
+//
+// If we did, it would always error.
+func (suite *TestSuiteStandard) TestCreateTransactionCheckTransactionEnvelopeNilUUID() {
+	eID := uuid.Nil
+	_ = suite.createTestTransaction(models.TransactionCreate{Note: "More tests something something", Amount: decimal.NewFromFloat(1253.17), EnvelopeID: &eID})
+}
+
 func (suite *TestSuiteStandard) TestTransactionSorting() {
 	tFebrurary := suite.createTestTransaction(models.TransactionCreate{Note: "Should be second in the list", Amount: decimal.NewFromFloat(1253.17), Date: time.Date(2022, 2, 15, 0, 0, 0, 0, time.UTC)})
 

--- a/pkg/models/transaction.go
+++ b/pkg/models/transaction.go
@@ -81,6 +81,12 @@ func (t *Transaction) links(tx *gorm.DB) {
 //   - sets the timezone for the Date for UTC
 //   - ensures that ReconciledSource and ReconciledDestination are set to valid values
 func (t *Transaction) BeforeSave(tx *gorm.DB) (err error) {
+	// Ensure that the Envelope ID is nil and not a pointer to a nil UUID
+	// when it is set
+	if t.EnvelopeID != nil && *t.EnvelopeID == uuid.Nil {
+		t.EnvelopeID = nil
+	}
+
 	if t.Date.IsZero() {
 		t.Date = time.Now().In(time.UTC)
 	} else {


### PR DESCRIPTION
When a Transaction is saved with a zero UUID for the Envelope,
the backend now explicitly sets the Envelope ID to nil.

This prevents errors when used in combination with the Transaction Preview
since the Transaction Preview returns the zero UUID for income.
