### PR TITLE
feat: add healthz endpoint

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -44,6 +44,41 @@ const docTemplate = `{
                 }
             }
         },
+        "/healthz": {
+            "get": {
+                "description": "Returns the application health and, if not healthy, an error",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "General"
+                ],
+                "summary": "Get health",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "tags": [
+                    "General"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
         "/v1": {
             "get": {
                 "description": "Returns general information about the v1 API",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -33,6 +33,41 @@
                 }
             }
         },
+        "/healthz": {
+            "get": {
+                "description": "Returns the application health and, if not healthy, an error",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "General"
+                ],
+                "summary": "Get health",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "tags": [
+                    "General"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
         "/v1": {
             "get": {
                 "description": "Returns general information about the v1 API",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1263,6 +1263,30 @@ paths:
       summary: Allowed HTTP verbs
       tags:
       - General
+  /healthz:
+    get:
+      description: Returns the application health and, if not healthy, an error
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Get health
+      tags:
+      - General
+    options:
+      description: Returns an empty response with the HTTP Header "allow" set to the
+        allowed HTTP verbs
+      responses:
+        "204":
+          description: No Content
+      summary: Allowed HTTP verbs
+      tags:
+      - General
   /v1:
     delete:
       description: Permanently deletes all resources

--- a/pkg/controllers/healthz.go
+++ b/pkg/controllers/healthz.go
@@ -1,0 +1,55 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/envelope-zero/backend/v3/pkg/httperrors"
+	"github.com/envelope-zero/backend/v3/pkg/httputil"
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterHealthzRoutes registers the routes for the healthz endpoint.
+func (co Controller) RegisterHealthzRoutes(r *gin.RouterGroup) {
+	r.OPTIONS("", co.OptionsHealthz)
+	r.GET("", co.GetHealthz)
+}
+
+// OptionsHealthz returns the allowed HTTP verbs
+//
+//	@Summary		Allowed HTTP verbs
+//	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
+//	@Tags			General
+//	@Success		204
+//	@Router			/healthz [options]
+func (co Controller) OptionsHealthz(c *gin.Context) {
+	httputil.OptionsGet(c)
+}
+
+type HealthResponse struct {
+	Error error `json:"error" example:"The database cannot be accessed"`
+}
+
+// GetHealthz returns data about the application health
+//
+//	@Summary		Get health
+//	@Description	Returns the application health and, if not healthy, an error
+//	@Tags			General
+//	@Produce		json
+//	@Success		204
+//	@Failure		500	{object} httperrors.HTTPError
+//	@Router			/healthz [get]
+func (co Controller) GetHealthz(c *gin.Context) {
+	sqlDB, err := co.DB.DB()
+	if err != nil {
+		httperrors.Handler(c, err)
+		return
+	}
+
+	err = sqlDB.Ping()
+	if err != nil {
+		httperrors.Handler(c, err)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}

--- a/pkg/controllers/healthz_test.go
+++ b/pkg/controllers/healthz_test.go
@@ -1,0 +1,21 @@
+package controllers_test
+
+import (
+	"net/http"
+
+	"github.com/envelope-zero/backend/v3/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *TestSuiteStandard) TestHealthzSuccess() {
+	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/healthz", "")
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNoContent)
+}
+
+func (suite *TestSuiteStandard) TestHealthzFail() {
+	suite.CloseDB()
+
+	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/healthz", "")
+	assertHTTPStatus(suite.T(), &recorder, http.StatusInternalServerError)
+	assert.Contains(suite.T(), test.DecodeError(suite.T(), recorder.Body.Bytes()), "There is a problem with the database connection")
+}

--- a/pkg/controllers/test_options_test.go
+++ b/pkg/controllers/test_options_test.go
@@ -13,6 +13,7 @@ func (suite *TestSuiteStandard) TestOptionsHeaderResources() {
 		path     string
 		response string
 	}{
+		{"http://example.com/healthz", "OPTIONS, GET"},
 		{"http://example.com/v1/budgets", "OPTIONS, GET, POST"},
 		{"http://example.com/v1/accounts", "OPTIONS, GET, POST"},
 		{"http://example.com/v1/categories", "OPTIONS, GET, POST"},

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -107,6 +107,7 @@ func AttachRoutes(co controllers.Controller, group *gin.RouterGroup) {
 	}
 
 	group.GET("/docs/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	co.RegisterHealthzRoutes(group.Group("/healthz"))
 
 	// API v1 setup
 	v1 := group.Group("/v1")


### PR DESCRIPTION
This adds the `/healthz` endpoint, which checks the health of the application.
For now, this mainly verifies that the database can be accessed.

Use this endpoint to automatically restart the backend with e.g. a docker compose
health check or Kubernetes probes.

It returns HTTP 204 for success and HTTP 500 with an error message when there is an error.
