### PR TITLE
fix: API v2 Transaction links

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -4033,7 +4033,7 @@ const docTemplate = `{
                     "description": "This field contains the transaction data",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/models.Transaction"
+                            "$ref": "#/definitions/controllers.TransactionV2"
                         }
                     ]
                 },
@@ -4044,6 +4044,108 @@ const docTemplate = `{
                 }
             }
         },
+        "controllers.Transaction": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 14.03
+                },
+                "availableFrom": {
+                    "description": "The date from which on the transaction amount is available for budgeting. Only used for income transactions. Defaults to the transaction date.",
+                    "type": "string",
+                    "example": "2021-11-17T00:00:00Z"
+                },
+                "budgetId": {
+                    "description": "ID of the budget",
+                    "type": "string",
+                    "example": "55eecbd8-7c46-4b06-ada9-f287802fb05e"
+                },
+                "createdAt": {
+                    "description": "Time the resource was created",
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "date": {
+                    "description": "Date of the transaction. Time is currently only used for sorting",
+                    "type": "string",
+                    "example": "1815-12-10T18:43:00.271152Z"
+                },
+                "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
+                "destinationAccountId": {
+                    "description": "ID of the destination account",
+                    "type": "string",
+                    "example": "8e16b456-a719-48ce-9fec-e115cfa7cbcc"
+                },
+                "envelopeId": {
+                    "description": "ID of the envelope",
+                    "type": "string",
+                    "example": "2649c965-7999-4873-ae16-89d5d5fa972e"
+                },
+                "id": {
+                    "description": "UUID for the resource",
+                    "type": "string",
+                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
+                },
+                "importHash": {
+                    "description": "The SHA256 hash of a unique combination of values to use in duplicate detection",
+                    "type": "string",
+                    "example": "867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70"
+                },
+                "links": {
+                    "description": "Links for the transaction",
+                    "type": "object",
+                    "properties": {
+                        "self": {
+                            "description": "The transaction itself",
+                            "type": "string",
+                            "example": "https://example.com/api/v1/transactions/d430d7c3-d14c-4712-9336-ee56965a6673"
+                        }
+                    }
+                },
+                "note": {
+                    "description": "A note",
+                    "type": "string",
+                    "example": "Lunch"
+                },
+                "reconciled": {
+                    "description": "DEPRECATED. Do not use, this field does not work as intended. See https://github.com/envelope-zero/backend/issues/528. Use reconciledSource and reconciledDestination instead.",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "reconciledDestination": {
+                    "description": "Is the transaction reconciled in the destination account?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "reconciledSource": {
+                    "description": "Is the transaction reconciled in the source account?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "sourceAccountId": {
+                    "description": "ID of the source account",
+                    "type": "string",
+                    "example": "fd81dc45-a3a2-468e-a6fa-b2618f30aa45"
+                },
+                "updatedAt": {
+                    "description": "Last time the resource was updated",
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
+                }
+            }
+        },
         "controllers.TransactionListResponse": {
             "type": "object",
             "properties": {
@@ -4051,7 +4153,7 @@ const docTemplate = `{
                     "description": "List of transactions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/models.Transaction"
+                        "$ref": "#/definitions/controllers.Transaction"
                     }
                 }
             }
@@ -4063,9 +4165,111 @@ const docTemplate = `{
                     "description": "Data for the transaction",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/models.Transaction"
+                            "$ref": "#/definitions/controllers.Transaction"
                         }
                     ]
+                }
+            }
+        },
+        "controllers.TransactionV2": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 14.03
+                },
+                "availableFrom": {
+                    "description": "The date from which on the transaction amount is available for budgeting. Only used for income transactions. Defaults to the transaction date.",
+                    "type": "string",
+                    "example": "2021-11-17T00:00:00Z"
+                },
+                "budgetId": {
+                    "description": "ID of the budget",
+                    "type": "string",
+                    "example": "55eecbd8-7c46-4b06-ada9-f287802fb05e"
+                },
+                "createdAt": {
+                    "description": "Time the resource was created",
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "date": {
+                    "description": "Date of the transaction. Time is currently only used for sorting",
+                    "type": "string",
+                    "example": "1815-12-10T18:43:00.271152Z"
+                },
+                "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
+                "destinationAccountId": {
+                    "description": "ID of the destination account",
+                    "type": "string",
+                    "example": "8e16b456-a719-48ce-9fec-e115cfa7cbcc"
+                },
+                "envelopeId": {
+                    "description": "ID of the envelope",
+                    "type": "string",
+                    "example": "2649c965-7999-4873-ae16-89d5d5fa972e"
+                },
+                "id": {
+                    "description": "UUID for the resource",
+                    "type": "string",
+                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
+                },
+                "importHash": {
+                    "description": "The SHA256 hash of a unique combination of values to use in duplicate detection",
+                    "type": "string",
+                    "example": "867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70"
+                },
+                "links": {
+                    "description": "Links for the transaction",
+                    "type": "object",
+                    "properties": {
+                        "self": {
+                            "description": "The transaction itself",
+                            "type": "string",
+                            "example": "https://example.com/api/v1/transactions/d430d7c3-d14c-4712-9336-ee56965a6673"
+                        }
+                    }
+                },
+                "note": {
+                    "description": "A note",
+                    "type": "string",
+                    "example": "Lunch"
+                },
+                "reconciled": {
+                    "description": "DEPRECATED. Do not use, this field does not work as intended. See https://github.com/envelope-zero/backend/issues/528. Use reconciledSource and reconciledDestination instead.",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "reconciledDestination": {
+                    "description": "Is the transaction reconciled in the destination account?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "reconciledSource": {
+                    "description": "Is the transaction reconciled in the source account?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "sourceAccountId": {
+                    "description": "ID of the source account",
+                    "type": "string",
+                    "example": "fd81dc45-a3a2-468e-a6fa-b2618f30aa45"
+                },
+                "updatedAt": {
+                    "description": "Last time the resource was updated",
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
                 }
             }
         },
@@ -4971,108 +5175,6 @@ const docTemplate = `{
                 "AffectAvailable",
                 "AffectEnvelope"
             ]
-        },
-        "models.Transaction": {
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
-                    "type": "number",
-                    "maximum": 1000000000000,
-                    "minimum": 1e-8,
-                    "multipleOf": 1e-8,
-                    "example": 14.03
-                },
-                "availableFrom": {
-                    "description": "The date from which on the transaction amount is available for budgeting. Only used for income transactions. Defaults to the transaction date.",
-                    "type": "string",
-                    "example": "2021-11-17T00:00:00Z"
-                },
-                "budgetId": {
-                    "description": "ID of the budget",
-                    "type": "string",
-                    "example": "55eecbd8-7c46-4b06-ada9-f287802fb05e"
-                },
-                "createdAt": {
-                    "description": "Time the resource was created",
-                    "type": "string",
-                    "example": "2022-04-02T19:28:44.491514Z"
-                },
-                "date": {
-                    "description": "Date of the transaction. Time is currently only used for sorting",
-                    "type": "string",
-                    "example": "1815-12-10T18:43:00.271152Z"
-                },
-                "deletedAt": {
-                    "description": "Time the resource was marked as deleted",
-                    "type": "string",
-                    "example": "2022-04-22T21:01:05.058161Z"
-                },
-                "destinationAccountId": {
-                    "description": "ID of the destination account",
-                    "type": "string",
-                    "example": "8e16b456-a719-48ce-9fec-e115cfa7cbcc"
-                },
-                "envelopeId": {
-                    "description": "ID of the envelope",
-                    "type": "string",
-                    "example": "2649c965-7999-4873-ae16-89d5d5fa972e"
-                },
-                "id": {
-                    "description": "UUID for the resource",
-                    "type": "string",
-                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
-                },
-                "importHash": {
-                    "description": "The SHA256 hash of a unique combination of values to use in duplicate detection",
-                    "type": "string",
-                    "example": "867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70"
-                },
-                "links": {
-                    "description": "Links for the transaction",
-                    "type": "object",
-                    "properties": {
-                        "self": {
-                            "description": "The transaction itself",
-                            "type": "string",
-                            "example": "https://example.com/api/v1/transactions/d430d7c3-d14c-4712-9336-ee56965a6673"
-                        }
-                    }
-                },
-                "note": {
-                    "description": "A note",
-                    "type": "string",
-                    "example": "Lunch"
-                },
-                "reconciled": {
-                    "description": "DEPRECATED. Do not use, this field does not work as intended. See https://github.com/envelope-zero/backend/issues/528. Use reconciledSource and reconciledDestination instead.",
-                    "type": "boolean",
-                    "default": false,
-                    "example": true
-                },
-                "reconciledDestination": {
-                    "description": "Is the transaction reconciled in the destination account?",
-                    "type": "boolean",
-                    "default": false,
-                    "example": true
-                },
-                "reconciledSource": {
-                    "description": "Is the transaction reconciled in the source account?",
-                    "type": "boolean",
-                    "default": false,
-                    "example": true
-                },
-                "sourceAccountId": {
-                    "description": "ID of the source account",
-                    "type": "string",
-                    "example": "fd81dc45-a3a2-468e-a6fa-b2618f30aa45"
-                },
-                "updatedAt": {
-                    "description": "Last time the resource was updated",
-                    "type": "string",
-                    "example": "2022-04-17T20:14:01.048145Z"
-                }
-            }
         },
         "models.TransactionCreate": {
             "type": "object",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -4022,7 +4022,7 @@
                     "description": "This field contains the transaction data",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/models.Transaction"
+                            "$ref": "#/definitions/controllers.TransactionV2"
                         }
                     ]
                 },
@@ -4033,6 +4033,108 @@
                 }
             }
         },
+        "controllers.Transaction": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 14.03
+                },
+                "availableFrom": {
+                    "description": "The date from which on the transaction amount is available for budgeting. Only used for income transactions. Defaults to the transaction date.",
+                    "type": "string",
+                    "example": "2021-11-17T00:00:00Z"
+                },
+                "budgetId": {
+                    "description": "ID of the budget",
+                    "type": "string",
+                    "example": "55eecbd8-7c46-4b06-ada9-f287802fb05e"
+                },
+                "createdAt": {
+                    "description": "Time the resource was created",
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "date": {
+                    "description": "Date of the transaction. Time is currently only used for sorting",
+                    "type": "string",
+                    "example": "1815-12-10T18:43:00.271152Z"
+                },
+                "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
+                "destinationAccountId": {
+                    "description": "ID of the destination account",
+                    "type": "string",
+                    "example": "8e16b456-a719-48ce-9fec-e115cfa7cbcc"
+                },
+                "envelopeId": {
+                    "description": "ID of the envelope",
+                    "type": "string",
+                    "example": "2649c965-7999-4873-ae16-89d5d5fa972e"
+                },
+                "id": {
+                    "description": "UUID for the resource",
+                    "type": "string",
+                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
+                },
+                "importHash": {
+                    "description": "The SHA256 hash of a unique combination of values to use in duplicate detection",
+                    "type": "string",
+                    "example": "867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70"
+                },
+                "links": {
+                    "description": "Links for the transaction",
+                    "type": "object",
+                    "properties": {
+                        "self": {
+                            "description": "The transaction itself",
+                            "type": "string",
+                            "example": "https://example.com/api/v1/transactions/d430d7c3-d14c-4712-9336-ee56965a6673"
+                        }
+                    }
+                },
+                "note": {
+                    "description": "A note",
+                    "type": "string",
+                    "example": "Lunch"
+                },
+                "reconciled": {
+                    "description": "DEPRECATED. Do not use, this field does not work as intended. See https://github.com/envelope-zero/backend/issues/528. Use reconciledSource and reconciledDestination instead.",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "reconciledDestination": {
+                    "description": "Is the transaction reconciled in the destination account?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "reconciledSource": {
+                    "description": "Is the transaction reconciled in the source account?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "sourceAccountId": {
+                    "description": "ID of the source account",
+                    "type": "string",
+                    "example": "fd81dc45-a3a2-468e-a6fa-b2618f30aa45"
+                },
+                "updatedAt": {
+                    "description": "Last time the resource was updated",
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
+                }
+            }
+        },
         "controllers.TransactionListResponse": {
             "type": "object",
             "properties": {
@@ -4040,7 +4142,7 @@
                     "description": "List of transactions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/models.Transaction"
+                        "$ref": "#/definitions/controllers.Transaction"
                     }
                 }
             }
@@ -4052,9 +4154,111 @@
                     "description": "Data for the transaction",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/models.Transaction"
+                            "$ref": "#/definitions/controllers.Transaction"
                         }
                     ]
+                }
+            }
+        },
+        "controllers.TransactionV2": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 14.03
+                },
+                "availableFrom": {
+                    "description": "The date from which on the transaction amount is available for budgeting. Only used for income transactions. Defaults to the transaction date.",
+                    "type": "string",
+                    "example": "2021-11-17T00:00:00Z"
+                },
+                "budgetId": {
+                    "description": "ID of the budget",
+                    "type": "string",
+                    "example": "55eecbd8-7c46-4b06-ada9-f287802fb05e"
+                },
+                "createdAt": {
+                    "description": "Time the resource was created",
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "date": {
+                    "description": "Date of the transaction. Time is currently only used for sorting",
+                    "type": "string",
+                    "example": "1815-12-10T18:43:00.271152Z"
+                },
+                "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
+                "destinationAccountId": {
+                    "description": "ID of the destination account",
+                    "type": "string",
+                    "example": "8e16b456-a719-48ce-9fec-e115cfa7cbcc"
+                },
+                "envelopeId": {
+                    "description": "ID of the envelope",
+                    "type": "string",
+                    "example": "2649c965-7999-4873-ae16-89d5d5fa972e"
+                },
+                "id": {
+                    "description": "UUID for the resource",
+                    "type": "string",
+                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
+                },
+                "importHash": {
+                    "description": "The SHA256 hash of a unique combination of values to use in duplicate detection",
+                    "type": "string",
+                    "example": "867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70"
+                },
+                "links": {
+                    "description": "Links for the transaction",
+                    "type": "object",
+                    "properties": {
+                        "self": {
+                            "description": "The transaction itself",
+                            "type": "string",
+                            "example": "https://example.com/api/v1/transactions/d430d7c3-d14c-4712-9336-ee56965a6673"
+                        }
+                    }
+                },
+                "note": {
+                    "description": "A note",
+                    "type": "string",
+                    "example": "Lunch"
+                },
+                "reconciled": {
+                    "description": "DEPRECATED. Do not use, this field does not work as intended. See https://github.com/envelope-zero/backend/issues/528. Use reconciledSource and reconciledDestination instead.",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "reconciledDestination": {
+                    "description": "Is the transaction reconciled in the destination account?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "reconciledSource": {
+                    "description": "Is the transaction reconciled in the source account?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "sourceAccountId": {
+                    "description": "ID of the source account",
+                    "type": "string",
+                    "example": "fd81dc45-a3a2-468e-a6fa-b2618f30aa45"
+                },
+                "updatedAt": {
+                    "description": "Last time the resource was updated",
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
                 }
             }
         },
@@ -4960,108 +5164,6 @@
                 "AffectAvailable",
                 "AffectEnvelope"
             ]
-        },
-        "models.Transaction": {
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
-                    "type": "number",
-                    "maximum": 1000000000000,
-                    "minimum": 1e-8,
-                    "multipleOf": 1e-8,
-                    "example": 14.03
-                },
-                "availableFrom": {
-                    "description": "The date from which on the transaction amount is available for budgeting. Only used for income transactions. Defaults to the transaction date.",
-                    "type": "string",
-                    "example": "2021-11-17T00:00:00Z"
-                },
-                "budgetId": {
-                    "description": "ID of the budget",
-                    "type": "string",
-                    "example": "55eecbd8-7c46-4b06-ada9-f287802fb05e"
-                },
-                "createdAt": {
-                    "description": "Time the resource was created",
-                    "type": "string",
-                    "example": "2022-04-02T19:28:44.491514Z"
-                },
-                "date": {
-                    "description": "Date of the transaction. Time is currently only used for sorting",
-                    "type": "string",
-                    "example": "1815-12-10T18:43:00.271152Z"
-                },
-                "deletedAt": {
-                    "description": "Time the resource was marked as deleted",
-                    "type": "string",
-                    "example": "2022-04-22T21:01:05.058161Z"
-                },
-                "destinationAccountId": {
-                    "description": "ID of the destination account",
-                    "type": "string",
-                    "example": "8e16b456-a719-48ce-9fec-e115cfa7cbcc"
-                },
-                "envelopeId": {
-                    "description": "ID of the envelope",
-                    "type": "string",
-                    "example": "2649c965-7999-4873-ae16-89d5d5fa972e"
-                },
-                "id": {
-                    "description": "UUID for the resource",
-                    "type": "string",
-                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
-                },
-                "importHash": {
-                    "description": "The SHA256 hash of a unique combination of values to use in duplicate detection",
-                    "type": "string",
-                    "example": "867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70"
-                },
-                "links": {
-                    "description": "Links for the transaction",
-                    "type": "object",
-                    "properties": {
-                        "self": {
-                            "description": "The transaction itself",
-                            "type": "string",
-                            "example": "https://example.com/api/v1/transactions/d430d7c3-d14c-4712-9336-ee56965a6673"
-                        }
-                    }
-                },
-                "note": {
-                    "description": "A note",
-                    "type": "string",
-                    "example": "Lunch"
-                },
-                "reconciled": {
-                    "description": "DEPRECATED. Do not use, this field does not work as intended. See https://github.com/envelope-zero/backend/issues/528. Use reconciledSource and reconciledDestination instead.",
-                    "type": "boolean",
-                    "default": false,
-                    "example": true
-                },
-                "reconciledDestination": {
-                    "description": "Is the transaction reconciled in the destination account?",
-                    "type": "boolean",
-                    "default": false,
-                    "example": true
-                },
-                "reconciledSource": {
-                    "description": "Is the transaction reconciled in the source account?",
-                    "type": "boolean",
-                    "default": false,
-                    "example": true
-                },
-                "sourceAccountId": {
-                    "description": "ID of the source account",
-                    "type": "string",
-                    "example": "fd81dc45-a3a2-468e-a6fa-b2618f30aa45"
-                },
-                "updatedAt": {
-                    "description": "Last time the resource was updated",
-                    "type": "string",
-                    "example": "2022-04-17T20:14:01.048145Z"
-                }
-            }
         },
         "models.TransactionCreate": {
             "type": "object",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -251,11 +251,98 @@ definitions:
     properties:
       data:
         allOf:
-        - $ref: '#/definitions/models.Transaction'
+        - $ref: '#/definitions/controllers.TransactionV2'
         description: This field contains the transaction data
       error:
         description: This field contains a human readable error message
         example: A human readable error message
+        type: string
+    type: object
+  controllers.Transaction:
+    properties:
+      amount:
+        description: The maximum value is "999999999999.99999999", swagger unfortunately
+          rounds this.
+        example: 14.03
+        maximum: 1000000000000
+        minimum: 1e-08
+        multipleOf: 1e-08
+        type: number
+      availableFrom:
+        description: The date from which on the transaction amount is available for
+          budgeting. Only used for income transactions. Defaults to the transaction
+          date.
+        example: "2021-11-17T00:00:00Z"
+        type: string
+      budgetId:
+        description: ID of the budget
+        example: 55eecbd8-7c46-4b06-ada9-f287802fb05e
+        type: string
+      createdAt:
+        description: Time the resource was created
+        example: "2022-04-02T19:28:44.491514Z"
+        type: string
+      date:
+        description: Date of the transaction. Time is currently only used for sorting
+        example: "1815-12-10T18:43:00.271152Z"
+        type: string
+      deletedAt:
+        description: Time the resource was marked as deleted
+        example: "2022-04-22T21:01:05.058161Z"
+        type: string
+      destinationAccountId:
+        description: ID of the destination account
+        example: 8e16b456-a719-48ce-9fec-e115cfa7cbcc
+        type: string
+      envelopeId:
+        description: ID of the envelope
+        example: 2649c965-7999-4873-ae16-89d5d5fa972e
+        type: string
+      id:
+        description: UUID for the resource
+        example: 65392deb-5e92-4268-b114-297faad6cdce
+        type: string
+      importHash:
+        description: The SHA256 hash of a unique combination of values to use in duplicate
+          detection
+        example: 867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70
+        type: string
+      links:
+        description: Links for the transaction
+        properties:
+          self:
+            description: The transaction itself
+            example: https://example.com/api/v1/transactions/d430d7c3-d14c-4712-9336-ee56965a6673
+            type: string
+        type: object
+      note:
+        description: A note
+        example: Lunch
+        type: string
+      reconciled:
+        default: false
+        description: DEPRECATED. Do not use, this field does not work as intended.
+          See https://github.com/envelope-zero/backend/issues/528. Use reconciledSource
+          and reconciledDestination instead.
+        example: true
+        type: boolean
+      reconciledDestination:
+        default: false
+        description: Is the transaction reconciled in the destination account?
+        example: true
+        type: boolean
+      reconciledSource:
+        default: false
+        description: Is the transaction reconciled in the source account?
+        example: true
+        type: boolean
+      sourceAccountId:
+        description: ID of the source account
+        example: fd81dc45-a3a2-468e-a6fa-b2618f30aa45
+        type: string
+      updatedAt:
+        description: Last time the resource was updated
+        example: "2022-04-17T20:14:01.048145Z"
         type: string
     type: object
   controllers.TransactionListResponse:
@@ -263,15 +350,102 @@ definitions:
       data:
         description: List of transactions
         items:
-          $ref: '#/definitions/models.Transaction'
+          $ref: '#/definitions/controllers.Transaction'
         type: array
     type: object
   controllers.TransactionResponse:
     properties:
       data:
         allOf:
-        - $ref: '#/definitions/models.Transaction'
+        - $ref: '#/definitions/controllers.Transaction'
         description: Data for the transaction
+    type: object
+  controllers.TransactionV2:
+    properties:
+      amount:
+        description: The maximum value is "999999999999.99999999", swagger unfortunately
+          rounds this.
+        example: 14.03
+        maximum: 1000000000000
+        minimum: 1e-08
+        multipleOf: 1e-08
+        type: number
+      availableFrom:
+        description: The date from which on the transaction amount is available for
+          budgeting. Only used for income transactions. Defaults to the transaction
+          date.
+        example: "2021-11-17T00:00:00Z"
+        type: string
+      budgetId:
+        description: ID of the budget
+        example: 55eecbd8-7c46-4b06-ada9-f287802fb05e
+        type: string
+      createdAt:
+        description: Time the resource was created
+        example: "2022-04-02T19:28:44.491514Z"
+        type: string
+      date:
+        description: Date of the transaction. Time is currently only used for sorting
+        example: "1815-12-10T18:43:00.271152Z"
+        type: string
+      deletedAt:
+        description: Time the resource was marked as deleted
+        example: "2022-04-22T21:01:05.058161Z"
+        type: string
+      destinationAccountId:
+        description: ID of the destination account
+        example: 8e16b456-a719-48ce-9fec-e115cfa7cbcc
+        type: string
+      envelopeId:
+        description: ID of the envelope
+        example: 2649c965-7999-4873-ae16-89d5d5fa972e
+        type: string
+      id:
+        description: UUID for the resource
+        example: 65392deb-5e92-4268-b114-297faad6cdce
+        type: string
+      importHash:
+        description: The SHA256 hash of a unique combination of values to use in duplicate
+          detection
+        example: 867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70
+        type: string
+      links:
+        description: Links for the transaction
+        properties:
+          self:
+            description: The transaction itself
+            example: https://example.com/api/v1/transactions/d430d7c3-d14c-4712-9336-ee56965a6673
+            type: string
+        type: object
+      note:
+        description: A note
+        example: Lunch
+        type: string
+      reconciled:
+        default: false
+        description: DEPRECATED. Do not use, this field does not work as intended.
+          See https://github.com/envelope-zero/backend/issues/528. Use reconciledSource
+          and reconciledDestination instead.
+        example: true
+        type: boolean
+      reconciledDestination:
+        default: false
+        description: Is the transaction reconciled in the destination account?
+        example: true
+        type: boolean
+      reconciledSource:
+        default: false
+        description: Is the transaction reconciled in the source account?
+        example: true
+        type: boolean
+      sourceAccountId:
+        description: ID of the source account
+        example: fd81dc45-a3a2-468e-a6fa-b2618f30aa45
+        type: string
+      updatedAt:
+        description: Last time the resource was updated
+        example: "2022-04-17T20:14:01.048145Z"
+        type: string
     type: object
   httperrors.HTTPError:
     properties:
@@ -982,93 +1156,6 @@ definitions:
     x-enum-varnames:
     - AffectAvailable
     - AffectEnvelope
-  models.Transaction:
-    properties:
-      amount:
-        description: The maximum value is "999999999999.99999999", swagger unfortunately
-          rounds this.
-        example: 14.03
-        maximum: 1000000000000
-        minimum: 1e-08
-        multipleOf: 1e-08
-        type: number
-      availableFrom:
-        description: The date from which on the transaction amount is available for
-          budgeting. Only used for income transactions. Defaults to the transaction
-          date.
-        example: "2021-11-17T00:00:00Z"
-        type: string
-      budgetId:
-        description: ID of the budget
-        example: 55eecbd8-7c46-4b06-ada9-f287802fb05e
-        type: string
-      createdAt:
-        description: Time the resource was created
-        example: "2022-04-02T19:28:44.491514Z"
-        type: string
-      date:
-        description: Date of the transaction. Time is currently only used for sorting
-        example: "1815-12-10T18:43:00.271152Z"
-        type: string
-      deletedAt:
-        description: Time the resource was marked as deleted
-        example: "2022-04-22T21:01:05.058161Z"
-        type: string
-      destinationAccountId:
-        description: ID of the destination account
-        example: 8e16b456-a719-48ce-9fec-e115cfa7cbcc
-        type: string
-      envelopeId:
-        description: ID of the envelope
-        example: 2649c965-7999-4873-ae16-89d5d5fa972e
-        type: string
-      id:
-        description: UUID for the resource
-        example: 65392deb-5e92-4268-b114-297faad6cdce
-        type: string
-      importHash:
-        description: The SHA256 hash of a unique combination of values to use in duplicate
-          detection
-        example: 867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70
-        type: string
-      links:
-        description: Links for the transaction
-        properties:
-          self:
-            description: The transaction itself
-            example: https://example.com/api/v1/transactions/d430d7c3-d14c-4712-9336-ee56965a6673
-            type: string
-        type: object
-      note:
-        description: A note
-        example: Lunch
-        type: string
-      reconciled:
-        default: false
-        description: DEPRECATED. Do not use, this field does not work as intended.
-          See https://github.com/envelope-zero/backend/issues/528. Use reconciledSource
-          and reconciledDestination instead.
-        example: true
-        type: boolean
-      reconciledDestination:
-        default: false
-        description: Is the transaction reconciled in the destination account?
-        example: true
-        type: boolean
-      reconciledSource:
-        default: false
-        description: Is the transaction reconciled in the source account?
-        example: true
-        type: boolean
-      sourceAccountId:
-        description: ID of the source account
-        example: fd81dc45-a3a2-468e-a6fa-b2618f30aa45
-        type: string
-      updatedAt:
-        description: Last time the resource was updated
-        example: "2022-04-17T20:14:01.048145Z"
-        type: string
-    type: object
   models.TransactionCreate:
     properties:
       amount:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,11 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
-  rules: {},
+  rules: {
+    "subject-case": () => [
+      2,
+      "never",
+      ["snake-case", "pascal-case", "upper-case"],
+    ],
+    "body-max-line-length": [0, "always", Infinity],
+  },
 };

--- a/pkg/controllers/responses.go
+++ b/pkg/controllers/responses.go
@@ -8,8 +8,8 @@ import (
 )
 
 type ResponseTransactionV2 struct {
-	Error string             `json:"error" example:"A human readable error message"` // This field contains a human readable error message
-	Data  models.Transaction `json:"data"`                                           // This field contains the transaction data
+	Error string        `json:"error" example:"A human readable error message"` // This field contains a human readable error message
+	Data  TransactionV2 `json:"data"`                                           // This field contains the transaction data
 }
 
 type ResponseMatchRule struct {

--- a/pkg/controllers/transaction_v2_test.go
+++ b/pkg/controllers/transaction_v2_test.go
@@ -1,0 +1,89 @@
+package controllers_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/envelope-zero/backend/v3/pkg/controllers"
+	"github.com/envelope-zero/backend/v3/pkg/models"
+	"github.com/envelope-zero/backend/v3/test"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *TestSuiteStandard) TestTransactionsCreateV2() {
+	budget := suite.createTestBudget(models.BudgetCreate{})
+	internalAccount := suite.createTestAccount(models.AccountCreate{External: false, BudgetID: budget.Data.ID, Name: "TestTransactionsCreate Internal"})
+	externalAccount := suite.createTestAccount(models.AccountCreate{External: true, BudgetID: budget.Data.ID, Name: "TestTransactionsCreate External"})
+
+	tests := []struct {
+		name           string
+		transactions   []models.TransactionCreate
+		expectedStatus int
+		expectedErrors []string
+	}{
+		{
+			"One success, one fail",
+			[]models.TransactionCreate{
+				{
+					BudgetID: uuid.New(),
+					Amount:   decimal.NewFromFloat(17.23),
+					Note:     "v2 non-existing budget ID",
+				},
+				{
+					BudgetID:             budget.Data.ID,
+					SourceAccountID:      internalAccount.Data.ID,
+					DestinationAccountID: externalAccount.Data.ID,
+					Amount:               decimal.NewFromFloat(57.01),
+				},
+			},
+			http.StatusNotFound,
+			[]string{
+				"there is no Budget with this ID",
+				"",
+			},
+		},
+		{
+			"Both succeed",
+			[]models.TransactionCreate{
+				{
+					BudgetID:             budget.Data.ID,
+					SourceAccountID:      internalAccount.Data.ID,
+					DestinationAccountID: externalAccount.Data.ID,
+					Amount:               decimal.NewFromFloat(17.23),
+				},
+				{
+					BudgetID:             budget.Data.ID,
+					SourceAccountID:      internalAccount.Data.ID,
+					DestinationAccountID: externalAccount.Data.ID,
+					Amount:               decimal.NewFromFloat(57.01),
+				},
+			},
+			http.StatusCreated,
+			[]string{
+				"",
+				"",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			r := test.Request(suite.controller, t, http.MethodPost, "http://example.com/v2/transactions", tt.transactions)
+			assertHTTPStatus(t, &r, tt.expectedStatus)
+
+			var tr []controllers.ResponseTransactionV2
+			suite.decodeResponse(&r, &tr)
+
+			for i, transaction := range tr {
+				assert.Equal(t, tt.expectedErrors[i], transaction.Error)
+
+				if tt.expectedErrors[i] == "" {
+					assert.Equal(t, fmt.Sprintf("http://example.com/v2/transactions/%s", transaction.Data.ID), transaction.Data.Links.Self)
+				}
+			}
+		})
+	}
+}

--- a/pkg/models/transaction.go
+++ b/pkg/models/transaction.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/envelope-zero/backend/v3/internal/types"
-	"github.com/envelope-zero/backend/v3/pkg/database"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"gorm.io/gorm"
@@ -19,10 +18,6 @@ type Transaction struct {
 	SourceAccount      Account  `json:"-"`
 	DestinationAccount Account  `json:"-"`
 	Envelope           Envelope `json:"-"`
-
-	Links struct {
-		Self string `json:"self" example:"https://example.com/api/v1/transactions/d430d7c3-d14c-4712-9336-ee56965a6673"` // The transaction itself
-	} `json:"links" gorm:"-"` // Links for the transaction
 }
 
 type TransactionCreate struct {
@@ -60,21 +55,7 @@ func (t *Transaction) AfterFind(tx *gorm.DB) (err error) {
 
 	// Enforce dates to be in UTC
 	t.Date = t.Date.In(time.UTC)
-
-	t.links(tx)
 	return
-}
-
-// AfterSave also sets the links so that we do not need to
-// query the resource directly after creating or updating it.
-func (t *Transaction) AfterSave(tx *gorm.DB) (err error) {
-	t.links(tx)
-	return
-}
-
-func (t *Transaction) links(tx *gorm.DB) {
-	// Set links
-	t.Links.Self = fmt.Sprintf("%s/v1/transactions/%s", tx.Statement.Context.Value(database.ContextURL), t.ID)
 }
 
 // BeforeSave


### PR DESCRIPTION
This fixes the API v2 Transaction links by performing the same refactor
that was already performed for the Accounts.
