### PR TITLE
test: work around codecov token rate limit

### DIFF
--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -26,10 +26,11 @@ jobs:
         run: |
           go test ./... -race -covermode=atomic -coverprofile=coverage.out
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
-          files: coverage.out
+          name: coverage
+          path: coverage.out
 
         # This builds the binary and starts it. If it does not exit within 3 seconds, consider it
         # successful
@@ -40,10 +41,47 @@ jobs:
           make build
           API_URL=https://example.com/api timeout 3 ./backend || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; fi
 
+  codecov-upstream:
+    if: github.repository == 'envelope-zero/backend'
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+        with:
+          files: coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  codecov-fork:
+    if: github.repository != 'envelope-zero/backend'
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+        with:
+          files: coverage.out
+
   tag:
     runs-on: ubuntu-latest
     needs: test
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: github.repository == 'envelope-zero/backend' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
With this change, PRs in the repo use the `CODECOV_TOKEN` to upload
coverage to codecov, while PRs from forks will keep using the upload
via the public API, which is suffering from rate limiting issues.

We can't fix the rate limiting issues, but at least we can work around it
for PRs by maintainers for now.
