### PR TITLE
ci: add codecov token

### DIFF
--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -26,11 +26,11 @@ jobs:
         run: |
           go test ./... -race -covermode=atomic -coverprofile=coverage.out
 
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         with:
-          name: coverage
-          path: coverage.out
+          files: coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
 
         # This builds the binary and starts it. If it does not exit within 3 seconds, consider it
         # successful
@@ -40,43 +40,6 @@ jobs:
         run: |
           make build
           API_URL=https://example.com/api timeout 3 ./backend || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; fi
-
-  codecov-upstream:
-    if: github.repository == 'envelope-zero/backend'
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-      - name: Download coverage artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          name: coverage
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
-        with:
-          files: coverage.out
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-  codecov-fork:
-    if: github.repository != 'envelope-zero/backend'
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-      - name: Download coverage artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          name: coverage
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
-        with:
-          files: coverage.out
 
   tag:
     runs-on: ubuntu-latest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
   "gopls": {
     "formatting.gofumpt": true
   },
-  "editor.tabSize": 4
+  "editor.tabSize": 4,
+  "[yaml]": {
+    "editor.tabSize": 2
+  }
 }


### PR DESCRIPTION
Just use the codecov token since it seems to work even when empty.
