### PR TITLE
refactor: remove retries from code

### DIFF
--- a/pkg/controllers/account_v1.go
+++ b/pkg/controllers/account_v1.go
@@ -183,7 +183,7 @@ func (co Controller) CreateAccount(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Create(&account)) {
+	if !queryAndHandleErrors(c, co.DB.Create(&account)) {
 		return
 	}
 
@@ -235,7 +235,7 @@ func (co Controller) GetAccounts(c *gin.Context) {
 	query = stringFilters(co.DB, query, setFields, filter.Name, filter.Note, filter.Search)
 
 	var accounts []models.Account
-	if !queryWithRetry(c, query.Find(&accounts)) {
+	if !queryAndHandleErrors(c, query.Find(&accounts)) {
 		return
 	}
 
@@ -318,7 +318,7 @@ func (co Controller) UpdateAccount(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Model(&account).Select("", updateFields...).Updates(data)) {
+	if !queryAndHandleErrors(c, co.DB.Model(&account).Select("", updateFields...).Updates(data)) {
 		return
 	}
 
@@ -354,7 +354,7 @@ func (co Controller) DeleteAccount(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Delete(&account)) {
+	if !queryAndHandleErrors(c, co.DB.Delete(&account)) {
 		return
 	}
 

--- a/pkg/controllers/account_v2.go
+++ b/pkg/controllers/account_v2.go
@@ -137,7 +137,7 @@ func (co Controller) GetAccountsV2(c *gin.Context) {
 	query = stringFilters(co.DB, query, setFields, filter.Name, filter.Note, filter.Search)
 
 	var accounts []models.Account
-	if !queryWithRetry(c, query.Find(&accounts)) {
+	if !queryAndHandleErrors(c, query.Find(&accounts)) {
 		return
 	}
 

--- a/pkg/controllers/allocation.go
+++ b/pkg/controllers/allocation.go
@@ -126,7 +126,7 @@ func (co Controller) CreateAllocation(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Create(&allocation)) {
+	if !queryAndHandleErrors(c, co.DB.Create(&allocation)) {
 		return
 	}
 
@@ -163,7 +163,7 @@ func (co Controller) GetAllocations(c *gin.Context) {
 	}
 
 	var allocations []models.Allocation
-	if !queryWithRetry(c, co.DB.Where(&models.Allocation{
+	if !queryAndHandleErrors(c, co.DB.Where(&models.Allocation{
 		AllocationCreate: create,
 	}, queryFields...).Find(&allocations)) {
 		return
@@ -242,7 +242,7 @@ func (co Controller) UpdateAllocation(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Model(&allocation).Select("", updateFields...).Updates(data)) {
+	if !queryAndHandleErrors(c, co.DB.Model(&allocation).Select("", updateFields...).Updates(data)) {
 		return
 	}
 
@@ -273,7 +273,7 @@ func (co Controller) DeleteAllocation(c *gin.Context) {
 	}
 
 	// Allocations are hard deleted instantly to avoid conflicts for the UNIQUE(id,month)
-	if !queryWithRetry(c, co.DB.Unscoped().Delete(&allocation)) {
+	if !queryAndHandleErrors(c, co.DB.Unscoped().Delete(&allocation)) {
 		return
 	}
 

--- a/pkg/controllers/category.go
+++ b/pkg/controllers/category.go
@@ -118,7 +118,7 @@ func (co Controller) CreateCategory(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Create(&category)) {
+	if !queryAndHandleErrors(c, co.DB.Create(&category)) {
 		return
 	}
 
@@ -163,7 +163,7 @@ func (co Controller) GetCategories(c *gin.Context) {
 	query = stringFilters(co.DB, query, setFields, filter.Name, filter.Note, filter.Search)
 
 	var categories []models.Category
-	if !queryWithRetry(c, query.Find(&categories)) {
+	if !queryAndHandleErrors(c, query.Find(&categories)) {
 		return
 	}
 
@@ -243,7 +243,7 @@ func (co Controller) UpdateCategory(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Model(&category).Select("", updateFields...).Updates(data)) {
+	if !queryAndHandleErrors(c, co.DB.Model(&category).Select("", updateFields...).Updates(data)) {
 		return
 	}
 
@@ -274,7 +274,7 @@ func (co Controller) DeleteCategory(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Delete(&category)) {
+	if !queryAndHandleErrors(c, co.DB.Delete(&category)) {
 		return
 	}
 
@@ -285,7 +285,7 @@ func (co Controller) DeleteCategory(c *gin.Context) {
 func (co Controller) getCategoryResources(c *gin.Context, id uuid.UUID) ([]models.Category, bool) {
 	var categories []models.Category
 
-	if !queryWithRetry(c, co.DB.Where(&models.Category{
+	if !queryAndHandleErrors(c, co.DB.Where(&models.Category{
 		CategoryCreate: models.CategoryCreate{
 			BudgetID: id,
 		},

--- a/pkg/controllers/database.go
+++ b/pkg/controllers/database.go
@@ -1,76 +1,18 @@
 package controllers
 
 import (
-	"errors"
-	"strings"
-
 	"github.com/envelope-zero/backend/v3/pkg/httperrors"
 	"github.com/gin-gonic/gin"
-	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 )
 
-// TryDBConnect checks the database error to decide
-// if a reconnection attempt makes sense and executes
-// the reconnection.
-// It returns nil for success and an error if reconnecting
-// the database is not possible or not a sensible decision
-//
-// In cases where the database file might have been deleted,
-// we err on the side of caution and do *not* reconnect the
-// database so that we do not have two states that need to
-// be merged manually by the user afterwards
-//
-// TODO: Actually implement the reconnection logic. This is
-// not yet done as we currently do not store.
-func TryDBConnect(e error) error {
-	// If there is no error or the error is a closed database, we try to connect
-	// to the database.
-	//
-	// A closed database will happen if the database is not initialized correctly
-	// or there was an error on the intialization
-	if e == nil || strings.Contains(e.Error(), "sql: database is closed") {
-		log.Warn().Str("db", "database is closed, please restart the backend").Msg("TryDBConnect")
-		return errors.New("database is closed")
-
-		// TODO: Implement something like the following for the reconenction
-		// log.Warn().Str("db", "(re)connecting database").Msg("TryDBConnect")
-		// err := database.Database()
-		// if err != nil {
-		// 	return err
-		// }
-
-		// return nil
-	}
-
-	// We do not try to connect to the database here. This is due to the database
-	// file possibly having been deleted
-	if strings.Contains(e.Error(), "attempt to write a readonly database (1032)") {
-		log.Error().Str("db", "database is read-only, not attempting to reconnect. Verify that the database file has not been deleted and restart the backend.").Msg("TryDBConnect")
-		return errors.New("database is read-only")
-	}
-
-	if e != gorm.ErrRecordNotFound {
-		log.Info().Err(e).Msg("Database")
-	}
-	return e
-}
-
-// queryWithRetry tries to execute a query. If it fails, it
+// queryAndHandleErrors tries to execute a query. If it fails, it
 // tries to reconnect the database and retries the query once.
-func queryWithRetry(c *gin.Context, tx *gorm.DB, notFoundMsg ...string) bool {
+func queryAndHandleErrors(c *gin.Context, tx *gorm.DB, notFoundMsg ...string) bool {
 	err := tx.Error
 	if err != nil {
-		if TryDBConnect(err) != nil {
-			httperrors.Handler(c, err, notFoundMsg...)
-			return false
-		}
-
-		err = tx.Error
-		if err != nil {
-			httperrors.Handler(c, err, notFoundMsg...)
-			return false
-		}
+		httperrors.Handler(c, err, notFoundMsg...)
+		return false
 	}
 
 	return true

--- a/pkg/controllers/envelope.go
+++ b/pkg/controllers/envelope.go
@@ -125,7 +125,7 @@ func (co Controller) CreateEnvelope(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Create(&envelope)) {
+	if !queryAndHandleErrors(c, co.DB.Create(&envelope)) {
 		return
 	}
 
@@ -168,7 +168,7 @@ func (co Controller) GetEnvelopes(c *gin.Context) {
 	query = stringFilters(co.DB, query, setFields, filter.Name, filter.Note, filter.Search)
 
 	var envelopes []models.Envelope
-	if !queryWithRetry(c, query.Find(&envelopes)) {
+	if !queryAndHandleErrors(c, query.Find(&envelopes)) {
 		return
 	}
 
@@ -291,7 +291,7 @@ func (co Controller) UpdateEnvelope(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Model(&envelope).Select("", updateFields...).Updates(data)) {
+	if !queryAndHandleErrors(c, co.DB.Model(&envelope).Select("", updateFields...).Updates(data)) {
 		return
 	}
 
@@ -321,7 +321,7 @@ func (co Controller) DeleteEnvelope(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Delete(&envelope)) {
+	if !queryAndHandleErrors(c, co.DB.Delete(&envelope)) {
 		return
 	}
 

--- a/pkg/controllers/generics.go
+++ b/pkg/controllers/generics.go
@@ -20,7 +20,7 @@ func getResourceByIDAndHandleErrors[T models.Model](c *gin.Context, co Controlle
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Where(
+	if !queryAndHandleErrors(c, co.DB.Where(
 		map[string]interface{}{"ID": id},
 	).First(&resource), fmt.Sprintf("No %s found for the specified ID", resource.Self())) {
 		return

--- a/pkg/controllers/match_rule.go
+++ b/pkg/controllers/match_rule.go
@@ -166,7 +166,7 @@ func (co Controller) GetMatchRules(c *gin.Context) {
 	}
 
 	var matchRules []models.MatchRule
-	if !queryWithRetry(c, co.DB.Where(&models.MatchRule{
+	if !queryAndHandleErrors(c, co.DB.Where(&models.MatchRule{
 		MatchRuleCreate: create,
 	}, queryFields...).Find(&matchRules)) {
 		return
@@ -245,7 +245,7 @@ func (co Controller) UpdateMatchRule(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Model(&matchRule).Select("", updateFields...).Updates(data)) {
+	if !queryAndHandleErrors(c, co.DB.Model(&matchRule).Select("", updateFields...).Updates(data)) {
 		return
 	}
 
@@ -276,7 +276,7 @@ func (co Controller) DeleteMatchRule(c *gin.Context) {
 	}
 
 	// MatchRules are hard deleted instantly to avoid conflicts for the UNIQUE(id,month)
-	if !queryWithRetry(c, co.DB.Unscoped().Delete(&matchRule)) {
+	if !queryAndHandleErrors(c, co.DB.Unscoped().Delete(&matchRule)) {
 		return
 	}
 

--- a/pkg/controllers/month.go
+++ b/pkg/controllers/month.go
@@ -120,7 +120,7 @@ func (co Controller) DeleteAllocations(c *gin.Context) {
 	// We query for all allocations here
 	var allocations []models.Allocation
 
-	if !queryWithRetry(c, co.DB.
+	if !queryAndHandleErrors(c, co.DB.
 		Joins("JOIN envelopes ON envelopes.id = allocations.envelope_id").
 		Joins("JOIN categories ON categories.id = envelopes.category_id").
 		Joins("JOIN budgets on budgets.id = categories.budget_id").
@@ -131,7 +131,7 @@ func (co Controller) DeleteAllocations(c *gin.Context) {
 	}
 
 	for _, allocation := range allocations {
-		if !queryWithRetry(c, co.DB.Unscoped().Delete(&allocation)) {
+		if !queryAndHandleErrors(c, co.DB.Unscoped().Delete(&allocation)) {
 			return
 		}
 	}
@@ -181,7 +181,7 @@ func (co Controller) SetAllocations(c *gin.Context) {
 
 	// Get all envelope IDs and allocation amounts where there is no allocation
 	// for the request month, but one for the last month
-	if !queryWithRetry(c, co.DB.
+	if !queryAndHandleErrors(c, co.DB.
 		Joins("JOIN allocations ON allocations.envelope_id = envelopes.id AND envelopes.hidden IS FALSE AND allocations.month = ? AND NOT EXISTS(?)", pastMonth, queryCurrentMonth).
 		Select("envelopes.id, allocations.amount").
 		Table("envelopes").
@@ -202,7 +202,7 @@ func (co Controller) SetAllocations(c *gin.Context) {
 			continue
 		}
 
-		if !queryWithRetry(c, co.DB.Create(&models.Allocation{
+		if !queryAndHandleErrors(c, co.DB.Create(&models.Allocation{
 			AllocationCreate: models.AllocationCreate{
 				EnvelopeID: allocation.EnvelopeID,
 				Amount:     amount,

--- a/pkg/controllers/month_config.go
+++ b/pkg/controllers/month_config.go
@@ -168,7 +168,7 @@ func (co Controller) GetMonthConfigs(c *gin.Context) {
 	}
 
 	var mConfigs []models.MonthConfig
-	if !queryWithRetry(c, co.DB.Where(&models.MonthConfig{
+	if !queryAndHandleErrors(c, co.DB.Where(&models.MonthConfig{
 		EnvelopeID: parsed.EnvelopeID,
 		Month:      parsed.Month,
 	}, queryFields...).Find(&mConfigs)) {
@@ -287,7 +287,7 @@ func (co Controller) UpdateMonthConfig(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Model(&mConfig).Select("", updateFields...).Updates(data)) {
+	if !queryAndHandleErrors(c, co.DB.Model(&mConfig).Select("", updateFields...).Updates(data)) {
 		return
 	}
 
@@ -330,7 +330,7 @@ func (co Controller) DeleteMonthConfig(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Delete(&mConfig)) {
+	if !queryAndHandleErrors(c, co.DB.Delete(&mConfig)) {
 		return
 	}
 
@@ -346,7 +346,7 @@ func (co Controller) getMonthConfigResource(c *gin.Context, envelopeID uuid.UUID
 
 	var mConfig models.MonthConfig
 
-	if !queryWithRetry(c, co.DB.First(&mConfig, &models.MonthConfig{
+	if !queryAndHandleErrors(c, co.DB.First(&mConfig, &models.MonthConfig{
 		EnvelopeID: envelopeID,
 		Month:      month,
 	}), "No MonthConfig found for the Envelope and month specified") {

--- a/pkg/controllers/rename_rule.go
+++ b/pkg/controllers/rename_rule.go
@@ -178,7 +178,7 @@ func (co Controller) GetRenameRules(c *gin.Context) {
 	}
 
 	var renameRules []models.MatchRule
-	if !queryWithRetry(c, co.DB.Where(&models.MatchRule{
+	if !queryAndHandleErrors(c, co.DB.Where(&models.MatchRule{
 		MatchRuleCreate: create,
 	}, queryFields...).Find(&renameRules)) {
 		return
@@ -259,7 +259,7 @@ func (co Controller) UpdateRenameRule(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Model(&renameRule).Select("", updateFields...).Updates(data)) {
+	if !queryAndHandleErrors(c, co.DB.Model(&renameRule).Select("", updateFields...).Updates(data)) {
 		return
 	}
 
@@ -291,7 +291,7 @@ func (co Controller) DeleteRenameRule(c *gin.Context) {
 	}
 
 	// RenameRules are hard deleted instantly to avoid conflicts for the UNIQUE(id,month)
-	if !queryWithRetry(c, co.DB.Unscoped().Delete(&renameRule)) {
+	if !queryAndHandleErrors(c, co.DB.Unscoped().Delete(&renameRule)) {
 		return
 	}
 

--- a/pkg/controllers/transaction_v1.go
+++ b/pkg/controllers/transaction_v1.go
@@ -297,7 +297,7 @@ func (co Controller) GetTransactions(c *gin.Context) {
 	}
 
 	var transactions []models.Transaction
-	if !queryWithRetry(c, query.Find(&transactions)) {
+	if !queryAndHandleErrors(c, query.Find(&transactions)) {
 		return
 	}
 
@@ -417,7 +417,7 @@ func (co Controller) UpdateTransaction(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Model(&transaction).Select("", updateFields...).Updates(data)) {
+	if !queryAndHandleErrors(c, co.DB.Model(&transaction).Select("", updateFields...).Updates(data)) {
 		return
 	}
 
@@ -452,7 +452,7 @@ func (co Controller) DeleteTransaction(c *gin.Context) {
 		return
 	}
 
-	if !queryWithRetry(c, co.DB.Delete(&transaction)) {
+	if !queryAndHandleErrors(c, co.DB.Delete(&transaction)) {
 		return
 	}
 


### PR DESCRIPTION
With this, retries for DB failures are removed. This implementation has
never been completed.

Instead, use the `/healthz` endpoint to detect an unhealthy backend and
restart it.

Resolves #707. 
