### PR TITLE
refactor: move REST attributes to controller

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -4408,6 +4408,56 @@ const docTemplate = `{
                 }
             }
         },
+        "controllers.MatchRule": {
+            "type": "object",
+            "properties": {
+                "accountId": {
+                    "description": "The account to map matching transactions to",
+                    "type": "string",
+                    "example": "f9e873c2-fb96-4367-bfb6-7ecd9bf4a6b5"
+                },
+                "createdAt": {
+                    "description": "Time the resource was created",
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
+                "id": {
+                    "description": "UUID for the resource",
+                    "type": "string",
+                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
+                },
+                "links": {
+                    "type": "object",
+                    "properties": {
+                        "self": {
+                            "description": "The match rule itself",
+                            "type": "string",
+                            "example": "https://example.com/api/v2/match-rules/95685c82-53c6-455d-b235-f49960b73b21"
+                        }
+                    }
+                },
+                "match": {
+                    "description": "The matching applied to the opposite account. This is a glob pattern. Multiple globs are allowed. Globbing is case sensitive.",
+                    "type": "string",
+                    "example": "Bank*"
+                },
+                "priority": {
+                    "description": "The priority of the match rule",
+                    "type": "integer",
+                    "example": 3
+                },
+                "updatedAt": {
+                    "description": "Last time the resource was updated",
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
+                }
+            }
+        },
         "controllers.MonthConfigListResponse": {
             "type": "object",
             "properties": {
@@ -4475,10 +4525,10 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "data": {
-                    "description": "This field contains the model data",
+                    "description": "This field contains the MatchRule data",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/models.MatchRule"
+                            "$ref": "#/definitions/controllers.MatchRule"
                         }
                     ]
                 },
@@ -4493,7 +4543,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "data": {
-                    "description": "This field contains the transaction data",
+                    "description": "This field contains the Transaction data",
                     "allOf": [
                         {
                             "$ref": "#/definitions/controllers.TransactionV2"
@@ -5191,16 +5241,6 @@ const docTemplate = `{
                     "description": "UUID for the resource",
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
-                },
-                "links": {
-                    "type": "object",
-                    "properties": {
-                        "self": {
-                            "description": "The match rule itself",
-                            "type": "string",
-                            "example": "https://example.com/api/v2/match-rules/95685c82-53c6-455d-b235-f49960b73b21"
-                        }
-                    }
                 },
                 "match": {
                     "description": "The matching applied to the opposite account. This is a glob pattern. Multiple globs are allowed. Globbing is case sensitive.",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -4397,6 +4397,56 @@
                 }
             }
         },
+        "controllers.MatchRule": {
+            "type": "object",
+            "properties": {
+                "accountId": {
+                    "description": "The account to map matching transactions to",
+                    "type": "string",
+                    "example": "f9e873c2-fb96-4367-bfb6-7ecd9bf4a6b5"
+                },
+                "createdAt": {
+                    "description": "Time the resource was created",
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
+                "id": {
+                    "description": "UUID for the resource",
+                    "type": "string",
+                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
+                },
+                "links": {
+                    "type": "object",
+                    "properties": {
+                        "self": {
+                            "description": "The match rule itself",
+                            "type": "string",
+                            "example": "https://example.com/api/v2/match-rules/95685c82-53c6-455d-b235-f49960b73b21"
+                        }
+                    }
+                },
+                "match": {
+                    "description": "The matching applied to the opposite account. This is a glob pattern. Multiple globs are allowed. Globbing is case sensitive.",
+                    "type": "string",
+                    "example": "Bank*"
+                },
+                "priority": {
+                    "description": "The priority of the match rule",
+                    "type": "integer",
+                    "example": 3
+                },
+                "updatedAt": {
+                    "description": "Last time the resource was updated",
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
+                }
+            }
+        },
         "controllers.MonthConfigListResponse": {
             "type": "object",
             "properties": {
@@ -4464,10 +4514,10 @@
             "type": "object",
             "properties": {
                 "data": {
-                    "description": "This field contains the model data",
+                    "description": "This field contains the MatchRule data",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/models.MatchRule"
+                            "$ref": "#/definitions/controllers.MatchRule"
                         }
                     ]
                 },
@@ -4482,7 +4532,7 @@
             "type": "object",
             "properties": {
                 "data": {
-                    "description": "This field contains the transaction data",
+                    "description": "This field contains the Transaction data",
                     "allOf": [
                         {
                             "$ref": "#/definitions/controllers.TransactionV2"
@@ -5180,16 +5230,6 @@
                     "description": "UUID for the resource",
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
-                },
-                "links": {
-                    "type": "object",
-                    "properties": {
-                        "self": {
-                            "description": "The match rule itself",
-                            "type": "string",
-                            "example": "https://example.com/api/v2/match-rules/95685c82-53c6-455d-b235-f49960b73b21"
-                        }
-                    }
                 },
                 "match": {
                     "description": "The matching applied to the opposite account. This is a glob pattern. Multiple globs are allowed. Globbing is case sensitive.",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -425,6 +425,45 @@ definitions:
           $ref: '#/definitions/importer.TransactionPreview'
         type: array
     type: object
+  controllers.MatchRule:
+    properties:
+      accountId:
+        description: The account to map matching transactions to
+        example: f9e873c2-fb96-4367-bfb6-7ecd9bf4a6b5
+        type: string
+      createdAt:
+        description: Time the resource was created
+        example: "2022-04-02T19:28:44.491514Z"
+        type: string
+      deletedAt:
+        description: Time the resource was marked as deleted
+        example: "2022-04-22T21:01:05.058161Z"
+        type: string
+      id:
+        description: UUID for the resource
+        example: 65392deb-5e92-4268-b114-297faad6cdce
+        type: string
+      links:
+        properties:
+          self:
+            description: The match rule itself
+            example: https://example.com/api/v2/match-rules/95685c82-53c6-455d-b235-f49960b73b21
+            type: string
+        type: object
+      match:
+        description: The matching applied to the opposite account. This is a glob
+          pattern. Multiple globs are allowed. Globbing is case sensitive.
+        example: Bank*
+        type: string
+      priority:
+        description: The priority of the match rule
+        example: 3
+        type: integer
+      updatedAt:
+        description: Last time the resource was updated
+        example: "2022-04-17T20:14:01.048145Z"
+        type: string
+    type: object
   controllers.MonthConfigListResponse:
     properties:
       data:
@@ -466,8 +505,8 @@ definitions:
     properties:
       data:
         allOf:
-        - $ref: '#/definitions/models.MatchRule'
-        description: This field contains the model data
+        - $ref: '#/definitions/controllers.MatchRule'
+        description: This field contains the MatchRule data
       error:
         description: This field contains a human readable error message
         example: A human readable error message
@@ -478,7 +517,7 @@ definitions:
       data:
         allOf:
         - $ref: '#/definitions/controllers.TransactionV2'
-        description: This field contains the transaction data
+        description: This field contains the Transaction data
       error:
         description: This field contains a human readable error message
         example: A human readable error message
@@ -1032,13 +1071,6 @@ definitions:
         description: UUID for the resource
         example: 65392deb-5e92-4268-b114-297faad6cdce
         type: string
-      links:
-        properties:
-          self:
-            description: The match rule itself
-            example: https://example.com/api/v2/match-rules/95685c82-53c6-455d-b235-f49960b73b21
-            type: string
-        type: object
       match:
         description: The matching applied to the opposite account. This is a glob
           pattern. Multiple globs are allowed. Globbing is case sensitive.

--- a/pkg/controllers/category.go
+++ b/pkg/controllers/category.go
@@ -14,11 +14,11 @@ import (
 
 type Category struct {
 	models.Category
-	Envelopes []Envelope `json:"envelopes" gorm:"-"` // Envelopes for the category
+	Envelopes []Envelope `json:"envelopes"` // Envelopes for the category
 	Links     struct {
 		Self      string `json:"self" example:"https://example.com/api/v1/categories/3b1ea324-d438-4419-882a-2fc91d71772f"`              // The category itself
 		Envelopes string `json:"envelopes" example:"https://example.com/api/v1/envelopes?category=3b1ea324-d438-4419-882a-2fc91d71772f"` // Envelopes for this category
-	} `json:"links" gorm:"-"`
+	} `json:"links"`
 }
 
 func (c *Category) links(context *gin.Context) {

--- a/pkg/controllers/envelope.go
+++ b/pkg/controllers/envelope.go
@@ -20,7 +20,7 @@ type Envelope struct {
 		Allocations  string `json:"allocations" example:"https://example.com/api/v1/allocations?envelope=45b6b5b9-f746-4ae9-b77b-7688b91f8166"`   // the envelope's allocations
 		Month        string `json:"month" example:"https://example.com/api/v1/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/YYYY-MM"`            // Month information endpoint. This will always end in 'YYYY-MM' for clients to use replace with actual numbers.
 		Transactions string `json:"transactions" example:"https://example.com/api/v1/transactions?envelope=45b6b5b9-f746-4ae9-b77b-7688b91f8166"` // The envelope's transactions
-	} `json:"links" gorm:"-"` // Links to related resources
+	} `json:"links"` // Links to related resources
 }
 
 func (e *Envelope) links(c *gin.Context) {

--- a/pkg/controllers/match_rule_test.go
+++ b/pkg/controllers/match_rule_test.go
@@ -1,16 +1,19 @@
 package controllers_test
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
 	"github.com/envelope-zero/backend/v3/pkg/controllers"
 	"github.com/envelope-zero/backend/v3/pkg/models"
 	"github.com/envelope-zero/backend/v3/test"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 )
 
 // TODO: migrate all createTest* methods to functions with *testing.T as first argument.
-func (suite *TestSuiteStandard) createTestMatchRule(t *testing.T, c models.MatchRuleCreate, expectedStatus ...int) models.MatchRule {
+func (suite *TestSuiteStandard) createTestMatchRule(t *testing.T, c models.MatchRuleCreate, expectedStatus ...int) controllers.MatchRule {
 	// Default to 201 Creted as expected status
 	if len(expectedStatus) == 0 {
 		expectedStatus = append(expectedStatus, http.StatusCreated)
@@ -25,4 +28,91 @@ func (suite *TestSuiteStandard) createTestMatchRule(t *testing.T, c models.Match
 	suite.decodeResponse(&r, &responseRules)
 
 	return responseRules[0].Data
+}
+
+func (suite *TestSuiteStandard) TestOptionsMatchRule() {
+	path := fmt.Sprintf("%s/%s", "http://example.com/v2/match-rules", uuid.New())
+	r := test.Request(suite.controller, suite.T(), http.MethodOptions, path, "")
+	assertHTTPStatus(suite.T(), &r, http.StatusNotFound)
+
+	r = test.Request(suite.controller, suite.T(), http.MethodOptions, "http://example.com/v2/match-rules/NotParseableAsUUID", "")
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+
+	path = suite.createTestMatchRule(suite.T(), models.MatchRuleCreate{
+		AccountID: suite.createTestAccount(models.AccountCreate{}).Data.ID,
+	},
+	).Links.Self
+
+	r = test.Request(suite.controller, suite.T(), http.MethodOptions, path, "")
+	assertHTTPStatus(suite.T(), &r, http.StatusNoContent)
+}
+
+func (suite *TestSuiteStandard) TestMatchRuleCreate() {
+	a := suite.createTestAccount(models.AccountCreate{Name: "TestMatchRuleCreate"})
+
+	tests := []struct {
+		name           string
+		create         []models.MatchRuleCreate
+		expectedErrors []string
+		expectedStatus int
+	}{
+		{
+			"All successful",
+			[]models.MatchRuleCreate{
+				{
+					Priority:  10,
+					Match:     "Some Match*",
+					AccountID: a.Data.ID,
+				},
+				{
+					Priority:  10,
+					Match:     "Bank*",
+					AccountID: a.Data.ID,
+				},
+			},
+			[]string{
+				"",
+				"",
+			},
+			http.StatusCreated,
+		},
+		{
+			"Second fails",
+			[]models.MatchRuleCreate{
+				{
+					Priority:  10,
+					Match:     "Bank*",
+					AccountID: a.Data.ID,
+				},
+				{
+					Priority:  10,
+					Match:     "Bank*",
+					AccountID: uuid.New(),
+				},
+			},
+			[]string{
+				"",
+				"there is no Account with this ID",
+			},
+			http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			r := test.Request(suite.controller, t, http.MethodPost, "http://example.com/v2/match-rules", tt.create)
+			assertHTTPStatus(t, &r, tt.expectedStatus)
+
+			var tr []controllers.ResponseMatchRule
+			suite.decodeResponse(&r, &tr)
+
+			for i, r := range tr {
+				assert.Equal(t, tt.expectedErrors[i], r.Error)
+
+				if tt.expectedErrors[i] == "" {
+					assert.Equal(t, fmt.Sprintf("http://example.com/v2/match-rules/%s", r.Data.ID), r.Data.Links.Self)
+				}
+			}
+		})
+	}
 }

--- a/pkg/controllers/rename_rule.go
+++ b/pkg/controllers/rename_rule.go
@@ -127,8 +127,8 @@ func (co Controller) CreateRenameRules(c *gin.Context) {
 	// The final http status. Will be modified when errors occur
 	status := http.StatusCreated
 
-	for _, o := range renameRules {
-		o, err := co.createRenameRule(c, o)
+	for _, create := range renameRules {
+		m, err := co.createRenameRule(c, create)
 
 		// Append the error or the successfully created transaction to the response list
 		if !err.Nil() {
@@ -140,6 +140,10 @@ func (co Controller) CreateRenameRules(c *gin.Context) {
 				status = err.Status
 			}
 		} else {
+			o, ok := co.getMatchRule(c, m.ID)
+			if !ok {
+				return
+			}
 			r = append(r, ResponseMatchRule{Data: o})
 		}
 	}

--- a/pkg/controllers/responses.go
+++ b/pkg/controllers/responses.go
@@ -3,16 +3,12 @@ package controllers
 // We use one type per Endpoint so that swagger can parse them - it cannot handle generics yet, see
 // https://github.com/swaggo/swag/issues/1170
 
-import (
-	"github.com/envelope-zero/backend/v3/pkg/models"
-)
-
 type ResponseTransactionV2 struct {
 	Error string        `json:"error" example:"A human readable error message"` // This field contains a human readable error message
-	Data  TransactionV2 `json:"data"`                                           // This field contains the transaction data
+	Data  TransactionV2 `json:"data"`                                           // This field contains the Transaction data
 }
 
 type ResponseMatchRule struct {
-	Error string           `json:"error" example:"A human readable error message"` // This field contains a human readable error message
-	Data  models.MatchRule `json:"data"`                                           // This field contains the model data
+	Error string    `json:"error" example:"A human readable error message"` // This field contains a human readable error message
+	Data  MatchRule `json:"data"`                                           // This field contains the MatchRule data
 }

--- a/pkg/models/match_rule.go
+++ b/pkg/models/match_rule.go
@@ -1,19 +1,12 @@
 package models
 
 import (
-	"fmt"
-
-	"github.com/envelope-zero/backend/v3/pkg/database"
 	"github.com/google/uuid"
-	"gorm.io/gorm"
 )
 
 type MatchRule struct {
 	DefaultModel
 	MatchRuleCreate
-	Links struct {
-		Self string `json:"self" example:"https://example.com/api/v2/match-rules/95685c82-53c6-455d-b235-f49960b73b21"` // The match rule itself
-	} `json:"links" gorm:"-"`
 }
 
 type MatchRuleCreate struct {
@@ -24,18 +17,4 @@ type MatchRuleCreate struct {
 
 func (r MatchRule) Self() string {
 	return "Match Rule"
-}
-
-func (r *MatchRule) links(tx *gorm.DB) {
-	r.Links.Self = fmt.Sprintf("%s/v2/match-rules/%s", tx.Statement.Context.Value(database.ContextURL), r.ID)
-}
-
-func (r *MatchRule) AfterSave(tx *gorm.DB) (err error) {
-	r.links(tx)
-	return
-}
-
-func (r *MatchRule) AfterFind(tx *gorm.DB) (err error) {
-	r.links(tx)
-	return
 }


### PR DESCRIPTION
This continues the cleanup refactor with the MatchRules
