### PR TITLE
fix: ignore transactions with amount of 0 on import

### DIFF
--- a/pkg/importer/parser/ynab-import/parse.go
+++ b/pkg/importer/parser/ynab-import/parse.go
@@ -87,8 +87,9 @@ func Parse(f io.Reader, account models.Account) ([]importer.TransactionPreview, 
 			t.Transaction.Amount = amount
 		}
 
+		// Ignore transactions that have an amount of 0
 		if t.Transaction.Amount.IsZero() {
-			return csvReadError(reader, errors.New("the amount for a transaction must not be 0"))
+			continue
 		}
 
 		transactions = append(transactions, t)

--- a/pkg/importer/parser/ynab-import/parse_test.go
+++ b/pkg/importer/parser/ynab-import/parse_test.go
@@ -65,7 +65,6 @@ func TestErrors(t *testing.T) {
 		{"error-decimal-inflow.csv", "error in line 4 of the CSV: inflow could not be parsed to a decimal"},
 		{"error-decimal-outflow.csv", "error in line 2 of the CSV: outflow could not be parsed to a decimal"},
 		{"error-missing-amount.csv", "error in line 3 of the CSV: no amount is set for the transaction"},
-		{"error-amount-zero.csv", "error in line 4 of the CSV: the amount for a transaction must not be 0"},
 		{"error-outflow-and-inflow.csv", "error in line 2 of the CSV: both outflow and inflow are set for the transaction"},
 	}
 

--- a/testdata/importer/ynab-import/bank2ynab-ynap.csv
+++ b/testdata/importer/ynab-import/bank2ynab-ynap.csv
@@ -1,2 +1,3 @@
 Category,Payee,Date,Inflow,Outflow
 ,exampleIssuer,11/06/2023,,82.8
+,Someone Sending 0 money,11/10/2023,,0

--- a/testdata/importer/ynab-import/error-amount-zero.csv
+++ b/testdata/importer/ynab-import/error-amount-zero.csv
@@ -1,4 +1,0 @@
-Date,Payee,Memo,Outflow,Inflow
-04/01/2019,,Test,59.97,
-04/01/2019,,ISHSII-MSCI EUR.SRI EOACC WPKNR: A1H7ZS ISIN: IE00B52VJ196,119.98,
-04/01/2019,Leo Bernard,Lastschrift Sparplan 1,,0.00


### PR DESCRIPTION
This fixes a bug where imports failed on a transaction with an amount of 0.
Since the backend can silently ignore these transactions, this change introduces
that exact behaviour.
