### PR TITLE
fix: show transactions with envelopes error to user when updating account

### DIFF
--- a/pkg/httperrors/errors.go
+++ b/pkg/httperrors/errors.go
@@ -70,6 +70,11 @@ func DBError(c *gin.Context, err error) ErrorStatus {
 		return ErrorStatus{Status: http.StatusBadRequest, Err: err}
 	}
 
+	// Account cannot be on budget because transactions have envelopes
+	if strings.Contains(err.Error(), "the account cannot be set to on budget because") {
+		return ErrorStatus{Status: http.StatusBadRequest, Err: err}
+	}
+
 	// Account name must be unique per Budget
 	if strings.Contains(err.Error(), "UNIQUE constraint failed: accounts.name, accounts.budget_id") {
 		return ErrorStatus{Status: http.StatusBadRequest, Err: errors.New("the account name must be unique for the budget")}

--- a/pkg/httperrors/errors_test.go
+++ b/pkg/httperrors/errors_test.go
@@ -172,6 +172,7 @@ func TestDatabaseErrorMessages(t *testing.T) {
 		msg  string
 	}{
 		{http.StatusBadRequest, "availability month must not be earlier than the month of the transaction, transaction date: 2023-10-22, available month 2023-09", "availability month must not be earlier than the month of the transaction, transaction date: 2023-10-22, available month 2023-09"},
+		{http.StatusBadRequest, "the account cannot be set to on budget because the following transactions have an envelope set", "the account cannot be set to on budget because the following transactions have an envelope set"},
 		{http.StatusBadRequest, "CHECK constraint failed: source_destination_different", "source and destination accounts for a transaction must be different"},
 		{http.StatusBadRequest, "UNIQUE constraint failed: accounts.name, accounts.budget_id", "the account name must be unique for the budget"},
 		{http.StatusBadRequest, "UNIQUE constraint failed: categories.name, categories.budget_id", "the category name must be unique for the budget"},


### PR DESCRIPTION
This fixes an issue where the error was not surfaced through the API, but
only available in the backend log.
