### PR TITLE
fix: transaction sorting now takes time of day and creation time into account

### DIFF
--- a/pkg/controllers/transaction_v1.go
+++ b/pkg/controllers/transaction_v1.go
@@ -247,7 +247,7 @@ func (co Controller) GetTransactions(c *gin.Context) {
 	}
 
 	var query *gorm.DB
-	query = co.DB.Order("date(date) DESC").Where(&models.Transaction{
+	query = co.DB.Order("datetime(date) DESC, datetime(created_at) DESC").Where(&models.Transaction{
 		TransactionCreate: create,
 	}, queryFields...)
 


### PR DESCRIPTION
Before this fix, transactions would be sorted correctly by date, but
transactions later in a day would be after transactions earlier in the day.

When transactions were added for the exact same time (typically when importing),
sorting was undefined. Sorting for transactions at the same time now is "newest first"
by creation time, putting transactions added later earlier in the list.

Since the sorting is "newest first", this was wrong.

Sorting takes place with second precision, meaning that any sub-second differences
are ignored in sorting. This is a limitation of the sqlite `datetime` function.
