### PR TITLE
feat: add /v3/transactions collection endpoint with GET support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ VERSION ?= $(shell git rev-parse HEAD)
 build:
 	go build -ldflags "-X github.com/envelope-zero/backend/v3/pkg/router.version=${VERSION}"
 
-
 .PHONY: docs
 docs:
 	swag init --parseDependency --output ./api

--- a/api/docs.go
+++ b/api/docs.go
@@ -3800,6 +3800,177 @@ const docTemplate = `{
                 }
             }
         },
+        "/v3": {
+            "get": {
+                "description": "Returns general information about the v3 API",
+                "tags": [
+                    "v3"
+                ],
+                "summary": "v3 API",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/router.V3Response"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "tags": [
+                    "v3"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/v3/transactions": {
+            "get": {
+                "description": "Returns a list of transactions",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Transactions"
+                ],
+                "summary": "Get transactions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Date of the transaction. Ignores exact time, matches on the day of the RFC3339 timestamp provided.",
+                        "name": "date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Transactions at and after this date. Ignores exact time, matches on the day of the RFC3339 timestamp provided.",
+                        "name": "fromDate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Transactions before and at this date. Ignores exact time, matches on the day of the RFC3339 timestamp provided.",
+                        "name": "untilDate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by amount",
+                        "name": "amount",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Amount less than or equal to this",
+                        "name": "amountLessOrEqual",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Amount more than or equal to this",
+                        "name": "amountMoreOrEqual",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by note",
+                        "name": "note",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by budget ID",
+                        "name": "budget",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by ID of associated account, regardeless of source or destination",
+                        "name": "account",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by source account ID",
+                        "name": "source",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by destination account ID",
+                        "name": "destination",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by envelope ID",
+                        "name": "envelope",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Reconcilication state in source account",
+                        "name": "reconciledSource",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Reconcilication state in destination account",
+                        "name": "reconciledDestination",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The offset of the first Transaction returned. Defaults to 0.",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": " Maximum number of transactions to return. Defaults to 50.",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.TransactionListResponseV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "tags": [
+                    "Transactions"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
         "/version": {
             "get": {
                 "description": "Returns the software version of the API",
@@ -4556,6 +4727,27 @@ const docTemplate = `{
                 }
             }
         },
+        "controllers.Pagination": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "description": "The amount of records returned in this response",
+                    "type": "integer"
+                },
+                "limit": {
+                    "description": "The maximum amount of resources to return for this request",
+                    "type": "integer"
+                },
+                "offset": {
+                    "description": "The offset for the first record returned",
+                    "type": "integer"
+                },
+                "total": {
+                    "description": "The total number of resources matching the query",
+                    "type": "integer"
+                }
+            }
+        },
         "controllers.RenameRuleListResponse": {
             "type": "object",
             "properties": {
@@ -4731,6 +4923,30 @@ const docTemplate = `{
                 }
             }
         },
+        "controllers.TransactionListResponseV3": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "List of transactions",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.TransactionV3"
+                    }
+                },
+                "error": {
+                    "description": "The error, if any occurred",
+                    "type": "string"
+                },
+                "pagination": {
+                    "description": "Pagination information",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/controllers.Pagination"
+                        }
+                    ]
+                }
+            }
+        },
         "controllers.TransactionResponse": {
             "type": "object",
             "properties": {
@@ -4807,7 +5023,109 @@ const docTemplate = `{
                         "self": {
                             "description": "The transaction itself",
                             "type": "string",
-                            "example": "https://example.com/api/v1/transactions/d430d7c3-d14c-4712-9336-ee56965a6673"
+                            "example": "https://example.com/api/v2/transactions/d430d7c3-d14c-4712-9336-ee56965a6673"
+                        }
+                    }
+                },
+                "note": {
+                    "description": "A note",
+                    "type": "string",
+                    "example": "Lunch"
+                },
+                "reconciled": {
+                    "description": "DEPRECATED. Do not use, this field does not work as intended. See https://github.com/envelope-zero/backend/issues/528. Use reconciledSource and reconciledDestination instead.",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "reconciledDestination": {
+                    "description": "Is the transaction reconciled in the destination account?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "reconciledSource": {
+                    "description": "Is the transaction reconciled in the source account?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "sourceAccountId": {
+                    "description": "ID of the source account",
+                    "type": "string",
+                    "example": "fd81dc45-a3a2-468e-a6fa-b2618f30aa45"
+                },
+                "updatedAt": {
+                    "description": "Last time the resource was updated",
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
+                }
+            }
+        },
+        "controllers.TransactionV3": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 14.03
+                },
+                "availableFrom": {
+                    "description": "The date from which on the transaction amount is available for budgeting. Only used for income transactions. Defaults to the transaction date.",
+                    "type": "string",
+                    "example": "2021-11-17T00:00:00Z"
+                },
+                "budgetId": {
+                    "description": "ID of the budget",
+                    "type": "string",
+                    "example": "55eecbd8-7c46-4b06-ada9-f287802fb05e"
+                },
+                "createdAt": {
+                    "description": "Time the resource was created",
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "date": {
+                    "description": "Date of the transaction. Time is currently only used for sorting",
+                    "type": "string",
+                    "example": "1815-12-10T18:43:00.271152Z"
+                },
+                "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
+                "destinationAccountId": {
+                    "description": "ID of the destination account",
+                    "type": "string",
+                    "example": "8e16b456-a719-48ce-9fec-e115cfa7cbcc"
+                },
+                "envelopeId": {
+                    "description": "ID of the envelope",
+                    "type": "string",
+                    "example": "2649c965-7999-4873-ae16-89d5d5fa972e"
+                },
+                "id": {
+                    "description": "UUID for the resource",
+                    "type": "string",
+                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
+                },
+                "importHash": {
+                    "description": "The SHA256 hash of a unique combination of values to use in duplicate detection",
+                    "type": "string",
+                    "example": "867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70"
+                },
+                "links": {
+                    "description": "Links for the transaction",
+                    "type": "object",
+                    "properties": {
+                        "self": {
+                            "description": "The transaction itself",
+                            "type": "string",
+                            "example": "https://example.com/api/v3/transactions/d430d7c3-d14c-4712-9336-ee56965a6673"
                         }
                     }
                 },
@@ -5521,6 +5839,11 @@ const docTemplate = `{
                     "type": "string",
                     "example": "https://example.com/api/v2"
                 },
+                "v3": {
+                    "description": "List endpoint for all v3 endpoints",
+                    "type": "string",
+                    "example": "https://example.com/api/v3"
+                },
                 "version": {
                     "description": "Endpoint returning the version of the backend",
                     "type": "string",
@@ -5632,6 +5955,29 @@ const docTemplate = `{
                     "allOf": [
                         {
                             "$ref": "#/definitions/router.V2Links"
+                        }
+                    ]
+                }
+            }
+        },
+        "router.V3Links": {
+            "type": "object",
+            "properties": {
+                "transactions": {
+                    "description": "URL of transaction collection endpoint",
+                    "type": "string",
+                    "example": "https://example.com/api/v3/transactions"
+                }
+            }
+        },
+        "router.V3Response": {
+            "type": "object",
+            "properties": {
+                "links": {
+                    "description": "Links for the v2 API",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/router.V3Links"
                         }
                     ]
                 }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -3789,6 +3789,177 @@
                 }
             }
         },
+        "/v3": {
+            "get": {
+                "description": "Returns general information about the v3 API",
+                "tags": [
+                    "v3"
+                ],
+                "summary": "v3 API",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/router.V3Response"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "tags": [
+                    "v3"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/v3/transactions": {
+            "get": {
+                "description": "Returns a list of transactions",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Transactions"
+                ],
+                "summary": "Get transactions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Date of the transaction. Ignores exact time, matches on the day of the RFC3339 timestamp provided.",
+                        "name": "date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Transactions at and after this date. Ignores exact time, matches on the day of the RFC3339 timestamp provided.",
+                        "name": "fromDate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Transactions before and at this date. Ignores exact time, matches on the day of the RFC3339 timestamp provided.",
+                        "name": "untilDate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by amount",
+                        "name": "amount",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Amount less than or equal to this",
+                        "name": "amountLessOrEqual",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Amount more than or equal to this",
+                        "name": "amountMoreOrEqual",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by note",
+                        "name": "note",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by budget ID",
+                        "name": "budget",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by ID of associated account, regardeless of source or destination",
+                        "name": "account",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by source account ID",
+                        "name": "source",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by destination account ID",
+                        "name": "destination",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by envelope ID",
+                        "name": "envelope",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Reconcilication state in source account",
+                        "name": "reconciledSource",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Reconcilication state in destination account",
+                        "name": "reconciledDestination",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The offset of the first Transaction returned. Defaults to 0.",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": " Maximum number of transactions to return. Defaults to 50.",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.TransactionListResponseV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "tags": [
+                    "Transactions"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
         "/version": {
             "get": {
                 "description": "Returns the software version of the API",
@@ -4545,6 +4716,27 @@
                 }
             }
         },
+        "controllers.Pagination": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "description": "The amount of records returned in this response",
+                    "type": "integer"
+                },
+                "limit": {
+                    "description": "The maximum amount of resources to return for this request",
+                    "type": "integer"
+                },
+                "offset": {
+                    "description": "The offset for the first record returned",
+                    "type": "integer"
+                },
+                "total": {
+                    "description": "The total number of resources matching the query",
+                    "type": "integer"
+                }
+            }
+        },
         "controllers.RenameRuleListResponse": {
             "type": "object",
             "properties": {
@@ -4720,6 +4912,30 @@
                 }
             }
         },
+        "controllers.TransactionListResponseV3": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "List of transactions",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.TransactionV3"
+                    }
+                },
+                "error": {
+                    "description": "The error, if any occurred",
+                    "type": "string"
+                },
+                "pagination": {
+                    "description": "Pagination information",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/controllers.Pagination"
+                        }
+                    ]
+                }
+            }
+        },
         "controllers.TransactionResponse": {
             "type": "object",
             "properties": {
@@ -4796,7 +5012,109 @@
                         "self": {
                             "description": "The transaction itself",
                             "type": "string",
-                            "example": "https://example.com/api/v1/transactions/d430d7c3-d14c-4712-9336-ee56965a6673"
+                            "example": "https://example.com/api/v2/transactions/d430d7c3-d14c-4712-9336-ee56965a6673"
+                        }
+                    }
+                },
+                "note": {
+                    "description": "A note",
+                    "type": "string",
+                    "example": "Lunch"
+                },
+                "reconciled": {
+                    "description": "DEPRECATED. Do not use, this field does not work as intended. See https://github.com/envelope-zero/backend/issues/528. Use reconciledSource and reconciledDestination instead.",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "reconciledDestination": {
+                    "description": "Is the transaction reconciled in the destination account?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "reconciledSource": {
+                    "description": "Is the transaction reconciled in the source account?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "sourceAccountId": {
+                    "description": "ID of the source account",
+                    "type": "string",
+                    "example": "fd81dc45-a3a2-468e-a6fa-b2618f30aa45"
+                },
+                "updatedAt": {
+                    "description": "Last time the resource was updated",
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
+                }
+            }
+        },
+        "controllers.TransactionV3": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 14.03
+                },
+                "availableFrom": {
+                    "description": "The date from which on the transaction amount is available for budgeting. Only used for income transactions. Defaults to the transaction date.",
+                    "type": "string",
+                    "example": "2021-11-17T00:00:00Z"
+                },
+                "budgetId": {
+                    "description": "ID of the budget",
+                    "type": "string",
+                    "example": "55eecbd8-7c46-4b06-ada9-f287802fb05e"
+                },
+                "createdAt": {
+                    "description": "Time the resource was created",
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "date": {
+                    "description": "Date of the transaction. Time is currently only used for sorting",
+                    "type": "string",
+                    "example": "1815-12-10T18:43:00.271152Z"
+                },
+                "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
+                "destinationAccountId": {
+                    "description": "ID of the destination account",
+                    "type": "string",
+                    "example": "8e16b456-a719-48ce-9fec-e115cfa7cbcc"
+                },
+                "envelopeId": {
+                    "description": "ID of the envelope",
+                    "type": "string",
+                    "example": "2649c965-7999-4873-ae16-89d5d5fa972e"
+                },
+                "id": {
+                    "description": "UUID for the resource",
+                    "type": "string",
+                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
+                },
+                "importHash": {
+                    "description": "The SHA256 hash of a unique combination of values to use in duplicate detection",
+                    "type": "string",
+                    "example": "867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70"
+                },
+                "links": {
+                    "description": "Links for the transaction",
+                    "type": "object",
+                    "properties": {
+                        "self": {
+                            "description": "The transaction itself",
+                            "type": "string",
+                            "example": "https://example.com/api/v3/transactions/d430d7c3-d14c-4712-9336-ee56965a6673"
                         }
                     }
                 },
@@ -5510,6 +5828,11 @@
                     "type": "string",
                     "example": "https://example.com/api/v2"
                 },
+                "v3": {
+                    "description": "List endpoint for all v3 endpoints",
+                    "type": "string",
+                    "example": "https://example.com/api/v3"
+                },
                 "version": {
                     "description": "Endpoint returning the version of the backend",
                     "type": "string",
@@ -5621,6 +5944,29 @@
                     "allOf": [
                         {
                             "$ref": "#/definitions/router.V2Links"
+                        }
+                    ]
+                }
+            }
+        },
+        "router.V3Links": {
+            "type": "object",
+            "properties": {
+                "transactions": {
+                    "description": "URL of transaction collection endpoint",
+                    "type": "string",
+                    "example": "https://example.com/api/v3/transactions"
+                }
+            }
+        },
+        "router.V3Response": {
+            "type": "object",
+            "properties": {
+                "links": {
+                    "description": "Links for the v2 API",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/router.V3Links"
                         }
                     ]
                 }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -531,6 +531,21 @@ definitions:
         - $ref: '#/definitions/models.Month'
         description: Data for the month
     type: object
+  controllers.Pagination:
+    properties:
+      count:
+        description: The amount of records returned in this response
+        type: integer
+      limit:
+        description: The maximum amount of resources to return for this request
+        type: integer
+      offset:
+        description: The offset for the first record returned
+        type: integer
+      total:
+        description: The total number of resources matching the query
+        type: integer
+    type: object
   controllers.RenameRuleListResponse:
     properties:
       data:
@@ -663,6 +678,21 @@ definitions:
           $ref: '#/definitions/controllers.Transaction'
         type: array
     type: object
+  controllers.TransactionListResponseV3:
+    properties:
+      data:
+        description: List of transactions
+        items:
+          $ref: '#/definitions/controllers.TransactionV3'
+        type: array
+      error:
+        description: The error, if any occurred
+        type: string
+      pagination:
+        allOf:
+        - $ref: '#/definitions/controllers.Pagination'
+        description: Pagination information
+    type: object
   controllers.TransactionResponse:
     properties:
       data:
@@ -724,7 +754,94 @@ definitions:
         properties:
           self:
             description: The transaction itself
-            example: https://example.com/api/v1/transactions/d430d7c3-d14c-4712-9336-ee56965a6673
+            example: https://example.com/api/v2/transactions/d430d7c3-d14c-4712-9336-ee56965a6673
+            type: string
+        type: object
+      note:
+        description: A note
+        example: Lunch
+        type: string
+      reconciled:
+        default: false
+        description: DEPRECATED. Do not use, this field does not work as intended.
+          See https://github.com/envelope-zero/backend/issues/528. Use reconciledSource
+          and reconciledDestination instead.
+        example: true
+        type: boolean
+      reconciledDestination:
+        default: false
+        description: Is the transaction reconciled in the destination account?
+        example: true
+        type: boolean
+      reconciledSource:
+        default: false
+        description: Is the transaction reconciled in the source account?
+        example: true
+        type: boolean
+      sourceAccountId:
+        description: ID of the source account
+        example: fd81dc45-a3a2-468e-a6fa-b2618f30aa45
+        type: string
+      updatedAt:
+        description: Last time the resource was updated
+        example: "2022-04-17T20:14:01.048145Z"
+        type: string
+    type: object
+  controllers.TransactionV3:
+    properties:
+      amount:
+        description: The maximum value is "999999999999.99999999", swagger unfortunately
+          rounds this.
+        example: 14.03
+        maximum: 1000000000000
+        minimum: 1e-08
+        multipleOf: 1e-08
+        type: number
+      availableFrom:
+        description: The date from which on the transaction amount is available for
+          budgeting. Only used for income transactions. Defaults to the transaction
+          date.
+        example: "2021-11-17T00:00:00Z"
+        type: string
+      budgetId:
+        description: ID of the budget
+        example: 55eecbd8-7c46-4b06-ada9-f287802fb05e
+        type: string
+      createdAt:
+        description: Time the resource was created
+        example: "2022-04-02T19:28:44.491514Z"
+        type: string
+      date:
+        description: Date of the transaction. Time is currently only used for sorting
+        example: "1815-12-10T18:43:00.271152Z"
+        type: string
+      deletedAt:
+        description: Time the resource was marked as deleted
+        example: "2022-04-22T21:01:05.058161Z"
+        type: string
+      destinationAccountId:
+        description: ID of the destination account
+        example: 8e16b456-a719-48ce-9fec-e115cfa7cbcc
+        type: string
+      envelopeId:
+        description: ID of the envelope
+        example: 2649c965-7999-4873-ae16-89d5d5fa972e
+        type: string
+      id:
+        description: UUID for the resource
+        example: 65392deb-5e92-4268-b114-297faad6cdce
+        type: string
+      importHash:
+        description: The SHA256 hash of a unique combination of values to use in duplicate
+          detection
+        example: 867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70
+        type: string
+      links:
+        description: Links for the transaction
+        properties:
+          self:
+            description: The transaction itself
+            example: https://example.com/api/v3/transactions/d430d7c3-d14c-4712-9336-ee56965a6673
             type: string
         type: object
       note:
@@ -1294,6 +1411,10 @@ definitions:
         description: List endpoint for all v2 endpoints
         example: https://example.com/api/v2
         type: string
+      v3:
+        description: List endpoint for all v3 endpoints
+        example: https://example.com/api/v3
+        type: string
       version:
         description: Endpoint returning the version of the backend
         example: https://example.com/api/version
@@ -1372,6 +1493,20 @@ definitions:
       links:
         allOf:
         - $ref: '#/definitions/router.V2Links'
+        description: Links for the v2 API
+    type: object
+  router.V3Links:
+    properties:
+      transactions:
+        description: URL of transaction collection endpoint
+        example: https://example.com/api/v3/transactions
+        type: string
+    type: object
+  router.V3Response:
+    properties:
+      links:
+        allOf:
+        - $ref: '#/definitions/router.V3Links'
         description: Links for the v2 API
     type: object
   router.VersionObject:
@@ -3965,6 +4100,125 @@ paths:
               $ref: '#/definitions/controllers.ResponseTransactionV2'
             type: array
       summary: Create transactions
+      tags:
+      - Transactions
+  /v3:
+    get:
+      description: Returns general information about the v3 API
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/router.V3Response'
+      summary: v3 API
+      tags:
+      - v3
+    options:
+      description: Returns an empty response with the HTTP Header "allow" set to the
+        allowed HTTP verbs
+      responses:
+        "204":
+          description: No Content
+      summary: Allowed HTTP verbs
+      tags:
+      - v3
+  /v3/transactions:
+    get:
+      description: Returns a list of transactions
+      parameters:
+      - description: Date of the transaction. Ignores exact time, matches on the day
+          of the RFC3339 timestamp provided.
+        in: query
+        name: date
+        type: string
+      - description: Transactions at and after this date. Ignores exact time, matches
+          on the day of the RFC3339 timestamp provided.
+        in: query
+        name: fromDate
+        type: string
+      - description: Transactions before and at this date. Ignores exact time, matches
+          on the day of the RFC3339 timestamp provided.
+        in: query
+        name: untilDate
+        type: string
+      - description: Filter by amount
+        in: query
+        name: amount
+        type: string
+      - description: Amount less than or equal to this
+        in: query
+        name: amountLessOrEqual
+        type: string
+      - description: Amount more than or equal to this
+        in: query
+        name: amountMoreOrEqual
+        type: string
+      - description: Filter by note
+        in: query
+        name: note
+        type: string
+      - description: Filter by budget ID
+        in: query
+        name: budget
+        type: string
+      - description: Filter by ID of associated account, regardeless of source or
+          destination
+        in: query
+        name: account
+        type: string
+      - description: Filter by source account ID
+        in: query
+        name: source
+        type: string
+      - description: Filter by destination account ID
+        in: query
+        name: destination
+        type: string
+      - description: Filter by envelope ID
+        in: query
+        name: envelope
+        type: string
+      - description: Reconcilication state in source account
+        in: query
+        name: reconciledSource
+        type: boolean
+      - description: Reconcilication state in destination account
+        in: query
+        name: reconciledDestination
+        type: boolean
+      - description: The offset of the first Transaction returned. Defaults to 0.
+        in: query
+        name: offset
+        type: integer
+      - description: ' Maximum number of transactions to return. Defaults to 50.'
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.TransactionListResponseV3'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Get transactions
+      tags:
+      - Transactions
+    options:
+      description: Returns an empty response with the HTTP Header "allow" set to the
+        allowed HTTP verbs
+      responses:
+        "204":
+          description: No Content
+      summary: Allowed HTTP verbs
       tags:
       - Transactions
   /version:

--- a/pkg/controllers/account.go
+++ b/pkg/controllers/account.go
@@ -17,7 +17,7 @@ type AccountQueryFilter struct {
 }
 
 func (f AccountQueryFilter) ToCreate(c *gin.Context) (models.AccountCreate, bool) {
-	budgetID, ok := httputil.UUIDFromString(c, f.BudgetID)
+	budgetID, ok := httputil.UUIDFromStringHandleErrors(c, f.BudgetID)
 	if !ok {
 		return models.AccountCreate{}, false
 	}

--- a/pkg/controllers/allocation.go
+++ b/pkg/controllers/allocation.go
@@ -55,7 +55,7 @@ type AllocationQueryFilter struct {
 }
 
 func (f AllocationQueryFilter) Parse(c *gin.Context) (models.AllocationCreate, bool) {
-	envelopeID, ok := httputil.UUIDFromString(c, f.EnvelopeID)
+	envelopeID, ok := httputil.UUIDFromStringHandleErrors(c, f.EnvelopeID)
 	if !ok {
 		return models.AllocationCreate{}, false
 	}

--- a/pkg/controllers/category.go
+++ b/pkg/controllers/category.go
@@ -76,7 +76,7 @@ type CategoryQueryFilter struct {
 }
 
 func (f CategoryQueryFilter) ToCreate(c *gin.Context) (models.CategoryCreate, bool) {
-	budgetID, ok := httputil.UUIDFromString(c, f.BudgetID)
+	budgetID, ok := httputil.UUIDFromStringHandleErrors(c, f.BudgetID)
 	if !ok {
 		return models.CategoryCreate{}, false
 	}

--- a/pkg/controllers/database.go
+++ b/pkg/controllers/database.go
@@ -8,12 +8,26 @@ import (
 
 // queryAndHandleErrors tries to execute a query. If it fails, it
 // tries to reconnect the database and retries the query once.
-func queryAndHandleErrors(c *gin.Context, tx *gorm.DB, notFoundMsg ...string) bool {
+//
+// This function is deprecated. Use `query(tx *gorm.DB) httperrors.Error` and
+// perform HTTP responses in the calling method.
+func queryAndHandleErrors(c *gin.Context, tx *gorm.DB) bool {
 	err := tx.Error
 	if err != nil {
-		httperrors.Handler(c, err, notFoundMsg...)
+		httperrors.Handler(c, err)
 		return false
 	}
 
 	return true
+}
+
+// query executes a query. If an error ocurrs, an appropriate user facing
+// error message and status code is returned in an httperrors.Error struct.
+func query(c *gin.Context, tx *gorm.DB) httperrors.Error {
+	err := tx.Error
+	if err != nil {
+		return httperrors.Parse(c, err)
+	}
+
+	return httperrors.Error{}
 }

--- a/pkg/controllers/envelope.go
+++ b/pkg/controllers/envelope.go
@@ -68,7 +68,7 @@ type EnvelopeQueryFilter struct {
 }
 
 func (f EnvelopeQueryFilter) ToCreate(c *gin.Context) (models.EnvelopeCreate, bool) {
-	categoryID, ok := httputil.UUIDFromString(c, f.CategoryID)
+	categoryID, ok := httputil.UUIDFromStringHandleErrors(c, f.CategoryID)
 	if !ok {
 		return models.EnvelopeCreate{}, false
 	}

--- a/pkg/controllers/import.go
+++ b/pkg/controllers/import.go
@@ -125,7 +125,7 @@ func (co Controller) ImportYnabImportPreview(c *gin.Context) {
 		return
 	}
 
-	accountID, ok := httputil.UUIDFromString(c, query.AccountID)
+	accountID, ok := httputil.UUIDFromStringHandleErrors(c, query.AccountID)
 	if !ok {
 		return
 	}

--- a/pkg/controllers/import_test.go
+++ b/pkg/controllers/import_test.go
@@ -101,7 +101,7 @@ func (suite *TestSuiteStandard) TestYnabImportPreviewFails() {
 		file          string
 	}{
 		{"No account ID", "", http.StatusBadRequest, "The accountId parameter must be set", ""},
-		{"Broken ID", "NotAUUID", http.StatusBadRequest, "The specified resource ID is not a valid UUID", "importer/ynab-import/empty.csv"},
+		{"Broken ID", "NotAUUID", http.StatusBadRequest, "the specified resource ID is not a valid UUID", "importer/ynab-import/empty.csv"},
 		{"No account with ID", "d2525c4f-2f45-49ba-9c5d-75d6b1c26f56", http.StatusNotFound, "No Account found for the specified ID", "importer/ynab-import/empty.csv"},
 		{"No file sent", accountID, http.StatusBadRequest, "You must send a file to this endpoint", ""},
 		{"Wrong file name", accountID, http.StatusBadRequest, "This endpoint only supports .csv files", "importer/ynab-import/wrong-suffix.json"},

--- a/pkg/controllers/match_rule.go
+++ b/pkg/controllers/match_rule.go
@@ -45,7 +45,7 @@ type MatchRuleQueryFilter struct {
 }
 
 func (f MatchRuleQueryFilter) Parse(c *gin.Context) (models.MatchRuleCreate, bool) {
-	envelopeID, ok := httputil.UUIDFromString(c, f.AccountID)
+	envelopeID, ok := httputil.UUIDFromStringHandleErrors(c, f.AccountID)
 	if !ok {
 		return models.MatchRuleCreate{}, false
 	}
@@ -315,7 +315,7 @@ func (co Controller) DeleteMatchRule(c *gin.Context) {
 }
 
 // createMatchRule creates a single matchRule after verifying it is a valid matchRule.
-func (co Controller) createMatchRule(c *gin.Context, create models.MatchRuleCreate) (models.MatchRule, httperrors.ErrorStatus) {
+func (co Controller) createMatchRule(c *gin.Context, create models.MatchRuleCreate) (models.MatchRule, httperrors.Error) {
 	r := models.MatchRule{
 		MatchRuleCreate: create,
 	}
@@ -332,5 +332,5 @@ func (co Controller) createMatchRule(c *gin.Context, create models.MatchRuleCrea
 		return models.MatchRule{}, httperrors.GenericDBError[models.MatchRule](r, c, dbErr)
 	}
 
-	return r, httperrors.ErrorStatus{}
+	return r, httperrors.Error{}
 }

--- a/pkg/controllers/rename_rule.go
+++ b/pkg/controllers/rename_rule.go
@@ -26,7 +26,7 @@ type RenameRuleQueryFilter struct {
 }
 
 func (f RenameRuleQueryFilter) Parse(c *gin.Context) (models.MatchRuleCreate, bool) {
-	envelopeID, ok := httputil.UUIDFromString(c, f.AccountID)
+	envelopeID, ok := httputil.UUIDFromStringHandleErrors(c, f.AccountID)
 	if !ok {
 		return models.MatchRuleCreate{}, false
 	}
@@ -303,7 +303,7 @@ func (co Controller) DeleteRenameRule(c *gin.Context) {
 }
 
 // createRenameRule creates a single renameRule after verifying it is a valid renameRule.
-func (co Controller) createRenameRule(c *gin.Context, r models.MatchRule) (models.MatchRule, httperrors.ErrorStatus) {
+func (co Controller) createRenameRule(c *gin.Context, r models.MatchRule) (models.MatchRule, httperrors.Error) {
 	// Check that the referenced account exists
 	_, err := getResourceByID[models.Account](c, co, r.AccountID)
 	if !err.Nil() {
@@ -316,5 +316,5 @@ func (co Controller) createRenameRule(c *gin.Context, r models.MatchRule) (model
 		return models.MatchRule{}, httperrors.GenericDBError[models.MatchRule](r, c, dbErr)
 	}
 
-	return r, httperrors.ErrorStatus{}
+	return r, httperrors.Error{}
 }

--- a/pkg/controllers/responses.go
+++ b/pkg/controllers/responses.go
@@ -12,3 +12,11 @@ type ResponseMatchRule struct {
 	Error string    `json:"error" example:"A human readable error message"` // This field contains a human readable error message
 	Data  MatchRule `json:"data"`                                           // This field contains the MatchRule data
 }
+
+// Pagination contains information about the pagination for collection endpoint responses.
+type Pagination struct {
+	Count  int   `json:"count"`  // The amount of records returned in this response
+	Offset uint  `json:"offset"` // The offset for the first record returned
+	Limit  int   `json:"limit"`  // The maximum amount of resources to return for this request
+	Total  int64 `json:"total"`  // The total number of resources matching the query
+}

--- a/pkg/controllers/test_options_test.go
+++ b/pkg/controllers/test_options_test.go
@@ -27,6 +27,7 @@ func (suite *TestSuiteStandard) TestOptionsHeaderResources() {
 		{"http://example.com/v2/transactions", "OPTIONS, POST"},
 		{"http://example.com/v2/match-rules", "OPTIONS, GET, POST"},
 		{"http://example.com/v2/accounts", "OPTIONS, GET"},
+		{"http://example.com/v3/transactions", "OPTIONS, GET"},
 	}
 
 	for _, tt := range optionsHeaderTests {

--- a/pkg/controllers/transaction.go
+++ b/pkg/controllers/transaction.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/envelope-zero/backend/v3/pkg/httperrors"
+	"github.com/envelope-zero/backend/v3/pkg/httputil"
 	"github.com/envelope-zero/backend/v3/pkg/models"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -12,7 +13,7 @@ import (
 )
 
 // createTransaction creates a single transaction after verifying it is a valid transaction.
-func (co Controller) createTransaction(c *gin.Context, t models.Transaction) (models.Transaction, httperrors.ErrorStatus) {
+func (co Controller) createTransaction(c *gin.Context, t models.Transaction) (models.Transaction, httperrors.Error) {
 	_, err := getResourceByID[models.Budget](c, co, t.BudgetID)
 	if !err.Nil() {
 		return t, err
@@ -41,7 +42,7 @@ func (co Controller) createTransaction(c *gin.Context, t models.Transaction) (mo
 		return models.Transaction{}, httperrors.GenericDBError[models.Transaction](t, c, dbErr)
 	}
 
-	return t, httperrors.ErrorStatus{}
+	return t, httperrors.Error{}
 }
 
 // checkTransactionAndHandleErrors verifies that the transaction is correct
@@ -86,24 +87,107 @@ func (co Controller) checkTransactionAndHandleErrors(c *gin.Context, transaction
 //   - the transaction is not between two external accounts
 //   - if an envelope is set: the transaction is not between two on-budget accounts
 //   - if an envelope is set: the envelope exists
-func (co Controller) checkTransaction(c *gin.Context, transaction models.Transaction, source, destination models.Account) httperrors.ErrorStatus {
+func (co Controller) checkTransaction(c *gin.Context, transaction models.Transaction, source, destination models.Account) httperrors.Error {
 	if !decimal.Decimal.IsPositive(transaction.Amount) {
-		return httperrors.ErrorStatus{Err: errors.New("the transaction amount must be positive"), Status: http.StatusBadRequest}
+		return httperrors.Error{Err: errors.New("the transaction amount must be positive"), Status: http.StatusBadRequest}
 	}
 
 	if source.External && destination.External {
-		return httperrors.ErrorStatus{Err: errors.New("a transaction between two external accounts is not possible"), Status: http.StatusBadRequest}
+		return httperrors.Error{Err: errors.New("a transaction between two external accounts is not possible"), Status: http.StatusBadRequest}
 	}
 
 	// Check envelope being set for transfer between on-budget accounts
 	if transaction.EnvelopeID != nil && *transaction.EnvelopeID != uuid.Nil {
 		if source.OnBudget && destination.OnBudget {
 			// TODO: Verify this state in the model hooks
-			return httperrors.ErrorStatus{Err: errors.New("transfers between two on-budget accounts must not have an envelope set. Such a transaction would be incoming and outgoing for this envelope at the same time, which is not possible"), Status: http.StatusBadRequest}
+			return httperrors.Error{Err: errors.New("transfers between two on-budget accounts must not have an envelope set. Such a transaction would be incoming and outgoing for this envelope at the same time, which is not possible"), Status: http.StatusBadRequest}
 		}
 		_, err := getResourceByID[models.Envelope](c, co, *transaction.EnvelopeID)
 		return err
 	}
 
-	return httperrors.ErrorStatus{}
+	return httperrors.Error{}
+}
+
+// ToCreateHandleErrors parses the query string and returns a TransactionCreate struct for
+// the database request.
+//
+// This method is deprecated, use ToCreate() and handle errors in the calling method.
+func (f TransactionQueryFilterV1) ToCreateHandleErrors(c *gin.Context) (models.TransactionCreate, bool) {
+	budgetID, ok := httputil.UUIDFromStringHandleErrors(c, f.BudgetID)
+	if !ok {
+		return models.TransactionCreate{}, false
+	}
+
+	sourceAccountID, ok := httputil.UUIDFromStringHandleErrors(c, f.SourceAccountID)
+	if !ok {
+		return models.TransactionCreate{}, false
+	}
+
+	destinationAccountID, ok := httputil.UUIDFromStringHandleErrors(c, f.DestinationAccountID)
+	if !ok {
+		return models.TransactionCreate{}, false
+	}
+
+	envelopeID, ok := httputil.UUIDFromStringHandleErrors(c, f.EnvelopeID)
+	if !ok {
+		return models.TransactionCreate{}, false
+	}
+
+	// If the envelopeID is nil, use an actual nil, not uuid.Nil
+	var eID *uuid.UUID
+	if envelopeID != uuid.Nil {
+		eID = &envelopeID
+	}
+
+	return models.TransactionCreate{
+		Amount:                f.Amount,
+		BudgetID:              budgetID,
+		SourceAccountID:       sourceAccountID,
+		DestinationAccountID:  destinationAccountID,
+		EnvelopeID:            eID,
+		Reconciled:            f.Reconciled,
+		ReconciledSource:      f.ReconciledSource,
+		ReconciledDestination: f.ReconciledDestination,
+	}, true
+}
+
+// ToCreate parses the query string and returns a TransactionCreate struct for
+// the database request. On error, it returns httperrors.ErrorStatus struct with.
+func (f TransactionQueryFilterV3) ToCreate(c *gin.Context) (models.TransactionCreate, httperrors.Error) {
+	budgetID, err := httputil.UUIDFromString(c, f.BudgetID)
+	if !err.Nil() {
+		return models.TransactionCreate{}, err
+	}
+
+	sourceAccountID, err := httputil.UUIDFromString(c, f.SourceAccountID)
+	if !err.Nil() {
+		return models.TransactionCreate{}, err
+	}
+
+	destinationAccountID, err := httputil.UUIDFromString(c, f.DestinationAccountID)
+	if !err.Nil() {
+		return models.TransactionCreate{}, err
+	}
+
+	envelopeID, err := httputil.UUIDFromString(c, f.EnvelopeID)
+	if !err.Nil() {
+		return models.TransactionCreate{}, err
+	}
+
+	// If the envelopeID is nil, use an actual nil, not uuid.Nil
+	var eID *uuid.UUID
+	if envelopeID != uuid.Nil {
+		eID = &envelopeID
+	}
+
+	return models.TransactionCreate{
+		Amount:                f.Amount,
+		BudgetID:              budgetID,
+		SourceAccountID:       sourceAccountID,
+		DestinationAccountID:  destinationAccountID,
+		EnvelopeID:            eID,
+		ReconciledSource:      f.ReconciledSource,
+		ReconciledDestination: f.ReconciledDestination,
+	}, httperrors.Error{}
 }

--- a/pkg/controllers/transaction_v2.go
+++ b/pkg/controllers/transaction_v2.go
@@ -11,7 +11,12 @@ import (
 	"github.com/google/uuid"
 )
 
-type TransactionV2 Transaction
+type TransactionV2 struct {
+	models.Transaction
+	Links struct {
+		Self string `json:"self" example:"https://example.com/api/v2/transactions/d430d7c3-d14c-4712-9336-ee56965a6673"` // The transaction itself
+	} `json:"links"` // Links for the transaction
+}
 
 // links generates HATEOAS links for the transaction.
 func (t *TransactionV2) links(c *gin.Context) {

--- a/pkg/controllers/transaction_v3.go
+++ b/pkg/controllers/transaction_v3.go
@@ -1,0 +1,250 @@
+package controllers
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/envelope-zero/backend/v3/pkg/database"
+	"github.com/envelope-zero/backend/v3/pkg/httperrors"
+	"github.com/envelope-zero/backend/v3/pkg/httputil"
+	"github.com/envelope-zero/backend/v3/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"golang.org/x/exp/slices"
+	"gorm.io/gorm"
+)
+
+type TransactionListResponseV3 struct {
+	Data       []TransactionV3 `json:"data"`       // List of transactions
+	Error      *string         `json:"error"`      // The error, if any occurred
+	Pagination *Pagination     `json:"pagination"` // Pagination information
+}
+
+// TransactionV3 is the representation of a Transaction in API v3.
+type TransactionV3 struct {
+	models.Transaction
+	Links struct {
+		Self string `json:"self" example:"https://example.com/api/v3/transactions/d430d7c3-d14c-4712-9336-ee56965a6673"` // The transaction itself
+	} `json:"links"` // Links for the transaction
+}
+
+// links generates HATEOAS links for the transaction.
+func (t *TransactionV3) links(c *gin.Context) {
+	// Set links
+	t.Links.Self = fmt.Sprintf("%s/v3/transactions/%s", c.GetString(string(database.ContextURL)), t.ID)
+}
+
+type TransactionQueryFilterV3 struct {
+	Date                  time.Time       `form:"date" filterField:"false"`              // Exact date. Time is ignored.
+	FromDate              time.Time       `form:"fromDate" filterField:"false"`          // From this date. Time is ignored.
+	UntilDate             time.Time       `form:"untilDate" filterField:"false"`         // Until this date. Time is ignored.
+	Amount                decimal.Decimal `form:"amount"`                                // Exact amount
+	AmountLessOrEqual     decimal.Decimal `form:"amountLessOrEqual" filterField:"false"` // Amount less than or equal to this
+	AmountMoreOrEqual     decimal.Decimal `form:"amountMoreOrEqual" filterField:"false"` // Amount more than or equal to this
+	Note                  string          `form:"note" filterField:"false"`              // Note contains this string
+	BudgetID              string          `form:"budget"`                                // ID of the budget
+	SourceAccountID       string          `form:"source"`                                // ID of the source account
+	DestinationAccountID  string          `form:"destination"`                           // ID of the destination account
+	EnvelopeID            string          `form:"envelope"`                              // ID of the envelope
+	ReconciledSource      bool            `form:"reconciledSource"`                      // Is the transaction reconciled in the source account?
+	ReconciledDestination bool            `form:"reconciledDestination"`                 // Is the transaction reconciled in the destination account?
+	AccountID             string          `form:"account" filterField:"false"`           // ID of either source or destination account
+	Offset                uint            `form:"offset" filterField:"false"`            // The offset of the first Transaction returned. Defaults to 0.
+	Limit                 int             `form:"limit" filterField:"false"`             // Maximum number of transactions to return. Defaults to 50.
+}
+
+func (co Controller) getTransactionV3(c *gin.Context, id uuid.UUID) (TransactionV3, httperrors.Error) {
+	transactionModel, err := getResourceByID[models.Transaction](c, co, id)
+	if !err.Nil() {
+		return TransactionV3{}, err
+	}
+
+	transaction := TransactionV3{
+		Transaction: transactionModel,
+	}
+
+	transaction.links(c)
+	return transaction, httperrors.Error{}
+}
+
+// RegisterTransactionRoutesV3 registers the routes for transactions with
+// the RouterGroup that is passed.
+func (co Controller) RegisterTransactionRoutesV3(r *gin.RouterGroup) {
+	// Root group
+	{
+		r.OPTIONS("", co.OptionsTransactionsV3)
+		r.GET("", co.GetTransactionsV3)
+	}
+}
+
+// OptionsTransactionsV3 returns the allowed HTTP methods
+//
+//	@Summary		Allowed HTTP verbs
+//	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
+//	@Tags			Transactions
+//	@Success		204
+//	@Router			/v3/transactions [options]
+func (co Controller) OptionsTransactionsV3(c *gin.Context) {
+	httputil.OptionsGet(c)
+}
+
+// GetTransactions returns transactions filtered by the query parameters
+//
+//	@Summary		Get transactions
+//	@Description	Returns a list of transactions
+//	@Tags			Transactions
+//	@Produce		json
+//	@Success		200	{object}	TransactionListResponseV3
+//	@Failure		400	{object}	httperrors.HTTPError
+//	@Failure		500	{object}	httperrors.HTTPError
+//	@Router			/v3/transactions [get]
+//	@Param			date					query	string	false	"Date of the transaction. Ignores exact time, matches on the day of the RFC3339 timestamp provided."
+//	@Param			fromDate				query	string	false	"Transactions at and after this date. Ignores exact time, matches on the day of the RFC3339 timestamp provided."
+//	@Param			untilDate				query	string	false	"Transactions before and at this date. Ignores exact time, matches on the day of the RFC3339 timestamp provided."
+//	@Param			amount					query	string	false	"Filter by amount"
+//	@Param			amountLessOrEqual		query	string	false	"Amount less than or equal to this"
+//	@Param			amountMoreOrEqual		query	string	false	"Amount more than or equal to this"
+//	@Param			note					query	string	false	"Filter by note"
+//	@Param			budget					query	string	false	"Filter by budget ID"
+//	@Param			account					query	string	false	"Filter by ID of associated account, regardeless of source or destination"
+//	@Param			source					query	string	false	"Filter by source account ID"
+//	@Param			destination				query	string	false	"Filter by destination account ID"
+//	@Param			envelope				query	string	false	"Filter by envelope ID"
+//	@Param			reconciledSource		query	bool	false	"Reconcilication state in source account"
+//	@Param			reconciledDestination	query	bool	false	"Reconcilication state in destination account"
+//
+//	@Param			offset					query	uint	false	"The offset of the first Transaction returned. Defaults to 0."
+//	@Param			limit					query	int		false	" Maximum number of transactions to return. Defaults to 50.".
+func (co Controller) GetTransactionsV3(c *gin.Context) {
+	var filter TransactionQueryFilterV3
+	if err := c.Bind(&filter); err != nil {
+		s := httperrors.ErrInvalidQueryString.Error()
+		c.JSON(http.StatusBadRequest, TransactionListResponseV3{
+			Error: &s,
+		})
+		return
+	}
+
+	// Get the fields set in the filter
+	queryFields, setFields := httputil.GetURLFields(c.Request.URL, filter)
+
+	// Convert the QueryFilter to a Create struct
+	create, err := filter.ToCreate(c)
+	if !err.Nil() {
+		e := err.Error()
+		c.JSON(err.Status, TransactionListResponseV3{
+			Error: &e,
+		})
+		return
+	}
+
+	var q *gorm.DB
+	q = co.DB.Order("datetime(date) DESC, datetime(created_at) DESC").Where(&models.Transaction{
+		TransactionCreate: create,
+	}, queryFields...)
+
+	// Filter for the transaction being at the same date
+	if !filter.Date.IsZero() {
+		date := time.Date(filter.Date.Year(), filter.Date.Month(), filter.Date.Day(), 0, 0, 0, 0, time.UTC)
+		q = q.Where("transactions.date >= date(?)", date).Where("transactions.date < date(?)", date.AddDate(0, 0, 1))
+	}
+
+	if !filter.FromDate.IsZero() {
+		q = q.Where("transactions.date >= date(?)", time.Date(filter.FromDate.Year(), filter.FromDate.Month(), filter.FromDate.Day(), 0, 0, 0, 0, time.UTC))
+	}
+
+	if !filter.UntilDate.IsZero() {
+		q = q.Where("transactions.date < date(?)", time.Date(filter.UntilDate.Year(), filter.UntilDate.Month(), filter.UntilDate.Day()+1, 0, 0, 0, 0, time.UTC))
+	}
+
+	if filter.AccountID != "" {
+		accountID, err := httputil.UUIDFromString(c, filter.AccountID)
+		if !err.Nil() {
+			s := fmt.Sprintf("Error parsing Account ID for filtering: %s", err.Error())
+			c.JSON(err.Status, TransactionListResponseV3{
+				Error: &s,
+			})
+			return
+		}
+
+		q = q.Where(co.DB.Where(&models.Transaction{
+			TransactionCreate: models.TransactionCreate{
+				SourceAccountID: accountID,
+			},
+		}).Or(&models.Transaction{
+			TransactionCreate: models.TransactionCreate{
+				DestinationAccountID: accountID,
+			},
+		}))
+	}
+
+	if !filter.AmountLessOrEqual.IsZero() {
+		q = q.Where("transactions.amount <= ?", filter.AmountLessOrEqual)
+	}
+
+	if !filter.AmountMoreOrEqual.IsZero() {
+		q = q.Where("transactions.amount >= ?", filter.AmountMoreOrEqual)
+	}
+
+	if filter.Note != "" {
+		q = q.Where("note LIKE 	?", fmt.Sprintf("%%%s%%", filter.Note))
+	} else if slices.Contains(setFields, "Note") {
+		q = q.Where("note = ''")
+	}
+
+	// Set the offset. Does not need checking since the default is 0
+	q = q.Offset(int(filter.Offset))
+
+	// Default to 50 transactions and set the limit
+	limit := 50
+	if slices.Contains(setFields, "Limit") {
+		limit = int(filter.Limit)
+	}
+	q = q.Limit(limit)
+
+	var transactions []models.Transaction
+	err = query(c, q.Find(&transactions))
+	if !err.Nil() {
+		e := err.Error()
+		c.JSON(err.Status, TransactionListResponseV3{
+			Error: &e,
+		})
+		return
+	}
+
+	var count int64
+	err = query(c, q.Limit(-1).Offset(-1).Count(&count))
+	if !err.Nil() {
+		e := err.Error()
+		c.JSON(err.Status, TransactionListResponseV3{
+			Error: &e,
+		})
+		return
+	}
+
+	transactionObjects := make([]TransactionV3, 0)
+	for _, t := range transactions {
+		transactionObject, err := co.getTransactionV3(c, t.ID)
+		if !err.Nil() {
+			e := err.Error()
+			c.JSON(err.Status, TransactionListResponseV3{
+				Error: &e,
+			})
+			return
+		}
+
+		transactionObjects = append(transactionObjects, transactionObject)
+	}
+
+	c.JSON(http.StatusOK, TransactionListResponseV3{
+		Data: transactionObjects,
+		Pagination: &Pagination{
+			Count:  len(transactionObjects),
+			Total:  count,
+			Offset: filter.Offset,
+			Limit:  limit,
+		},
+	})
+}

--- a/pkg/controllers/transaction_v3_test.go
+++ b/pkg/controllers/transaction_v3_test.go
@@ -1,0 +1,201 @@
+package controllers_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/envelope-zero/backend/v3/pkg/controllers"
+	"github.com/envelope-zero/backend/v3/pkg/models"
+	"github.com/envelope-zero/backend/v3/test"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *TestSuiteStandard) TestTransactionsV3() {
+	suite.CloseDB()
+
+	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v3/transactions", "")
+	assertHTTPStatus(suite.T(), &recorder, http.StatusInternalServerError)
+	assert.Contains(suite.T(), test.DecodeError(suite.T(), recorder.Body.Bytes()), "there is a problem with the database connection")
+}
+
+// TestGetTransactions verifies that transactions can be read from the API.
+// It also acts as a regression test for a bug where transactions were sorted by date(date)
+// instead of datetime(date), leading to transactions being correctly sorted by dates, but
+// not correctly sorted when multiple transactions occurred on a day. In that case, the
+// oldest transaction would be at the bottom and not at the top.
+func (suite *TestSuiteStandard) TestGetTransactionsV3() {
+	t1 := suite.createTestTransaction(models.TransactionCreate{
+		Amount: decimal.NewFromFloat(17.23),
+		Date:   time.Date(2023, 11, 10, 10, 11, 12, 0, time.UTC),
+	})
+
+	_ = suite.createTestTransaction(models.TransactionCreate{
+		Amount: decimal.NewFromFloat(23.42),
+		Date:   time.Date(2023, 11, 10, 11, 12, 13, 0, time.UTC),
+	})
+
+	// Need to sleep 1 second because SQLite datetime only has second precision
+	time.Sleep(1 * time.Second)
+
+	t3 := suite.createTestTransaction(models.TransactionCreate{
+		Amount: decimal.NewFromFloat(44.05),
+		Date:   time.Date(2023, 11, 10, 10, 11, 12, 0, time.UTC),
+	})
+
+	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v3/transactions", "")
+
+	var response controllers.TransactionListResponseV3
+	suite.decodeResponse(&recorder, &response)
+
+	assert.Equal(suite.T(), 200, recorder.Code)
+	assert.Len(suite.T(), response.Data, 3)
+
+	// Verify that the transaction with the earlier date is the last in the list
+	assert.Equal(suite.T(), t1.Data.ID, response.Data[2].ID, t1.Data.CreatedAt)
+
+	// Verify that the transaction added for the same time as the first, but added later
+	// is before the other
+	assert.Equal(suite.T(), t3.Data.ID, response.Data[1].ID, t3.Data.CreatedAt)
+}
+
+func (suite *TestSuiteStandard) TestGetTransactionsInvalidQueryV3() {
+	tests := []string{
+		"budget=DefinitelyACat",
+		"source=MaybeADog",
+		"destination=OrARat?",
+		"envelope=NopeDefinitelyAMole",
+		"date=A long time ago",
+		"amount=Seventeen Cents",
+		"reconciledSource=I don't think so",
+		"account=ItIsAHippo!",
+		"offset=-1",  // offset is a uint
+		"limit=name", // limit is an int
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt, func(t *testing.T) {
+			recorder := test.Request(suite.controller, suite.T(), http.MethodGet, fmt.Sprintf("http://example.com/v3/transactions?%s", tt), "")
+			assertHTTPStatus(suite.T(), &recorder, http.StatusBadRequest)
+		})
+	}
+}
+
+func (suite *TestSuiteStandard) TestGetTransactionsFilterV3() {
+	b := suite.createTestBudget(models.BudgetCreate{})
+
+	a1 := suite.createTestAccount(models.AccountCreate{BudgetID: b.Data.ID, Name: "TestGetTransactionsFilterV3 1"})
+	a2 := suite.createTestAccount(models.AccountCreate{BudgetID: b.Data.ID, Name: "TestGetTransactionsFilterV3 2"})
+	a3 := suite.createTestAccount(models.AccountCreate{BudgetID: b.Data.ID, Name: "TestGetTransactionsFilterV3 3"})
+
+	c := suite.createTestCategory(models.CategoryCreate{BudgetID: b.Data.ID})
+
+	e1 := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: c.Data.ID})
+	e2 := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: c.Data.ID})
+
+	e1ID := &e1.Data.ID
+	e2ID := &e2.Data.ID
+
+	_ = suite.createTestTransaction(models.TransactionCreate{
+		Date:                  time.Date(2018, 9, 5, 17, 13, 29, 45256, time.UTC),
+		Amount:                decimal.NewFromFloat(2.718),
+		Note:                  "This was an important expense",
+		BudgetID:              b.Data.ID,
+		EnvelopeID:            e1ID,
+		SourceAccountID:       a1.Data.ID,
+		DestinationAccountID:  a2.Data.ID,
+		Reconciled:            false,
+		ReconciledSource:      true,
+		ReconciledDestination: false,
+	})
+
+	_ = suite.createTestTransaction(models.TransactionCreate{
+		Date:                  time.Date(2016, 5, 1, 14, 13, 25, 584575, time.UTC),
+		Amount:                decimal.NewFromFloat(11235.813),
+		Note:                  "Not important",
+		BudgetID:              b.Data.ID,
+		EnvelopeID:            e2ID,
+		SourceAccountID:       a2.Data.ID,
+		DestinationAccountID:  a1.Data.ID,
+		Reconciled:            false,
+		ReconciledSource:      true,
+		ReconciledDestination: true,
+	})
+
+	_ = suite.createTestTransaction(models.TransactionCreate{
+		Date:                  time.Date(2021, 2, 6, 5, 1, 0, 585, time.UTC),
+		Amount:                decimal.NewFromFloat(2.718),
+		Note:                  "",
+		BudgetID:              b.Data.ID,
+		EnvelopeID:            e1ID,
+		SourceAccountID:       a3.Data.ID,
+		DestinationAccountID:  a2.Data.ID,
+		Reconciled:            true,
+		ReconciledSource:      false,
+		ReconciledDestination: true,
+	})
+
+	tests := []struct {
+		name  string
+		query string
+		len   int
+	}{
+		{"Exact Time", fmt.Sprintf("date=%s", time.Date(2021, 2, 6, 5, 1, 0, 585, time.UTC).Format(time.RFC3339Nano)), 1},
+		{"Same date", fmt.Sprintf("date=%s", time.Date(2021, 2, 6, 7, 0, 0, 700, time.UTC).Format(time.RFC3339Nano)), 1},
+		{"After date", fmt.Sprintf("fromDate=%s", time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)), 2},
+		{"Before date", fmt.Sprintf("untilDate=%s", time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)), 1},
+		{"After all dates", fmt.Sprintf("fromDate=%s", time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)), 0},
+		{"Before all dates", fmt.Sprintf("untilDate=%s", time.Date(2010, 8, 17, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)), 0},
+		{"Regression #749", fmt.Sprintf("untilDate=%s", time.Date(2021, 2, 6, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)), 3},
+		{"Between two dates", fmt.Sprintf("untilDate=%s&fromDate=%s", time.Date(2019, 8, 17, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano), time.Date(2015, 12, 24, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)), 2},
+		{"Impossible between two dates", fmt.Sprintf("fromDate=%s&untilDate=%s", time.Date(2019, 8, 17, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano), time.Date(2015, 12, 24, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)), 0},
+		{"Exact Amount", fmt.Sprintf("amount=%s", decimal.NewFromFloat(2.718).String()), 2},
+		{"Note", "note=Not important", 1},
+		{"No note", "note=", 1},
+		{"Fuzzy note", "note=important", 2},
+		{"Budget Match", fmt.Sprintf("budget=%s", b.Data.ID), 3},
+		{"Envelope 2", fmt.Sprintf("envelope=%s", e2.Data.ID), 1},
+		{"Non-existing Source Account", "source=3340a084-acf8-4cb4-8f86-9e7f88a86190", 0},
+		{"Destination Account", fmt.Sprintf("destination=%s", a2.Data.ID), 2},
+		{"Not reconciled in source account", "reconciledSource=false", 1},
+		{"Not reconciled in destination account", "reconciledDestination=false", 1},
+		{"Reconciled in source account", "reconciledSource=true", 2},
+		{"Reconciled in destination account", "reconciledDestination=true", 2},
+		{"Non-existing Account", "account=534a3562-c5e8-46d1-a2e2-e96c00e7efec", 0},
+		{"Existing Account 2", fmt.Sprintf("account=%s", a2.Data.ID), 3},
+		{"Existing Account 1", fmt.Sprintf("account=%s", a1.Data.ID), 2},
+		{"Amount less or equal to 2.71", "amountLessOrEqual=2.71", 0},
+		{"Amount less or equal to 2.718", "amountLessOrEqual=2.718", 2},
+		{"Amount less or equal to 1000", "amountLessOrEqual=1000", 2},
+		{"Amount more or equal to 2.718", "amountMoreOrEqual=2.718", 3},
+		{"Amount more or equal to 11235.813", "amountMoreOrEqual=11235.813", 1},
+		{"Amount more or equal to 99999", "amountMoreOrEqual=99999", 0},
+		{"Amount more or equal to 100", "amountMoreOrEqual=100", 1},
+		{"Amount more or equal to 100 and less than 10", "amountMoreOrEqual=100&amountLessOrEqual=10", 0},
+		{"Amount more or equal to 1 and less than 3", "amountMoreOrEqual=1&amountLessOrEqual=3", 2},
+		{"Regression - For 'account', query needs to be ORed between the accounts and ANDed with all other conditions", fmt.Sprintf("note=&account=%s", a2.Data.ID), 1},
+		{"Limit positive", "limit=2", 2},
+		{"Limit zero", "limit=0", 0},
+		{"Limit unset", "limit=-1", 3},
+		{"Limit negative", "limit=-123", 3},
+		{"Offset zero", "offset=0", 3},
+		{"Offset positive", "offset=2", 1},
+		{"Offset higher than number", "offset=5", 0},
+		{"Limit and Offset", "limit=1&offset=1", 1},
+		{"Limit and Fuzzy Note", "limit=1&note=important", 1},
+		{"Offset and Fuzzy Note", "offset=2&note=important", 0},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			var re controllers.TransactionListResponse
+			r := test.Request(suite.controller, t, http.MethodGet, fmt.Sprintf("/v3/transactions?%s", tt.query), "")
+			assertHTTPStatus(suite.T(), &r, http.StatusOK)
+			suite.decodeResponse(&r, &re)
+
+			assert.Equal(t, tt.len, len(re.Data), "Request ID: %s", r.Result().Header.Get("x-request-id"))
+		})
+	}
+}

--- a/pkg/httperrors/errors.go
+++ b/pkg/httperrors/errors.go
@@ -17,12 +17,26 @@ import (
 	"gorm.io/gorm"
 )
 
+var (
+	ErrInvalidQueryString = errors.New("the query string contains unparseable data. Please check the values")
+	ErrInvalidUUID        = errors.New("the specified resource ID is not a valid UUID")
+	ErrNoResource         = errors.New("there is no resource for the ID you specified")
+	ErrDatabaseClosed     = errors.New("there is a problem with the database connection, please try again later")
+	ErrRequestBodyEmpty   = errors.New("the request body must not be empty")
+)
+
 // Generate a struct containing the HTTP error on the fly.
 func New(c *gin.Context, status int, msgAndArgs ...any) {
 	// Format msgAndArgs in a final string.
 	// This is taken almost exactly from https://github.com/stretchr/testify/blob/181cea6eab8b2de7071383eca4be32a424db38dd/assert/assertions.go#L181
 	msg := ""
 	if len(msgAndArgs) == 1 {
+		// If the only argument is a pointer to a string
+		if msgAsStr, ok := msgAndArgs[0].(*string); ok {
+			msg = *msgAsStr
+		}
+
+		// If it is a string
 		if msgAsStr, ok := msgAndArgs[0].(string); ok {
 			msg = msgAsStr
 		}
@@ -39,11 +53,11 @@ func New(c *gin.Context, status int, msgAndArgs ...any) {
 }
 
 func InvalidUUID(c *gin.Context) {
-	New(c, http.StatusBadRequest, "The specified resource ID is not a valid UUID")
+	New(c, http.StatusBadRequest, ErrInvalidUUID.Error())
 }
 
 func InvalidQueryString(c *gin.Context) {
-	New(c, http.StatusBadRequest, "The query string contains unparseable data. Please check the values")
+	New(c, http.StatusBadRequest, ErrInvalidQueryString.Error())
 }
 
 func InvalidMonth(c *gin.Context) {
@@ -51,81 +65,124 @@ func InvalidMonth(c *gin.Context) {
 }
 
 // GenericDBError wraps DBError with a more specific error message for not found errors.
-func GenericDBError[T models.Model](r T, c *gin.Context, err error) ErrorStatus {
+func GenericDBError[T models.Model](r T, c *gin.Context, err error) Error {
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return ErrorStatus{Status: http.StatusNotFound, Err: fmt.Errorf("there is no %s with this ID", r.Self())}
+		return Error{Status: http.StatusNotFound, Err: fmt.Errorf("there is no %s with this ID", r.Self())}
 	}
 
 	return DBError(c, err)
 }
 
 // DBError returns an error message and status code appropriate to the error that has occurred.
-func DBError(c *gin.Context, err error) ErrorStatus {
+func DBError(c *gin.Context, err error) Error {
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return ErrorStatus{Status: http.StatusNotFound, Err: errors.New("there is no resource for the ID you specified")}
+		return Error{Status: http.StatusNotFound, Err: ErrNoResource}
 	}
 
 	// Availability month is set before the month of the transaction
 	if strings.Contains(err.Error(), "availability month must not be earlier than the month of the transaction") {
-		return ErrorStatus{Status: http.StatusBadRequest, Err: err}
+		return Error{Status: http.StatusBadRequest, Err: err}
 	}
 
 	// Account cannot be on budget because transactions have envelopes
 	if strings.Contains(err.Error(), "the account cannot be set to on budget because") {
-		return ErrorStatus{Status: http.StatusBadRequest, Err: err}
+		return Error{Status: http.StatusBadRequest, Err: err}
 	}
 
 	// Account name must be unique per Budget
 	if strings.Contains(err.Error(), "UNIQUE constraint failed: accounts.name, accounts.budget_id") {
-		return ErrorStatus{Status: http.StatusBadRequest, Err: errors.New("the account name must be unique for the budget")}
+		return Error{Status: http.StatusBadRequest, Err: errors.New("the account name must be unique for the budget")}
 	}
 
 	// Category names need to be unique per budget
 	if strings.Contains(err.Error(), "UNIQUE constraint failed: categories.name, categories.budget_id") {
-		return ErrorStatus{Status: http.StatusBadRequest, Err: errors.New("the category name must be unique for the budget")}
+		return Error{Status: http.StatusBadRequest, Err: errors.New("the category name must be unique for the budget")}
 	}
 
 	// Unique envelope names per category
 	if strings.Contains(err.Error(), "UNIQUE constraint failed: envelopes.name, envelopes.category_id") {
-		return ErrorStatus{Status: http.StatusBadRequest, Err: errors.New("the envelope name must be unique for the category")}
+		return Error{Status: http.StatusBadRequest, Err: errors.New("the envelope name must be unique for the category")}
 	}
 
 	// Only one allocation per envelope per month
 	if strings.Contains(err.Error(), "UNIQUE constraint failed: allocations.month, allocations.envelope_id") {
-		return ErrorStatus{Status: http.StatusBadRequest, Err: errors.New("you can not create multiple allocations for the same month")}
+		return Error{Status: http.StatusBadRequest, Err: errors.New("you can not create multiple allocations for the same month")}
 	}
 
 	// Source and destination accounts need to be different
 	if strings.Contains(err.Error(), "CHECK constraint failed: source_destination_different") {
-		return ErrorStatus{Status: http.StatusBadRequest, Err: errors.New("source and destination accounts for a transaction must be different")}
+		return Error{Status: http.StatusBadRequest, Err: errors.New("source and destination accounts for a transaction must be different")}
 	}
 
 	// General message when a field references a non-existing resource
 	if strings.Contains(err.Error(), "constraint failed: FOREIGN KEY constraint failed") {
-		return ErrorStatus{Status: http.StatusBadRequest, Err: errors.New("there is no resource for the ID you specificed in the reference to another resource")}
+		return Error{Status: http.StatusBadRequest, Err: errors.New("there is no resource for the ID you specificed in the reference to another resource")}
 	}
 
 	// Database is read only or file has been deleted
 	if strings.Contains(err.Error(), "attempt to write a readonly database (1032)") {
 		log.Error().Msgf("Database is in read-only mode. This might be due to the file being deleted: %#v", err)
-		return ErrorStatus{Status: http.StatusInternalServerError, Err: errors.New("the database is currently in read-only mode, please try again later")}
+		return Error{Status: http.StatusInternalServerError, Err: errors.New("the database is currently in read-only mode, please try again later")}
 	}
 
 	// A general error we do not know more about
 	log.Error().Msgf("%T: %v", err, err.Error())
-	return ErrorStatus{Status: http.StatusInternalServerError, Err: fmt.Errorf("an error occurred on the server during your request, please contact your server administrator. The request id is '%v', send this to your server administrator to help them finding the problem", requestid.Get(c))}
+	return Error{Status: http.StatusInternalServerError, Err: fmt.Errorf("an error occurred on the server during your request, please contact your server administrator. The request id is '%v', send this to your server administrator to help them finding the problem", requestid.Get(c))}
+}
+
+// Parse parses an error and returns an appropriate Error struct.
+//
+// If the error is not well known, it is logged and a generic message
+// with the Request ID returned. This is done to prevent leaking sensitive
+// data.
+func Parse(c *gin.Context, err error) Error {
+	// No record found => 404
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return Error{
+			Status: http.StatusNotFound,
+			Err:    ErrNoResource,
+		}
+
+		// Database error
+	} else if reflect.TypeOf(err) == reflect.TypeOf(&sqlite.Error{}) {
+		return DBError(c, err)
+	} else if errors.Is(err, models.ErrAllocationZero) {
+		return Error{
+			Status: http.StatusBadRequest,
+			Err:    err,
+		}
+
+		// Database connection has not been opened or has been closed already
+	} else if strings.Contains(err.Error(), "sql: database is closed") {
+		log.Error().Msgf("Database connection is closed: %#v", err)
+		return Error{
+			Status: http.StatusInternalServerError,
+			Err:    ErrDatabaseClosed,
+		}
+
+		// End of file reached when reading
+	} else if errors.Is(io.EOF, err) {
+		return Error{Status: http.StatusBadRequest, Err: ErrRequestBodyEmpty}
+
+		// Time could not be parsed. Return the error string as lets the user
+		// know the exact issue
+	} else if reflect.TypeOf(err) == reflect.TypeOf(&time.ParseError{}) {
+		return Error{Status: http.StatusBadRequest, Err: err}
+	}
+
+	log.Error().Str("request-id", requestid.Get(c)).Msgf("%T: %v", err, err.Error())
+	return Error{Status: http.StatusInternalServerError, Err: fmt.Errorf("an error occurred on the server during your request, please contact your server administrator. The request id is '%v', send this to your server administrator to help them finding the problem", requestid.Get(c))}
 }
 
 // Handler handles errors for fetching data from the database.
-func Handler(c *gin.Context, err error, notFoundMsg ...string) {
+//
+// This function is deprecated. Use Parse and handle HTTP responses
+// in the calling function.
+func Handler(c *gin.Context, err error) {
 	// No record found => 404
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		// Allow the specification of more exact messages when no resource is found
-		msg := "There is no resource for the ID you specified"
-		if len(notFoundMsg) > 0 {
-			msg = notFoundMsg[0]
-		}
-
+		msg := "there is no resource for the ID you specified"
 		New(c, http.StatusNotFound, msg)
 
 		// Database error

--- a/pkg/httperrors/types.go
+++ b/pkg/httperrors/types.go
@@ -4,25 +4,19 @@ type HTTPError struct {
 	Error string `json:"error" example:"An ID specified in the query string was not a valid UUID"`
 }
 
-// ErrorStatus is used to return an error with the corresponding HTTP status code to a controller.
-type ErrorStatus struct {
+// Error is used to return an error with the corresponding HTTP status code to a controller.
+type Error struct {
 	Err    error
 	Status int // Used with http.StatusX for the corresponding HTTP status code
 }
 
 // Nil checks if the ErrorStatus is the zero value.
-func (e ErrorStatus) Nil() bool {
+func (e Error) Nil() bool {
 	return e.Err == nil && e.Status == 0
 }
 
-// Body returns the the content of the HTTP response body for the error.
-func (e ErrorStatus) Body() map[string]string {
-	return map[string]string{
-		"error": e.Error(),
-	}
-}
-
-// Error returns the error as string.
-func (e ErrorStatus) Error() string {
-	return e.Err.Error()
+// Error returns the error as a string.
+func (e Error) Error() string {
+	s := e.Err.Error()
+	return s
 }

--- a/pkg/httperrors/types_test.go
+++ b/pkg/httperrors/types_test.go
@@ -1,7 +1,6 @@
 package httperrors_test
 
 import (
-	"errors"
 	"net/http"
 	"testing"
 
@@ -10,23 +9,13 @@ import (
 )
 
 func TestErrorStatusNil(t *testing.T) {
-	err := httperrors.ErrorStatus{}
+	err := httperrors.Error{}
 	assert.True(t, err.Nil())
 }
 
 func TestErrorStatusNotNil(t *testing.T) {
-	err := httperrors.ErrorStatus{
+	err := httperrors.Error{
 		Status: http.StatusOK,
 	}
 	assert.False(t, err.Nil())
-}
-
-func TestErrorStatusBody(t *testing.T) {
-	err := httperrors.ErrorStatus{
-		Status: http.StatusBadRequest,
-		Err:    errors.New("Testing the response body"),
-	}
-	assert.Equal(t, map[string]string{
-		"error": "Testing the response body",
-	}, err.Body())
 }

--- a/pkg/httputil/request.go
+++ b/pkg/httputil/request.go
@@ -32,7 +32,9 @@ func BindData(c *gin.Context, data interface{}) error {
 
 // This is needed because gin does not support form binding to uuid.UUID currently.
 // Follow https://github.com/gin-gonic/gin/pull/3045 to see when this gets resolved.
-func UUIDFromString(c *gin.Context, s string) (uuid.UUID, bool) {
+//
+// This method is deprecated. Use UUIDFromString and handle errors in the calling method.
+func UUIDFromStringHandleErrors(c *gin.Context, s string) (uuid.UUID, bool) {
 	if s == "" {
 		return uuid.Nil, true
 	}
@@ -44,4 +46,24 @@ func UUIDFromString(c *gin.Context, s string) (uuid.UUID, bool) {
 	}
 
 	return u, true
+}
+
+// UUIDFromString binds a string to a UUID
+//
+// This is needed because gin does not support form binding to uuid.UUID currently.
+// Follow https://github.com/gin-gonic/gin/pull/3045 to see when this gets resolved.
+func UUIDFromString(_ *gin.Context, s string) (uuid.UUID, httperrors.Error) {
+	if s == "" {
+		return uuid.Nil, httperrors.Error{}
+	}
+
+	u, err := uuid.Parse(s)
+	if err != nil {
+		return uuid.Nil, httperrors.Error{
+			Status: http.StatusBadRequest,
+			Err:    httperrors.ErrInvalidUUID,
+		}
+	}
+
+	return u, httperrors.Error{}
 }

--- a/pkg/httputil/request_test.go
+++ b/pkg/httputil/request_test.go
@@ -78,7 +78,7 @@ func TestUUIDFromString(t *testing.T) {
 		}
 
 		_ = c.Bind(&o)
-		_, ok := httputil.UUIDFromString(c, o.UUID)
+		_, ok := httputil.UUIDFromStringHandleErrors(c, o.UUID)
 		if !ok {
 			c.AbortWithStatus(http.StatusBadRequest)
 		}
@@ -100,7 +100,7 @@ func TestUUIDFromStringInvalid(t *testing.T) {
 		}
 
 		_ = c.Bind(&o)
-		_, ok := httputil.UUIDFromString(c, o.UUID)
+		_, ok := httputil.UUIDFromStringHandleErrors(c, o.UUID)
 		if !ok {
 			c.AbortWithStatus(http.StatusBadRequest)
 		}
@@ -122,7 +122,7 @@ func TestUUIDFromStringEmpty(t *testing.T) {
 		}
 
 		_ = c.Bind(&o)
-		_, ok := httputil.UUIDFromString(c, o.UUID)
+		_, ok := httputil.UUIDFromStringHandleErrors(c, o.UUID)
 		if !ok {
 			c.AbortWithStatus(http.StatusBadRequest)
 		}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -138,6 +138,15 @@ func AttachRoutes(co controllers.Controller, group *gin.RouterGroup) {
 	co.RegisterTransactionRoutesV2(v2.Group("/transactions"))
 	co.RegisterRenameRuleRoutes(v2.Group("/rename-rules"))
 	co.RegisterMatchRuleRoutes(v2.Group("/match-rules"))
+
+	// API v3 setup
+	v3 := group.Group("/v3")
+	{
+		v3.GET("", GetV3)
+		v3.OPTIONS("", OptionsV3)
+	}
+
+	co.RegisterTransactionRoutesV3(v3.Group("/transactions"))
 }
 
 type RootResponse struct {
@@ -150,6 +159,7 @@ type RootLinks struct {
 	Version string `json:"version" example:"https://example.com/api/version"`      // Endpoint returning the version of the backend
 	V1      string `json:"v1" example:"https://example.com/api/v1"`                // List endpoint for all v1 endpoints
 	V2      string `json:"v2" example:"https://example.com/api/v2"`                // List endpoint for all v2 endpoints
+	V3      string `json:"v3" example:"https://example.com/api/v3"`                // List endpoint for all v3 endpoints
 }
 
 // GetRoot returns the link list for the API root
@@ -167,6 +177,7 @@ func GetRoot(c *gin.Context) {
 			Version: c.GetString(string(database.ContextURL)) + "/version",
 			V1:      c.GetString(string(database.ContextURL)) + "/v1",
 			V2:      c.GetString(string(database.ContextURL)) + "/v2",
+			V3:      c.GetString(string(database.ContextURL)) + "/v3",
 		},
 	})
 }
@@ -300,5 +311,39 @@ func GetV2(c *gin.Context) {
 //	@Success		204
 //	@Router			/v2 [options]
 func OptionsV2(c *gin.Context) {
+	httputil.OptionsGet(c)
+}
+
+type V3Response struct {
+	Links V3Links `json:"links"` // Links for the v2 API
+}
+
+type V3Links struct {
+	Transactions string `json:"transactions" example:"https://example.com/api/v3/transactions"` // URL of transaction collection endpoint
+}
+
+// GetV3 returns the link list for v3
+//
+//	@Summary		v3 API
+//	@Description	Returns general information about the v3 API
+//	@Tags			v3
+//	@Success		200	{object}	V3Response
+//	@Router			/v3 [get]
+func GetV3(c *gin.Context) {
+	c.JSON(http.StatusOK, V3Response{
+		Links: V3Links{
+			Transactions: c.GetString(string(database.ContextURL)) + "/v3/transactions",
+		},
+	})
+}
+
+// OptionsV3 returns the allowed HTTP methods
+//
+//	@Summary		Allowed HTTP verbs
+//	@Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
+//	@Tags			v3
+//	@Success		204
+//	@Router			/v3 [options]
+func OptionsV3(c *gin.Context) {
 	httputil.OptionsGet(c)
 }

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -92,6 +92,7 @@ func TestGetRoot(t *testing.T) {
 			Version: "/version",
 			V1:      "/v1",
 			V2:      "/v2",
+			V3:      "/v3",
 		},
 	}
 
@@ -169,6 +170,33 @@ func TestGetV2(t *testing.T) {
 	assert.Equal(t, l, lr)
 }
 
+func TestGetV3(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.GET("/v3", func(ctx *gin.Context) {
+		router.GetV3(c)
+	})
+
+	// Test contexts cannot be injected any middleware, therefore
+	// this only tests the path, not the host
+	l := router.V3Response{
+		Links: router.V3Links{
+			Transactions: "/v3/transactions",
+		},
+	}
+
+	var lr router.V3Response
+
+	c.Request, _ = http.NewRequest(http.MethodGet, "http://example.com/v3", nil)
+	r.ServeHTTP(w, c.Request)
+
+	decodeResponse(t, w, &lr)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, l, lr)
+}
+
 func TestGetVersion(t *testing.T) {
 	t.Parallel()
 	w := httptest.NewRecorder()
@@ -205,6 +233,8 @@ func TestOptions(t *testing.T) {
 		{"/", router.OptionsRoot, "OPTIONS, GET"},
 		{"/version", router.OptionsVersion, "OPTIONS, GET"},
 		{"/v1", router.OptionsV1, "OPTIONS, GET, DELETE"},
+		{"/v2", router.OptionsV2, "OPTIONS, GET"},
+		{"/v3", router.OptionsV3, "OPTIONS, GET"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This adds the first endpoint for API v3: /v3/transactions.

It is the collection endpoint for Transactions, supporting pagination.
For transactions, the default `limit` is set to `50`.
