### PR TITLE
refactor: define all errors as variables

### DIFF
--- a/pkg/controllers/month_config_test.go
+++ b/pkg/controllers/month_config_test.go
@@ -162,7 +162,7 @@ func (suite *TestSuiteStandard) TestMonthConfigsOptions() {
 		errMsg   string
 	}{
 		{"Bad Envelope ID", "Definitely-Not-A-UUID", "1984-03", http.StatusBadRequest, "not a valid UUID"},
-		{"Invalid Month", envelope.Data.ID.String(), "2000-00", http.StatusBadRequest, "Could not parse the specified month"},
+		{"Invalid Month", envelope.Data.ID.String(), "2000-00", http.StatusBadRequest, "could not parse the specified month"},
 		{"No envelope", uuid.New().String(), "1984-03", http.StatusNoContent, ""},
 		{"No MonthConfig", envelope.Data.ID.String(), "1984-03", http.StatusNoContent, ""},
 		{"Existing", envelope.Data.ID.String(), "2014-05", http.StatusNoContent, ""},

--- a/pkg/httperrors/errors_test.go
+++ b/pkg/httperrors/errors_test.go
@@ -166,7 +166,7 @@ func TestDatabaseErrorMessages(t *testing.T) {
 		{http.StatusBadRequest, "UNIQUE constraint failed: categories.name, categories.budget_id", "the category name must be unique for the budget"},
 		{http.StatusBadRequest, "UNIQUE constraint failed: envelopes.name, envelopes.category_id", "the envelope name must be unique for the category"},
 		{http.StatusBadRequest, "UNIQUE constraint failed: allocations.month, allocations.envelope_id", "you can not create multiple allocations for the same month"},
-		{http.StatusBadRequest, "constraint failed: FOREIGN KEY constraint failed", "there is no resource for the ID you specificed in the reference to another resource"},
+		{http.StatusBadRequest, "constraint failed: FOREIGN KEY constraint failed", "a resource you are referencing in another resource does not exist"},
 		{http.StatusInternalServerError, "This is a very weird error", "an error occurred on the server during your request, please contact your server administrator. The request id is '', send this to your server administrator to help them finding the problem"},
 		{http.StatusInternalServerError, "attempt to write a readonly database (1032)", "the database is currently in read-only mode, please try again later"},
 	}
@@ -221,7 +221,7 @@ func TestDatabaseNo(t *testing.T) {
 		{http.StatusBadRequest, "UNIQUE constraint failed: categories.name, categories.budget_id", "the category name must be unique for the budget"},
 		{http.StatusBadRequest, "UNIQUE constraint failed: envelopes.name, envelopes.category_id", "the envelope name must be unique for the category"},
 		{http.StatusBadRequest, "UNIQUE constraint failed: allocations.month, allocations.envelope_id", "you can not create multiple allocations for the same month"},
-		{http.StatusBadRequest, "constraint failed: FOREIGN KEY constraint failed", "there is no resource for the ID you specificed in the reference to another resource"},
+		{http.StatusBadRequest, "constraint failed: FOREIGN KEY constraint failed", "a resource you are referencing in another resource does not exist"},
 		{http.StatusInternalServerError, "This is a very weird error", "an error occurred on the server during your request, please contact your server administrator. The request id is '', send this to your server administrator to help them finding the problem"},
 		{http.StatusInternalServerError, "attempt to write a readonly database (1032)", "the database is currently in read-only mode, please try again later"},
 	}


### PR DESCRIPTION
This defines the remaining errors in the httperrors package as exported variables.
