### PR TITLE
chore: deprecate /v1/transactions and /v2/transactions endpoints

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2637,6 +2637,7 @@ const docTemplate = `{
                     "Transactions"
                 ],
                 "summary": "Get transactions",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2804,6 +2805,7 @@ const docTemplate = `{
                     "Transactions"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -3737,6 +3739,7 @@ const docTemplate = `{
                     "Transactions"
                 ],
                 "summary": "Create transactions",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Transactions",
@@ -3793,6 +3796,7 @@ const docTemplate = `{
                     "Transactions"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2626,6 +2626,7 @@
                     "Transactions"
                 ],
                 "summary": "Get transactions",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2793,6 +2794,7 @@
                     "Transactions"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -3726,6 +3728,7 @@
                     "Transactions"
                 ],
                 "summary": "Create transactions",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Transactions",
@@ -3782,6 +3785,7 @@
                     "Transactions"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3323,6 +3323,7 @@ paths:
       - Months
   /v1/transactions:
     get:
+      deprecated: true
       description: Returns a list of transactions
       parameters:
       - description: Date of the transaction. Ignores exact time, matches on the day
@@ -3408,6 +3409,7 @@ paths:
       tags:
       - Transactions
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       responses:
@@ -4073,6 +4075,7 @@ paths:
       - RenameRules
   /v2/transactions:
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       responses:
@@ -4082,6 +4085,7 @@ paths:
       tags:
       - Transactions
     post:
+      deprecated: true
       description: Creates transactions from the list of submitted transaction data.
         The response code is the highest response code number that a single transaction
         creation would have caused. If it is not equal to 201, at least one transaction

--- a/pkg/controllers/transaction_v1.go
+++ b/pkg/controllers/transaction_v1.go
@@ -98,6 +98,7 @@ func (co Controller) RegisterTransactionRoutes(r *gin.RouterGroup) {
 //	@Tags			Transactions
 //	@Success		204
 //	@Router			/v1/transactions [options]
+//	@Deprecated		true
 func (co Controller) OptionsTransactionList(c *gin.Context) {
 	httputil.OptionsGetPost(c)
 }
@@ -193,6 +194,7 @@ func (co Controller) CreateTransaction(c *gin.Context) {
 //	@Param			reconciled				query	bool	false	"DEPRECATED. Filter by reconcilication state"
 //	@Param			reconciledSource		query	bool	false	"Reconcilication state in source account"
 //	@Param			reconciledDestination	query	bool	false	"Reconcilication state in destination account"
+//	@Deprecated		true
 func (co Controller) GetTransactions(c *gin.Context) {
 	var filter TransactionQueryFilterV1
 	if err := c.Bind(&filter); err != nil {

--- a/pkg/controllers/transaction_v2.go
+++ b/pkg/controllers/transaction_v2.go
@@ -55,6 +55,7 @@ func (co Controller) RegisterTransactionRoutesV2(r *gin.RouterGroup) {
 //	@Tags			Transactions
 //	@Success		204
 //	@Router			/v2/transactions [options]
+//	@Deprecated		true
 func (co Controller) OptionsTransactionsV2(c *gin.Context) {
 	httputil.OptionsPost(c)
 }
@@ -71,6 +72,7 @@ func (co Controller) OptionsTransactionsV2(c *gin.Context) {
 //	@Failure		500				{object}	[]ResponseTransactionV2
 //	@Param			transactions	body		[]models.TransactionCreate	true	"Transactions"
 //	@Router			/v2/transactions [post]
+//	@Deprecated		true
 func (co Controller) CreateTransactionsV2(c *gin.Context) {
 	var transactions []models.Transaction
 


### PR DESCRIPTION
This deprecates the endpoints that are already available in /v3.
