### PR TITLE
docs: add examples for errors

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -4972,19 +4972,23 @@ const docTemplate = `{
             "properties": {
                 "count": {
                     "description": "The amount of records returned in this response",
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 25
                 },
                 "limit": {
                     "description": "The maximum amount of resources to return for this request",
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 25
                 },
                 "offset": {
                     "description": "The offset for the first record returned",
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 50
                 },
                 "total": {
                     "description": "The total number of resources matching the query",
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 827
                 }
             }
         },
@@ -5163,7 +5167,8 @@ const docTemplate = `{
                 },
                 "error": {
                     "description": "The error, if any occurred",
-                    "type": "string"
+                    "type": "string",
+                    "example": "the specified resource ID is not a valid UUID"
                 }
             }
         },
@@ -5191,7 +5196,8 @@ const docTemplate = `{
                 },
                 "error": {
                     "description": "The error, if any occurred",
-                    "type": "string"
+                    "type": "string",
+                    "example": "the specified resource ID is not a valid UUID"
                 },
                 "pagination": {
                     "description": "Pagination information",
@@ -5229,7 +5235,8 @@ const docTemplate = `{
                 },
                 "error": {
                     "description": "The error, if any occurred for this transaction",
-                    "type": "string"
+                    "type": "string",
+                    "example": "the specified resource ID is not a valid UUID"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -4961,19 +4961,23 @@
             "properties": {
                 "count": {
                     "description": "The amount of records returned in this response",
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 25
                 },
                 "limit": {
                     "description": "The maximum amount of resources to return for this request",
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 25
                 },
                 "offset": {
                     "description": "The offset for the first record returned",
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 50
                 },
                 "total": {
                     "description": "The total number of resources matching the query",
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 827
                 }
             }
         },
@@ -5152,7 +5156,8 @@
                 },
                 "error": {
                     "description": "The error, if any occurred",
-                    "type": "string"
+                    "type": "string",
+                    "example": "the specified resource ID is not a valid UUID"
                 }
             }
         },
@@ -5180,7 +5185,8 @@
                 },
                 "error": {
                     "description": "The error, if any occurred",
-                    "type": "string"
+                    "type": "string",
+                    "example": "the specified resource ID is not a valid UUID"
                 },
                 "pagination": {
                     "description": "Pagination information",
@@ -5218,7 +5224,8 @@
                 },
                 "error": {
                     "description": "The error, if any occurred for this transaction",
-                    "type": "string"
+                    "type": "string",
+                    "example": "the specified resource ID is not a valid UUID"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -535,15 +535,19 @@ definitions:
     properties:
       count:
         description: The amount of records returned in this response
+        example: 25
         type: integer
       limit:
         description: The maximum amount of resources to return for this request
+        example: 25
         type: integer
       offset:
         description: The offset for the first record returned
+        example: 50
         type: integer
       total:
         description: The total number of resources matching the query
+        example: 827
         type: integer
     type: object
   controllers.RenameRuleListResponse:
@@ -679,6 +683,7 @@ definitions:
         type: array
       error:
         description: The error, if any occurred
+        example: the specified resource ID is not a valid UUID
         type: string
     type: object
   controllers.TransactionListResponse:
@@ -698,6 +703,7 @@ definitions:
         type: array
       error:
         description: The error, if any occurred
+        example: the specified resource ID is not a valid UUID
         type: string
       pagination:
         allOf:
@@ -719,6 +725,7 @@ definitions:
         description: The transaction data, if creation was successful
       error:
         description: The error, if any occurred for this transaction
+        example: the specified resource ID is not a valid UUID
         type: string
     type: object
   controllers.TransactionV2:

--- a/pkg/controllers/responses.go
+++ b/pkg/controllers/responses.go
@@ -15,8 +15,8 @@ type ResponseMatchRule struct {
 
 // Pagination contains information about the pagination for collection endpoint responses.
 type Pagination struct {
-	Count  int   `json:"count"`  // The amount of records returned in this response
-	Offset uint  `json:"offset"` // The offset for the first record returned
-	Limit  int   `json:"limit"`  // The maximum amount of resources to return for this request
-	Total  int64 `json:"total"`  // The total number of resources matching the query
+	Count  int   `json:"count" example:"25"`  // The amount of records returned in this response
+	Offset uint  `json:"offset" example:"50"` // The offset for the first record returned
+	Limit  int   `json:"limit" example:"25"`  // The maximum amount of resources to return for this request
+	Total  int64 `json:"total" example:"827"` // The total number of resources matching the query
 }

--- a/pkg/controllers/transaction_v3.go
+++ b/pkg/controllers/transaction_v3.go
@@ -17,19 +17,19 @@ import (
 )
 
 type TransactionListResponseV3 struct {
-	Data       []TransactionV3 `json:"data"`       // List of transactions
-	Error      *string         `json:"error"`      // The error, if any occurred
-	Pagination *Pagination     `json:"pagination"` // Pagination information
+	Data       []TransactionV3 `json:"data"`                                                          // List of transactions
+	Error      *string         `json:"error" example:"the specified resource ID is not a valid UUID"` // The error, if any occurred
+	Pagination *Pagination     `json:"pagination"`                                                    // Pagination information
 }
 
 type TransactionCreateResponseV3 struct {
-	Error *string                 `json:"error"` // The error, if any occurred
-	Data  []TransactionResponseV3 `json:"data"`  // List of created transactions
+	Error *string                 `json:"error" example:"the specified resource ID is not a valid UUID"` // The error, if any occurred
+	Data  []TransactionResponseV3 `json:"data"`                                                          // List of created transactions
 }
 
 type TransactionResponseV3 struct {
-	Error *string        `json:"error"` // The error, if any occurred for this transaction
-	Data  *TransactionV3 `json:"data"`  // The transaction data, if creation was successful
+	Error *string        `json:"error" example:"the specified resource ID is not a valid UUID"` // The error, if any occurred for this transaction
+	Data  *TransactionV3 `json:"data"`                                                          // The transaction data, if creation was successful
 }
 
 // TransactionV3 is the representation of a Transaction in API v3.


### PR DESCRIPTION
This adds missing example error messages to the swagger API documentation.
