### PR TITLE
fix: only archive envelopes in category when archiving a category

### DIFF
--- a/pkg/models/category.go
+++ b/pkg/models/category.go
@@ -27,7 +27,7 @@ func (c Category) Self() string {
 func (c *Category) BeforeUpdate(tx *gorm.DB) (err error) {
 	if tx.Statement.Changed("Hidden") && !c.Hidden {
 		var envelopes []Envelope
-		err = tx.Model(&Envelope{EnvelopeCreate: EnvelopeCreate{
+		err = tx.Where(&Envelope{EnvelopeCreate: EnvelopeCreate{
 			CategoryID: c.ID,
 		}}).
 			Find(&envelopes).Error

--- a/pkg/models/category_test.go
+++ b/pkg/models/category_test.go
@@ -20,10 +20,37 @@ func (suite *TestSuiteStandard) TestCategoryArchiveArchivesEnvelopes() {
 	err := suite.db.Model(&category).Select("Hidden").Updates(models.Category{CategoryCreate: models.CategoryCreate{Hidden: true}}).Error
 	assert.Nil(suite.T(), err)
 
-	// Verify that the envelope is not archived
+	// Verify that the envelope is archived
 	err = suite.db.First(&envelope, envelope.ID).Error
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), envelope.Hidden, "Envelope was not archived together with category")
+}
+
+func (suite *TestSuiteStandard) TestCategoryArchiveNoEnvelopes() {
+	budget := suite.createTestBudget(models.BudgetCreate{})
+	category := suite.createTestCategory(models.CategoryCreate{
+		BudgetID: budget.ID,
+		Name:     "TestCategoryArchiveNoEnvelopes",
+	})
+
+	category2 := suite.createTestCategory(models.CategoryCreate{
+		BudgetID: budget.ID,
+	})
+
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{
+		CategoryID: category2.ID,
+		Hidden:     false,
+	})
+	assert.False(suite.T(), envelope.Hidden, "Envelope archived on creation, it should not be")
+
+	// Archive the empty category
+	err := suite.db.Model(&category).Select("Hidden").Updates(models.Category{CategoryCreate: models.CategoryCreate{Hidden: true}}).Error
+	assert.Nil(suite.T(), err)
+
+	// Verify that the envelope is not archived
+	err = suite.db.First(&envelope, envelope.ID).Error
+	assert.Nil(suite.T(), err)
+	assert.False(suite.T(), envelope.Hidden, "Envelope was archived together with category")
 }
 
 func (suite *TestSuiteStandard) TestCategorySetEnvelopes() {


### PR DESCRIPTION
fixes #845