### PR TITLE
fix: sort Match Rules

### DIFF
--- a/pkg/controllers/match_rule_v3.go
+++ b/pkg/controllers/match_rule_v3.go
@@ -228,7 +228,7 @@ func (co Controller) GetMatchRulesV3(c *gin.Context) {
 		return
 	}
 
-	q := co.DB.Where(&models.MatchRule{
+	q := co.DB.Order("priority ASC, match ASC").Where(&models.MatchRule{
 		MatchRuleCreate: create,
 	}, queryFields...)
 


### PR DESCRIPTION
With this, Match Rules are sorted by priority first and the match second.
