### PR TITLE
fix: remove reconciled field in API v3 responses

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -5840,10 +5840,8 @@ const docTemplate = `{
                     "example": "Lunch"
                 },
                 "reconciled": {
-                    "description": "DEPRECATED. Do not use, this field does not work as intended. See https://github.com/envelope-zero/backend/issues/528. Use reconciledSource and reconciledDestination instead. This field will be removed in 4.0.0",
-                    "type": "boolean",
-                    "default": false,
-                    "example": true
+                    "description": "Remove the reconciled field",
+                    "type": "boolean"
                 },
                 "reconciledDestination": {
                     "description": "Is the transaction reconciled in the destination account?",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -5829,10 +5829,8 @@
                     "example": "Lunch"
                 },
                 "reconciled": {
-                    "description": "DEPRECATED. Do not use, this field does not work as intended. See https://github.com/envelope-zero/backend/issues/528. Use reconciledSource and reconciledDestination instead. This field will be removed in 4.0.0",
-                    "type": "boolean",
-                    "default": false,
-                    "example": true
+                    "description": "Remove the reconciled field",
+                    "type": "boolean"
                 },
                 "reconciledDestination": {
                     "description": "Is the transaction reconciled in the destination account?",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -955,11 +955,7 @@ definitions:
         example: Lunch
         type: string
       reconciled:
-        default: false
-        description: DEPRECATED. Do not use, this field does not work as intended.
-          See https://github.com/envelope-zero/backend/issues/528. Use reconciledSource
-          and reconciledDestination instead. This field will be removed in 4.0.0
-        example: true
+        description: Remove the reconciled field
         type: boolean
       reconciledDestination:
         default: false

--- a/pkg/controllers/transaction_v3.go
+++ b/pkg/controllers/transaction_v3.go
@@ -35,7 +35,8 @@ type TransactionResponseV3 struct {
 // TransactionV3 is the representation of a Transaction in API v3.
 type TransactionV3 struct {
 	models.Transaction
-	Links struct {
+	Reconciled bool `json:"reconciled,omitempty"` // Remove the reconciled field
+	Links      struct {
 		Self string `json:"self" example:"https://example.com/api/v3/transactions/d430d7c3-d14c-4712-9336-ee56965a6673"` // The transaction itself
 	} `json:"links"` // Links for the transaction
 }


### PR DESCRIPTION
This removes the deprecated field from API v3 responses, where it should not have appeared in the first place.

It can still be used in requests, but will not have any effect since the field is ignored.
