### PR TITLE
chore: deprecate /v1/budgets endpoints

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -747,6 +747,7 @@ const docTemplate = `{
                     "Budgets"
                 ],
                 "summary": "List budgets",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -800,6 +801,7 @@ const docTemplate = `{
                     "Budgets"
                 ],
                 "summary": "Create budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Budget",
@@ -838,6 +840,7 @@ const docTemplate = `{
                     "Budgets"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -855,6 +858,7 @@ const docTemplate = `{
                     "Budgets"
                 ],
                 "summary": "Get budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -897,6 +901,7 @@ const docTemplate = `{
                     "Budgets"
                 ],
                 "summary": "Delete budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -936,6 +941,7 @@ const docTemplate = `{
                     "Budgets"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -981,6 +987,7 @@ const docTemplate = `{
                     "Budgets"
                 ],
                 "summary": "Update budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -736,6 +736,7 @@
                     "Budgets"
                 ],
                 "summary": "List budgets",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -789,6 +790,7 @@
                     "Budgets"
                 ],
                 "summary": "Create budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Budget",
@@ -827,6 +829,7 @@
                     "Budgets"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -844,6 +847,7 @@
                     "Budgets"
                 ],
                 "summary": "Get budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -886,6 +890,7 @@
                     "Budgets"
                 ],
                 "summary": "Delete budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -925,6 +930,7 @@
                     "Budgets"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -970,6 +976,7 @@
                     "Budgets"
                 ],
                 "summary": "Update budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2260,6 +2260,7 @@ paths:
       - Allocations
   /v1/budgets:
     get:
+      deprecated: true
       description: Returns a list of budgets
       parameters:
       - description: Filter by name
@@ -2293,6 +2294,7 @@ paths:
       tags:
       - Budgets
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       responses:
@@ -2304,6 +2306,7 @@ paths:
     post:
       consumes:
       - application/json
+      deprecated: true
       description: Creates a new budget
       parameters:
       - description: Budget
@@ -2332,6 +2335,7 @@ paths:
       - Budgets
   /v1/budgets/{id}:
     delete:
+      deprecated: true
       description: Deletes a budget
       parameters:
       - description: ID formatted as string
@@ -2358,6 +2362,7 @@ paths:
       tags:
       - Budgets
     get:
+      deprecated: true
       description: Returns a specific budget
       parameters:
       - description: ID formatted as string
@@ -2388,6 +2393,7 @@ paths:
       tags:
       - Budgets
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
@@ -2417,6 +2423,7 @@ paths:
     patch:
       consumes:
       - application/json
+      deprecated: true
       description: Update an existing budget. Only values to be updated need to be
         specified.
       parameters:

--- a/pkg/controllers/budget_v1.go
+++ b/pkg/controllers/budget_v1.go
@@ -116,6 +116,7 @@ func (co Controller) RegisterBudgetRoutes(r *gin.RouterGroup) {
 //	@Tags			Budgets
 //	@Success		204
 //	@Router			/v1/budgets [options]
+//	@Deprecated		true
 func (co Controller) OptionsBudgetList(c *gin.Context) {
 	httputil.OptionsGetPost(c)
 }
@@ -131,6 +132,7 @@ func (co Controller) OptionsBudgetList(c *gin.Context) {
 //	@Failure		500	{object}	httperrors.HTTPError
 //	@Param			id	path		string	true	"ID formatted as string"
 //	@Router			/v1/budgets/{id} [options]
+//	@Deprecated		true
 func (co Controller) OptionsBudgetDetail(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
@@ -223,6 +225,7 @@ func (co Controller) OptionsBudgetMonthAllocations(c *gin.Context) {
 //	@Failure		500		{object}	httperrors.HTTPError
 //	@Param			budget	body		models.BudgetCreate	true	"Budget"
 //	@Router			/v1/budgets [post]
+//	@Deprecated		true
 func (co Controller) CreateBudget(c *gin.Context) {
 	var bCreate models.BudgetCreate
 
@@ -259,6 +262,7 @@ func (co Controller) CreateBudget(c *gin.Context) {
 //	@Param			note		query	string	false	"Filter by note"
 //	@Param			currency	query	string	false	"Filter by currency"
 //	@Param			search		query	string	false	"Search for this text in name and note"
+//	@Deprecated		true
 func (co Controller) GetBudgets(c *gin.Context) {
 	var filter BudgetQueryFilter
 
@@ -308,6 +312,7 @@ func (co Controller) GetBudgets(c *gin.Context) {
 //	@Failure		500	{object}	httperrors.HTTPError
 //	@Param			id	path		string	true	"ID formatted as string"
 //	@Router			/v1/budgets/{id} [get]
+//	@Deprecated		true
 func (co Controller) GetBudget(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
@@ -469,6 +474,7 @@ func (co Controller) GetBudgetMonth(c *gin.Context) {
 //	@Param			id		path		string				true	"ID formatted as string"
 //	@Param			budget	body		models.BudgetCreate	true	"Budget"
 //	@Router			/v1/budgets/{id} [patch]
+//	@Deprecated		true
 func (co Controller) UpdateBudget(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
@@ -514,6 +520,7 @@ func (co Controller) UpdateBudget(c *gin.Context) {
 //	@Failure		500	{object}	httperrors.HTTPError
 //	@Param			id	path		string	true	"ID formatted as string"
 //	@Router			/v1/budgets/{id} [delete]
+//	@Deprecated		true
 func (co Controller) DeleteBudget(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {


### PR DESCRIPTION
This adds the missing deprecation with the addition of /v3/budgets
