### PR TITLE
chore: mark v2 as deprecated

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3023,6 +3023,7 @@ const docTemplate = `{
                     "v2"
                 ],
                 "summary": "v2 API",
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -3038,6 +3039,7 @@ const docTemplate = `{
                     "v2"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -3012,6 +3012,7 @@
                     "v2"
                 ],
                 "summary": "v2 API",
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -3027,6 +3028,7 @@
                     "v2"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3973,6 +3973,7 @@ paths:
       - Transactions
   /v2:
     get:
+      deprecated: true
       description: Returns general information about the v2 API
       responses:
         "200":
@@ -3983,6 +3984,7 @@ paths:
       tags:
       - v2
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       responses:

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -311,6 +311,7 @@ type V2Links struct {
 //	@Tags			v2
 //	@Success		200	{object}	V2Response
 //	@Router			/v2 [get]
+//	@Deprecated		true
 func GetV2(c *gin.Context) {
 	c.JSON(http.StatusOK, V2Response{
 		Links: V2Links{
@@ -329,6 +330,7 @@ func GetV2(c *gin.Context) {
 //	@Tags			v2
 //	@Success		204
 //	@Router			/v2 [options]
+//	@Deprecated		true
 func OptionsV2(c *gin.Context) {
 	httputil.OptionsGet(c)
 }


### PR DESCRIPTION
This marks API v2 as deprecated. All its endpoints are already deprecated, this
finishes the needed work to deprecate v2 completely.
