### PR TITLE
fix: Add the missing archived field to Envelope, Category, and Account responses

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3973,13 +3973,13 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "The offset of the first Transaction returned. Defaults to 0.",
+                        "description": "The offset of the first Account returned. Defaults to 0.",
                         "name": "offset",
                         "in": "query"
                     },
                     {
                         "type": "integer",
-                        "description": "Maximum number of transactions to return. Defaults to 50.",
+                        "description": "Maximum number of Accounts to return. Defaults to 50.",
                         "name": "limit",
                         "in": "query"
                     }
@@ -4283,6 +4283,18 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Search for this text in name and note",
                         "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The offset of the first Budget returned. Defaults to 0.",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of Budgets to return. Defaults to 50.",
+                        "name": "limit",
                         "in": "query"
                     }
                 ],
@@ -5899,7 +5911,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Maximum number of transactions to return. Defaults to 50.",
+                        "description": "Maximum number of Transactions to return. Defaults to 50.",
                         "name": "limit",
                         "in": "query"
                     }
@@ -6204,6 +6216,12 @@ const docTemplate = `{
         "controllers.Account": {
             "type": "object",
             "properties": {
+                "archived": {
+                    "description": "Is the account archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "balance": {
                     "description": "Balance of the account, including all transactions referencing it",
                     "type": "number",
@@ -6395,6 +6413,12 @@ const docTemplate = `{
         "controllers.AccountV3": {
             "type": "object",
             "properties": {
+                "archived": {
+                    "description": "Is the account archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "balance": {
                     "description": "Balance of the account, including all transactions referencing it",
                     "type": "number",
@@ -6422,10 +6446,8 @@ const docTemplate = `{
                     "example": false
                 },
                 "hidden": {
-                    "description": "Is the account archived?",
-                    "type": "boolean",
-                    "default": false,
-                    "example": true
+                    "description": "Remove the hidden field",
+                    "type": "boolean"
                 },
                 "id": {
                     "description": "UUID for the resource",
@@ -6867,6 +6889,12 @@ const docTemplate = `{
         "controllers.Category": {
             "type": "object",
             "properties": {
+                "archived": {
+                    "description": "Is the Category archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "budgetId": {
                     "description": "ID of the budget the category belongs to",
                     "type": "string",
@@ -7020,6 +7048,12 @@ const docTemplate = `{
         "controllers.CategoryV3": {
             "type": "object",
             "properties": {
+                "archived": {
+                    "description": "Is the Category archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "budgetId": {
                     "description": "ID of the budget the category belongs to",
                     "type": "string",
@@ -7043,10 +7077,8 @@ const docTemplate = `{
                     }
                 },
                 "hidden": {
-                    "description": "Is the category hidden?",
-                    "type": "boolean",
-                    "default": false,
-                    "example": true
+                    "description": "Remove the hidden field",
+                    "type": "boolean"
                 },
                 "id": {
                     "description": "UUID for the resource",
@@ -7088,6 +7120,12 @@ const docTemplate = `{
         "controllers.Envelope": {
             "type": "object",
             "properties": {
+                "archived": {
+                    "description": "Is the Envelope archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "categoryId": {
                     "description": "ID of the category the envelope belongs to",
                     "type": "string",
@@ -7258,6 +7296,12 @@ const docTemplate = `{
         "controllers.EnvelopeV3": {
             "type": "object",
             "properties": {
+                "archived": {
+                    "description": "Is the Envelope archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "categoryId": {
                     "description": "ID of the category the envelope belongs to",
                     "type": "string",
@@ -7274,10 +7318,8 @@ const docTemplate = `{
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "hidden": {
-                    "description": "Is the envelope hidden?",
-                    "type": "boolean",
-                    "default": false,
-                    "example": true
+                    "description": "Remove the hidden field",
+                    "type": "boolean"
                 },
                 "id": {
                     "description": "UUID for the resource",
@@ -8431,6 +8473,12 @@ const docTemplate = `{
                     "type": "number",
                     "example": 90
                 },
+                "archived": {
+                    "description": "Is the Category archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "balance": {
                     "description": "Sum of the balances of the envelopes",
                     "type": "number",
@@ -8494,6 +8542,12 @@ const docTemplate = `{
         "models.Envelope": {
             "type": "object",
             "properties": {
+                "archived": {
+                    "description": "Is the Envelope archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "categoryId": {
                     "description": "ID of the category the envelope belongs to",
                     "type": "string",
@@ -8570,6 +8624,12 @@ const docTemplate = `{
                     "description": "The amount of money allocated",
                     "type": "number",
                     "example": 85.44
+                },
+                "archived": {
+                    "description": "Is the Envelope archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
                 },
                 "balance": {
                     "description": "The balance at the end of the monht",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -3962,13 +3962,13 @@
                     },
                     {
                         "type": "integer",
-                        "description": "The offset of the first Transaction returned. Defaults to 0.",
+                        "description": "The offset of the first Account returned. Defaults to 0.",
                         "name": "offset",
                         "in": "query"
                     },
                     {
                         "type": "integer",
-                        "description": "Maximum number of transactions to return. Defaults to 50.",
+                        "description": "Maximum number of Accounts to return. Defaults to 50.",
                         "name": "limit",
                         "in": "query"
                     }
@@ -4272,6 +4272,18 @@
                         "type": "string",
                         "description": "Search for this text in name and note",
                         "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The offset of the first Budget returned. Defaults to 0.",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of Budgets to return. Defaults to 50.",
+                        "name": "limit",
                         "in": "query"
                     }
                 ],
@@ -5888,7 +5900,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Maximum number of transactions to return. Defaults to 50.",
+                        "description": "Maximum number of Transactions to return. Defaults to 50.",
                         "name": "limit",
                         "in": "query"
                     }
@@ -6193,6 +6205,12 @@
         "controllers.Account": {
             "type": "object",
             "properties": {
+                "archived": {
+                    "description": "Is the account archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "balance": {
                     "description": "Balance of the account, including all transactions referencing it",
                     "type": "number",
@@ -6384,6 +6402,12 @@
         "controllers.AccountV3": {
             "type": "object",
             "properties": {
+                "archived": {
+                    "description": "Is the account archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "balance": {
                     "description": "Balance of the account, including all transactions referencing it",
                     "type": "number",
@@ -6411,10 +6435,8 @@
                     "example": false
                 },
                 "hidden": {
-                    "description": "Is the account archived?",
-                    "type": "boolean",
-                    "default": false,
-                    "example": true
+                    "description": "Remove the hidden field",
+                    "type": "boolean"
                 },
                 "id": {
                     "description": "UUID for the resource",
@@ -6856,6 +6878,12 @@
         "controllers.Category": {
             "type": "object",
             "properties": {
+                "archived": {
+                    "description": "Is the Category archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "budgetId": {
                     "description": "ID of the budget the category belongs to",
                     "type": "string",
@@ -7009,6 +7037,12 @@
         "controllers.CategoryV3": {
             "type": "object",
             "properties": {
+                "archived": {
+                    "description": "Is the Category archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "budgetId": {
                     "description": "ID of the budget the category belongs to",
                     "type": "string",
@@ -7032,10 +7066,8 @@
                     }
                 },
                 "hidden": {
-                    "description": "Is the category hidden?",
-                    "type": "boolean",
-                    "default": false,
-                    "example": true
+                    "description": "Remove the hidden field",
+                    "type": "boolean"
                 },
                 "id": {
                     "description": "UUID for the resource",
@@ -7077,6 +7109,12 @@
         "controllers.Envelope": {
             "type": "object",
             "properties": {
+                "archived": {
+                    "description": "Is the Envelope archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "categoryId": {
                     "description": "ID of the category the envelope belongs to",
                     "type": "string",
@@ -7247,6 +7285,12 @@
         "controllers.EnvelopeV3": {
             "type": "object",
             "properties": {
+                "archived": {
+                    "description": "Is the Envelope archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "categoryId": {
                     "description": "ID of the category the envelope belongs to",
                     "type": "string",
@@ -7263,10 +7307,8 @@
                     "example": "2022-04-22T21:01:05.058161Z"
                 },
                 "hidden": {
-                    "description": "Is the envelope hidden?",
-                    "type": "boolean",
-                    "default": false,
-                    "example": true
+                    "description": "Remove the hidden field",
+                    "type": "boolean"
                 },
                 "id": {
                     "description": "UUID for the resource",
@@ -8420,6 +8462,12 @@
                     "type": "number",
                     "example": 90
                 },
+                "archived": {
+                    "description": "Is the Category archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "balance": {
                     "description": "Sum of the balances of the envelopes",
                     "type": "number",
@@ -8483,6 +8531,12 @@
         "models.Envelope": {
             "type": "object",
             "properties": {
+                "archived": {
+                    "description": "Is the Envelope archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
                 "categoryId": {
                     "description": "ID of the category the envelope belongs to",
                     "type": "string",
@@ -8559,6 +8613,12 @@
                     "description": "The amount of money allocated",
                     "type": "number",
                     "example": 85.44
+                },
+                "archived": {
+                    "description": "Is the Envelope archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
                 },
                 "balance": {
                     "description": "The balance at the end of the monht",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1,6 +1,11 @@
 definitions:
   controllers.Account:
     properties:
+      archived:
+        default: false
+        description: Is the account archived?
+        example: true
+        type: boolean
       balance:
         description: Balance of the account, including all transactions referencing
           it
@@ -142,6 +147,11 @@ definitions:
     type: object
   controllers.AccountV3:
     properties:
+      archived:
+        default: false
+        description: Is the account archived?
+        example: true
+        type: boolean
       balance:
         description: Balance of the account, including all transactions referencing
           it
@@ -165,9 +175,7 @@ definitions:
         example: false
         type: boolean
       hidden:
-        default: false
-        description: Is the account archived?
-        example: true
+        description: Remove the hidden field
         type: boolean
       id:
         description: UUID for the resource
@@ -497,6 +505,11 @@ definitions:
     type: object
   controllers.Category:
     properties:
+      archived:
+        default: false
+        description: Is the Category archived?
+        example: true
+        type: boolean
       budgetId:
         description: ID of the budget the category belongs to
         example: 52d967d3-33f4-4b04-9ba7-772e5ab9d0ce
@@ -603,6 +616,11 @@ definitions:
     type: object
   controllers.CategoryV3:
     properties:
+      archived:
+        default: false
+        description: Is the Category archived?
+        example: true
+        type: boolean
       budgetId:
         description: ID of the budget the category belongs to
         example: 52d967d3-33f4-4b04-9ba7-772e5ab9d0ce
@@ -621,9 +639,7 @@ definitions:
           $ref: '#/definitions/controllers.EnvelopeV3'
         type: array
       hidden:
-        default: false
-        description: Is the category hidden?
-        example: true
+        description: Remove the hidden field
         type: boolean
       id:
         description: UUID for the resource
@@ -655,6 +671,11 @@ definitions:
     type: object
   controllers.Envelope:
     properties:
+      archived:
+        default: false
+        description: Is the Envelope archived?
+        example: true
+        type: boolean
       categoryId:
         description: ID of the category the envelope belongs to
         example: 878c831f-af99-4a71-b3ca-80deb7d793c1
@@ -773,6 +794,11 @@ definitions:
     type: object
   controllers.EnvelopeV3:
     properties:
+      archived:
+        default: false
+        description: Is the Envelope archived?
+        example: true
+        type: boolean
       categoryId:
         description: ID of the category the envelope belongs to
         example: 878c831f-af99-4a71-b3ca-80deb7d793c1
@@ -786,9 +812,7 @@ definitions:
         example: "2022-04-22T21:01:05.058161Z"
         type: string
       hidden:
-        default: false
-        description: Is the envelope hidden?
-        example: true
+        description: Remove the hidden field
         type: boolean
       id:
         description: UUID for the resource
@@ -1663,6 +1687,11 @@ definitions:
         description: Sum of allocations for the envelopes
         example: 90
         type: number
+      archived:
+        default: false
+        description: Is the Category archived?
+        example: true
+        type: boolean
       balance:
         description: Sum of the balances of the envelopes
         example: -10.13
@@ -1712,6 +1741,11 @@ definitions:
     type: object
   models.Envelope:
     properties:
+      archived:
+        default: false
+        description: Is the Envelope archived?
+        example: true
+        type: boolean
       categoryId:
         description: ID of the category the envelope belongs to
         example: 878c831f-af99-4a71-b3ca-80deb7d793c1
@@ -1772,6 +1806,11 @@ definitions:
         description: The amount of money allocated
         example: 85.44
         type: number
+      archived:
+        default: false
+        description: Is the Envelope archived?
+        example: true
+        type: boolean
       balance:
         description: The balance at the end of the monht
         example: 12.32
@@ -4876,11 +4915,11 @@ paths:
         in: query
         name: search
         type: string
-      - description: The offset of the first Transaction returned. Defaults to 0.
+      - description: The offset of the first Account returned. Defaults to 0.
         in: query
         name: offset
         type: integer
-      - description: Maximum number of transactions to return. Defaults to 50.
+      - description: Maximum number of Accounts to return. Defaults to 50.
         in: query
         name: limit
         type: integer
@@ -5086,6 +5125,14 @@ paths:
         in: query
         name: search
         type: string
+      - description: The offset of the first Budget returned. Defaults to 0.
+        in: query
+        name: offset
+        type: integer
+      - description: Maximum number of Budgets to return. Defaults to 50.
+        in: query
+        name: limit
+        type: integer
       produces:
       - application/json
       responses:
@@ -6179,7 +6226,7 @@ paths:
         in: query
         name: offset
         type: integer
-      - description: Maximum number of transactions to return. Defaults to 50.
+      - description: Maximum number of Transactions to return. Defaults to 50.
         in: query
         name: limit
         type: integer

--- a/pkg/controllers/account_v3.go
+++ b/pkg/controllers/account_v3.go
@@ -37,6 +37,7 @@ type AccountV3 struct {
 	Balance           decimal.Decimal `json:"balance" example:"2735.17"`           // Balance of the account, including all transactions referencing it
 	ReconciledBalance decimal.Decimal `json:"reconciledBalance" example:"2539.57"` // Balance of the account, including all reconciled transactions referencing it
 	RecentEnvelopes   []*uuid.UUID    `json:"recentEnvelopes"`                     // Envelopes recently used with this account
+	Hidden            bool            `json:"hidden,omitempty"`                    // Remove the hidden field
 
 	Links struct {
 		Self         string `json:"self" example:"https://example.com/api/v3/accounts/af892e10-7e0a-4fb8-b1bc-4b6d88401ed2"`                     // The account itself
@@ -59,8 +60,8 @@ type AccountQueryFilterV3 struct {
 	External bool   `form:"external"`                     // Is the account external?
 	Archived bool   `form:"archived" filterField:"false"` // Is the account hidden?
 	Search   string `form:"search" filterField:"false"`   // By string in name or note
-	Offset   uint   `form:"offset" filterField:"false"`   // The offset of the first Transaction returned. Defaults to 0.
-	Limit    int    `form:"limit" filterField:"false"`    // Maximum number of transactions to return. Defaults to 50.
+	Offset   uint   `form:"offset" filterField:"false"`   // The offset of the first Account returned. Defaults to 0.
+	Limit    int    `form:"limit" filterField:"false"`    // Maximum number of Accounts to return. Defaults to 50.
 }
 
 func (f AccountQueryFilterV3) ToCreate() (models.AccountCreate, httperrors.Error) {
@@ -258,8 +259,8 @@ func (co Controller) CreateAccountsV3(c *gin.Context) {
 // @Param			external	query	bool	false	"Is the account external?"
 // @Param			archived	query	bool	false	"Is the account archived?"
 // @Param			search		query	string	false	"Search for this text in name and note"
-// @Param			offset		query	uint	false	"The offset of the first Transaction returned. Defaults to 0."
-// @Param			limit		query	int		false	"Maximum number of transactions to return. Defaults to 50."
+// @Param			offset		query	uint	false	"The offset of the first Account returned. Defaults to 0."
+// @Param			limit		query	int		false	"Maximum number of Accounts to return. Defaults to 50."
 func (co Controller) GetAccountsV3(c *gin.Context) {
 	var filter AccountQueryFilterV3
 	if err := c.Bind(&filter); err != nil {

--- a/pkg/controllers/allocation.go
+++ b/pkg/controllers/allocation.go
@@ -19,7 +19,7 @@ type Allocation struct {
 	models.Allocation
 	Links struct {
 		Self string `json:"self" example:"https://example.com/api/v1/allocations/902cd93c-3724-4e46-8540-d014131282fc"` // The allocation itself
-	} `json:"links" gorm:"-"`
+	} `json:"links"`
 }
 
 func (a *Allocation) links(c *gin.Context) {

--- a/pkg/controllers/budget_v1.go
+++ b/pkg/controllers/budget_v1.go
@@ -24,7 +24,7 @@ type BudgetQueryFilter struct {
 // Budget is the API v1 representation of a Budget.
 type Budget struct {
 	models.Budget
-	Balance decimal.Decimal `json:"balance" gorm:"-" example:"3423.42"` // DEPRECATED. Will be removed in API v2, see https://github.com/envelope-zero/backend/issues/526.
+	Balance decimal.Decimal `json:"balance" example:"3423.42"` // DEPRECATED. Will be removed in API v2, see https://github.com/envelope-zero/backend/issues/526.
 	Links   struct {
 		Self             string `json:"self" example:"https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf"`                                 // The budget itself
 		Accounts         string `json:"accounts" example:"https://example.com/api/v1/accounts?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"`                     // Accounts for this budget
@@ -34,7 +34,7 @@ type Budget struct {
 		Month            string `json:"month" example:"https://example.com/api/v1/budgets/550dc009-cea6-4c12-b2a5-03446eb7b7cf/YYYY-MM"`                        // This uses 'YYYY-MM' for clients to replace with the actual year and month.
 		GroupedMonth     string `json:"groupedMonth" example:"https://example.com/api/v1/months?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf&month=YYYY-MM"`     // This uses 'YYYY-MM' for clients to replace with the actual year and month.
 		MonthAllocations string `json:"monthAllocations" example:"https://example.com/api/v1/months?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf&month=YYYY-MM"` // This uses 'YYYY-MM' for clients to replace with the actual year and month.
-	} `json:"links" gorm:"-"`
+	} `json:"links"`
 }
 
 // links sets all links for the Budget.

--- a/pkg/controllers/budget_v3.go
+++ b/pkg/controllers/budget_v3.go
@@ -18,8 +18,8 @@ type BudgetQueryFilterV3 struct {
 	Note     string `form:"note" filterField:"false"`   // By note
 	Currency string `form:"currency"`                   // By currency
 	Search   string `form:"search" filterField:"false"` // By string in name or note
-	Offset   uint   `form:"offset" filterField:"false"` // The offset of the first Transaction returned. Defaults to 0.
-	Limit    int    `form:"limit" filterField:"false"`  // Maximum number of transactions to return. Defaults to 50.
+	Offset   uint   `form:"offset" filterField:"false"` // The offset of the first Budget returned. Defaults to 0.
+	Limit    int    `form:"limit" filterField:"false"`  // Maximum number of Budgets to return. Defaults to 50.
 }
 
 // Budget is the API v3 representation of a Budget.
@@ -32,7 +32,7 @@ type BudgetV3 struct {
 		Envelopes    string `json:"envelopes" example:"https://example.com/api/v3/envelopes?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"`        // Envelopes for this budget
 		Transactions string `json:"transactions" example:"https://example.com/api/v3/transactions?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"`  // Transactions for this budget
 		Month        string `json:"month" example:"https://example.com/api/v3/months?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf&month=YYYY-MM"` // This uses 'YYYY-MM' for clients to replace with the actual year and month.
-	} `json:"links" gorm:"-"`
+	} `json:"links"`
 }
 
 // links sets all links for the Budget.
@@ -222,6 +222,8 @@ func (co Controller) CreateBudgetsV3(c *gin.Context) {
 // @Param			note		query	string	false	"Filter by note"
 // @Param			currency	query	string	false	"Filter by currency"
 // @Param			search		query	string	false	"Search for this text in name and note"
+// @Param			offset		query	uint	false	"The offset of the first Budget returned. Defaults to 0."
+// @Param			limit		query	int		false	"Maximum number of Budgets to return. Defaults to 50."
 func (co Controller) GetBudgetsV3(c *gin.Context) {
 	var filter BudgetQueryFilterV3
 

--- a/pkg/controllers/category_v3.go
+++ b/pkg/controllers/category_v3.go
@@ -15,8 +15,10 @@ import (
 
 type CategoryV3 struct {
 	models.Category
-	Envelopes []EnvelopeV3 `json:"envelopes"` // Envelopes for the category
-	Links     struct {
+	Envelopes []EnvelopeV3 `json:"envelopes"`        // Envelopes for the category
+	Hidden    bool         `json:"hidden,omitempty"` // Remove the hidden field
+
+	Links struct {
 		Self      string `json:"self" example:"https://example.com/api/v3/categories/3b1ea324-d438-4419-882a-2fc91d71772f"`              // The category itself
 		Envelopes string `json:"envelopes" example:"https://example.com/api/v3/envelopes?category=3b1ea324-d438-4419-882a-2fc91d71772f"` // Envelopes for this category
 	} `json:"links"`
@@ -236,7 +238,6 @@ func (co Controller) CreateCategoriesV3(c *gin.Context) {
 // @Param			budget	query	string	false	"Filter by budget ID"
 // @Param			hidden	query	bool	false	"Is the category hidden?"
 // @Param			search	query	string	false	"Search for this text in name and note"
-//
 // @Param			offset	query	uint	false	"The offset of the first Category returned. Defaults to 0."
 // @Param			limit	query	int		false	"Maximum number of Categories to return. Defaults to 50."
 func (co Controller) GetCategoriesV3(c *gin.Context) {

--- a/pkg/controllers/envelope_v3.go
+++ b/pkg/controllers/envelope_v3.go
@@ -15,6 +15,8 @@ import (
 
 type EnvelopeV3 struct {
 	models.Envelope
+	Hidden bool `json:"hidden,omitempty"` // Remove the hidden field
+
 	Links struct {
 		Self         string `json:"self" example:"https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166"`                      // The envelope itself
 		Transactions string `json:"transactions" example:"https://example.com/api/v3/transactions?envelope=45b6b5b9-f746-4ae9-b77b-7688b91f8166"`  // The envelope's transactions

--- a/pkg/controllers/envelope_v3_test.go
+++ b/pkg/controllers/envelope_v3_test.go
@@ -161,32 +161,41 @@ func (suite *TestSuiteStandard) TestEnvelopesV3GetFilter() {
 	})
 
 	tests := []struct {
-		name  string
-		query string
-		len   int
+		name      string
+		query     string
+		len       int
+		checkFunc func(t *testing.T, envelopes []controllers.EnvelopeV3)
 	}{
-		{"Category 2", fmt.Sprintf("category=%s", c2.Data.ID), 2},
-		{"Category Not Existing", "category=e0f9ff7a-9f07-463c-bbd2-0d72d09d3cc6", 0},
-		{"Empty Note", "note=", 0},
-		{"Empty Name", "name=", 0},
-		{"Name & Note", "name=Groceries&note=For the stuff bought in supermarkets", 1},
-		{"Fuzzy name", "name=es", 2},
-		{"Fuzzy note", "note=Because", 2},
-		{"Not archived", "archived=false", 2},
-		{"Archived", "archived=true", 1},
-		{"Search for 'hair'", "search=hair", 2},
-		{"Search for 'st'", "search=st", 2},
-		{"Search for 'STUFF'", "search=STUFF", 1},
-		{"Offset 2", "offset=2", 1},
-		{"Offset 0, limit 2", "offset=0&limit=2", 2},
-		{"Limit 4", "limit=4", 3},
-		{"Limit 0", "limit=0", 0},
-		{"Limit -1", "limit=-1", 3},
+		{"Category 2", fmt.Sprintf("category=%s", c2.Data.ID), 2, nil},
+		{"Category Not Existing", "category=e0f9ff7a-9f07-463c-bbd2-0d72d09d3cc6", 0, nil},
+		{"Empty Note", "note=", 0, nil},
+		{"Empty Name", "name=", 0, nil},
+		{"Name & Note", "name=Groceries&note=For the stuff bought in supermarkets", 1, nil},
+		{"Fuzzy name", "name=es", 2, nil},
+		{"Fuzzy note", "note=Because", 2, nil},
+		{"Not archived", "archived=false", 2, func(t *testing.T, envelopes []controllers.EnvelopeV3) {
+			for _, e := range envelopes {
+				assert.False(t, e.Archived)
+			}
+		}},
+		{"Archived", "archived=true", 1, func(t *testing.T, envelopes []controllers.EnvelopeV3) {
+			for _, e := range envelopes {
+				assert.True(t, e.Archived)
+			}
+		}},
+		{"Search for 'hair'", "search=hair", 2, nil},
+		{"Search for 'st'", "search=st", 2, nil},
+		{"Search for 'STUFF'", "search=STUFF", 1, nil},
+		{"Offset 2", "offset=2", 1, nil},
+		{"Offset 0, limit 2", "offset=0&limit=2", 2, nil},
+		{"Limit 4", "limit=4", 3, nil},
+		{"Limit 0", "limit=0", 0, nil},
+		{"Limit -1", "limit=-1", 3, nil},
 	}
 
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
-			var re controllers.EnvelopeListResponse
+			var re controllers.EnvelopeListResponseV3
 			r := test.Request(suite.controller, t, http.MethodGet, fmt.Sprintf("/v3/envelopes?%s", tt.query), "")
 			assertHTTPStatus(suite.T(), &r, http.StatusOK)
 			suite.decodeResponse(&r, &re)

--- a/pkg/controllers/transaction_v3.go
+++ b/pkg/controllers/transaction_v3.go
@@ -203,7 +203,7 @@ func (co Controller) GetTransactionV3(c *gin.Context) {
 // @Param			reconciledSource		query	bool	false	"Reconcilication state in source account"
 // @Param			reconciledDestination	query	bool	false	"Reconcilication state in destination account"
 // @Param			offset					query	uint	false	"The offset of the first Transaction returned. Defaults to 0."
-// @Param			limit					query	int		false	"Maximum number of transactions to return. Defaults to 50."
+// @Param			limit					query	int		false	"Maximum number of Transactions to return. Defaults to 50."
 func (co Controller) GetTransactionsV3(c *gin.Context) {
 	var filter TransactionQueryFilterV3
 	if err := c.Bind(&filter); err != nil {

--- a/pkg/controllers/transaction_v3_test.go
+++ b/pkg/controllers/transaction_v3_test.go
@@ -260,7 +260,7 @@ func (suite *TestSuiteStandard) TestTransactionsV3GetFilter() {
 
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
-			var re controllers.TransactionListResponse
+			var re controllers.TransactionListResponseV3
 			r := test.Request(suite.controller, t, http.MethodGet, fmt.Sprintf("/v3/transactions?%s", tt.query), "")
 			assertHTTPStatus(t, &r, http.StatusOK)
 			suite.decodeResponse(&r, &re)

--- a/pkg/models/account.go
+++ b/pkg/models/account.go
@@ -28,11 +28,19 @@ type AccountCreate struct {
 type Account struct {
 	DefaultModel
 	AccountCreate
-	Budget Budget `json:"-"`
+	Budget   Budget `json:"-"`
+	Archived bool   `json:"archived" example:"true" default:"false" gorm:"-"` // Is the account archived?
 }
 
 func (Account) Self() string {
 	return "Account"
+}
+
+func (a *Account) AfterFind(_ *gorm.DB) (err error) {
+	// Set the Archived field to the value of Hidden
+	a.Archived = a.Hidden
+
+	return nil
 }
 
 // BeforeUpdate verifies the state of the account before

--- a/pkg/models/category.go
+++ b/pkg/models/category.go
@@ -9,7 +9,8 @@ import (
 type Category struct {
 	DefaultModel
 	CategoryCreate
-	Budget Budget `json:"-"` // The budget the category belongs to
+	Budget   Budget `json:"-"`
+	Archived bool   `json:"archived" example:"true" default:"false" gorm:"-"` // Is the Category archived?
 }
 
 type CategoryCreate struct {
@@ -21,6 +22,13 @@ type CategoryCreate struct {
 
 func (c Category) Self() string {
 	return "Category"
+}
+
+func (c *Category) AfterFind(_ *gorm.DB) (err error) {
+	// Set the Archived field to the value of Hidden
+	c.Archived = c.Hidden
+
+	return nil
 }
 
 // BeforeUpdate archives all envelopes when the category is archived.

--- a/pkg/models/envelope.go
+++ b/pkg/models/envelope.go
@@ -15,6 +15,7 @@ type Envelope struct {
 	DefaultModel
 	EnvelopeCreate
 	Category Category `json:"-"`
+	Archived bool     `json:"archived" example:"true" default:"false" gorm:"-"` // Is the Envelope archived?
 }
 
 type EnvelopeCreate struct {
@@ -26,6 +27,13 @@ type EnvelopeCreate struct {
 
 func (e Envelope) Self() string {
 	return "Envelope"
+}
+
+func (e *Envelope) AfterFind(_ *gorm.DB) (err error) {
+	// Set the Archived field to the value of Hidden
+	e.Archived = e.Hidden
+
+	return nil
 }
 
 // BeforeUpdate verifies the state of the envelope before


### PR DESCRIPTION
This adds the field that was missing so far and removes the "hidden" field as documented.
It also improves tests to ensure fields are set correctly.

Some small API documentation fixes are also included in this commit, mainly fixing wrong resource names due to copy-pasting.
