### PR TITLE
feat: integrate allocations into MonthConfig in API v3

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -460,6 +460,7 @@ const docTemplate = `{
                     "Allocations"
                 ],
                 "summary": "Get allocations",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -510,6 +511,7 @@ const docTemplate = `{
                     "Allocations"
                 ],
                 "summary": "Create allocations",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Allocation",
@@ -554,6 +556,7 @@ const docTemplate = `{
                     "Allocations"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -571,6 +574,7 @@ const docTemplate = `{
                     "Allocations"
                 ],
                 "summary": "Get allocation",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -613,6 +617,7 @@ const docTemplate = `{
                     "Allocations"
                 ],
                 "summary": "Delete allocation",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -652,6 +657,7 @@ const docTemplate = `{
                     "Allocations"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -697,6 +703,7 @@ const docTemplate = `{
                     "Allocations"
                 ],
                 "summary": "Update allocation",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -5309,7 +5316,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.MonthConfigCreate"
+                            "$ref": "#/definitions/controllers.MonthConfigCreateV3"
                         }
                     }
                 ],
@@ -7584,6 +7591,14 @@ const docTemplate = `{
         "controllers.MonthConfig": {
             "type": "object",
             "properties": {
+                "allocation": {
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 22.01
+                },
                 "createdAt": {
                     "description": "Time the resource was created",
                     "type": "string",
@@ -7641,6 +7656,24 @@ const docTemplate = `{
                 }
             }
         },
+        "controllers.MonthConfigCreateV3": {
+            "type": "object",
+            "properties": {
+                "allocation": {
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 22.01
+                },
+                "note": {
+                    "description": "A note for the month config",
+                    "type": "string",
+                    "example": "Added 200€ here because we replaced Tim's expensive vase"
+                }
+            }
+        },
         "controllers.MonthConfigListResponse": {
             "type": "object",
             "properties": {
@@ -7687,6 +7720,14 @@ const docTemplate = `{
         "controllers.MonthConfigV3": {
             "type": "object",
             "properties": {
+                "allocation": {
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 22.01
+                },
                 "createdAt": {
                     "description": "Time the resource was created",
                     "type": "string",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -449,6 +449,7 @@
                     "Allocations"
                 ],
                 "summary": "Get allocations",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -499,6 +500,7 @@
                     "Allocations"
                 ],
                 "summary": "Create allocations",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Allocation",
@@ -543,6 +545,7 @@
                     "Allocations"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -560,6 +563,7 @@
                     "Allocations"
                 ],
                 "summary": "Get allocation",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -602,6 +606,7 @@
                     "Allocations"
                 ],
                 "summary": "Delete allocation",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -641,6 +646,7 @@
                     "Allocations"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -686,6 +692,7 @@
                     "Allocations"
                 ],
                 "summary": "Update allocation",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -5298,7 +5305,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.MonthConfigCreate"
+                            "$ref": "#/definitions/controllers.MonthConfigCreateV3"
                         }
                     }
                 ],
@@ -7573,6 +7580,14 @@
         "controllers.MonthConfig": {
             "type": "object",
             "properties": {
+                "allocation": {
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 22.01
+                },
                 "createdAt": {
                     "description": "Time the resource was created",
                     "type": "string",
@@ -7630,6 +7645,24 @@
                 }
             }
         },
+        "controllers.MonthConfigCreateV3": {
+            "type": "object",
+            "properties": {
+                "allocation": {
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 22.01
+                },
+                "note": {
+                    "description": "A note for the month config",
+                    "type": "string",
+                    "example": "Added 200€ here because we replaced Tim's expensive vase"
+                }
+            }
+        },
         "controllers.MonthConfigListResponse": {
             "type": "object",
             "properties": {
@@ -7676,6 +7709,14 @@
         "controllers.MonthConfigV3": {
             "type": "object",
             "properties": {
+                "allocation": {
+                    "description": "The maximum value is \"999999999999.99999999\", swagger unfortunately rounds this.",
+                    "type": "number",
+                    "maximum": 1000000000000,
+                    "minimum": 1e-8,
+                    "multipleOf": 1e-8,
+                    "example": 22.01
+                },
                 "createdAt": {
                     "description": "Time the resource was created",
                     "type": "string",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1004,6 +1004,14 @@ definitions:
     type: object
   controllers.MonthConfig:
     properties:
+      allocation:
+        description: The maximum value is "999999999999.99999999", swagger unfortunately
+          rounds this.
+        example: 22.01
+        maximum: 1000000000000
+        minimum: 1e-08
+        multipleOf: 1e-08
+        type: number
       createdAt:
         description: Time the resource was created
         example: "2022-04-02T19:28:44.491514Z"
@@ -1048,6 +1056,21 @@ definitions:
         example: "2022-04-17T20:14:01.048145Z"
         type: string
     type: object
+  controllers.MonthConfigCreateV3:
+    properties:
+      allocation:
+        description: The maximum value is "999999999999.99999999", swagger unfortunately
+          rounds this.
+        example: 22.01
+        maximum: 1000000000000
+        minimum: 1e-08
+        multipleOf: 1e-08
+        type: number
+      note:
+        description: A note for the month config
+        example: Added 200€ here because we replaced Tim's expensive vase
+        type: string
+    type: object
   controllers.MonthConfigListResponse:
     properties:
       data:
@@ -1076,6 +1099,14 @@ definitions:
     type: object
   controllers.MonthConfigV3:
     properties:
+      allocation:
+        description: The maximum value is "999999999999.99999999", swagger unfortunately
+          rounds this.
+        example: 22.01
+        maximum: 1000000000000
+        minimum: 1e-08
+        multipleOf: 1e-08
+        type: number
       createdAt:
         description: Time the resource was created
         example: "2022-04-02T19:28:44.491514Z"
@@ -2506,6 +2537,7 @@ paths:
       - Accounts
   /v1/allocations:
     get:
+      deprecated: true
       description: Returns a list of allocations
       parameters:
       - description: Filter by month
@@ -2539,6 +2571,7 @@ paths:
       tags:
       - Allocations
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       responses:
@@ -2548,6 +2581,7 @@ paths:
       tags:
       - Allocations
     post:
+      deprecated: true
       description: Create a new allocation of funds to an envelope for a specific
         month
       parameters:
@@ -2581,6 +2615,7 @@ paths:
       - Allocations
   /v1/allocations/{id}:
     delete:
+      deprecated: true
       description: Deletes an allocation
       parameters:
       - description: ID formatted as string
@@ -2607,6 +2642,7 @@ paths:
       tags:
       - Allocations
     get:
+      deprecated: true
       description: Returns a specific allocation
       parameters:
       - description: ID formatted as string
@@ -2637,6 +2673,7 @@ paths:
       tags:
       - Allocations
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
@@ -2666,6 +2703,7 @@ paths:
     patch:
       consumes:
       - application/json
+      deprecated: true
       description: Update an allocation. Only values to be updated need to be specified.
       parameters:
       - description: ID formatted as string
@@ -5817,7 +5855,7 @@ paths:
         name: monthConfig
         required: true
         schema:
-          $ref: '#/definitions/models.MonthConfigCreate'
+          $ref: '#/definitions/controllers.MonthConfigCreateV3'
       produces:
       - application/json
       responses:

--- a/pkg/controllers/allocation.go
+++ b/pkg/controllers/allocation.go
@@ -99,6 +99,7 @@ func (co Controller) RegisterAllocationRoutes(r *gin.RouterGroup) {
 //	@Tags			Allocations
 //	@Success		204
 //	@Router			/v1/allocations [options]
+//	@Deprecated		true
 func (co Controller) OptionsAllocationList(c *gin.Context) {
 	httputil.OptionsGetPost(c)
 }
@@ -114,6 +115,7 @@ func (co Controller) OptionsAllocationList(c *gin.Context) {
 //	@Failure		500	{object}	httperrors.HTTPError
 //	@Param			id	path		string	true	"ID formatted as string"
 //	@Router			/v1/allocations/{id} [options]
+//	@Deprecated		true
 func (co Controller) OptionsAllocationDetail(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
@@ -140,6 +142,7 @@ func (co Controller) OptionsAllocationDetail(c *gin.Context) {
 //	@Failure		500			{object}	httperrors.HTTPError
 //	@Param			allocation	body		models.AllocationCreate	true	"Allocation"
 //	@Router			/v1/allocations [post]
+//	@Deprecated		true
 func (co Controller) CreateAllocation(c *gin.Context) {
 	var create models.AllocationCreate
 
@@ -182,6 +185,7 @@ func (co Controller) CreateAllocation(c *gin.Context) {
 //	@Param			month		query	string	false	"Filter by month"
 //	@Param			amount		query	string	false	"Filter by amount"
 //	@Param			envelope	query	string	false	"Filter by envelope ID"
+//	@Deprecated		true
 func (co Controller) GetAllocations(c *gin.Context) {
 	var filter AllocationQueryFilter
 	if err := c.Bind(&filter); err != nil {
@@ -230,6 +234,7 @@ func (co Controller) GetAllocations(c *gin.Context) {
 //	@Failure		500	{object}	httperrors.HTTPError
 //	@Param			id	path		string	true	"ID formatted as string"
 //	@Router			/v1/allocations/{id} [get]
+//	@Deprecated		true
 func (co Controller) GetAllocation(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
@@ -264,6 +269,7 @@ func (co Controller) GetAllocation(c *gin.Context) {
 //	@Param			id			path		string					true	"ID formatted as string"
 //	@Param			allocation	body		models.AllocationCreate	true	"Allocation"
 //	@Router			/v1/allocations/{id} [patch]
+//	@Deprecated		true
 func (co Controller) UpdateAllocation(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
@@ -309,6 +315,7 @@ func (co Controller) UpdateAllocation(c *gin.Context) {
 //	@Failure		500	{object}	httperrors.HTTPError
 //	@Param			id	path		string	true	"ID formatted as string"
 //	@Router			/v1/allocations/{id} [delete]
+//	@Deprecated		true
 func (co Controller) DeleteAllocation(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {


### PR DESCRIPTION
Starting with this, allocations can be set directly on the MonthConfig with API v3 and do not need a separate application call.
Under the hood, API v3 still manages allocation resources to ensure that both API v1 and v3 function correctly.
