### PR TITLE
fix: accept archived parameter on resource creation for accounts, categories, envelopes

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -4037,7 +4037,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.AccountCreate"
+                                "$ref": "#/definitions/controllers.AccountCreateV3"
                             }
                         }
                     }
@@ -4232,7 +4232,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.AccountCreate"
+                            "$ref": "#/definitions/controllers.AccountCreateV3"
                         }
                     }
                 ],
@@ -4659,7 +4659,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.CategoryCreate"
+                                "$ref": "#/definitions/controllers.CategoryCreateV3"
                             }
                         }
                     }
@@ -4854,7 +4854,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.CategoryCreate"
+                            "$ref": "#/definitions/controllers.CategoryCreateV3"
                         }
                     }
                 ],
@@ -4979,7 +4979,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.EnvelopeCreate"
+                                "$ref": "#/definitions/controllers.EnvelopeCreateV3"
                             }
                         }
                     }
@@ -5174,7 +5174,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.EnvelopeCreate"
+                            "$ref": "#/definitions/controllers.EnvelopeCreateV3"
                         }
                     }
                 ],
@@ -6523,6 +6523,60 @@ const docTemplate = `{
                 }
             }
         },
+        "controllers.AccountCreateV3": {
+            "type": "object",
+            "properties": {
+                "archived": {
+                    "description": "Is the account archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "budgetId": {
+                    "description": "ID of the budget this account belongs to",
+                    "type": "string",
+                    "example": "550dc009-cea6-4c12-b2a5-03446eb7b7cf"
+                },
+                "external": {
+                    "description": "Does the account belong to the budget owner or not?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": false
+                },
+                "importHash": {
+                    "description": "The SHA256 hash of a unique combination of values to use in duplicate detection",
+                    "type": "string",
+                    "example": "867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70"
+                },
+                "initialBalance": {
+                    "description": "Balance of the account before any transactions were recorded",
+                    "type": "number",
+                    "default": 0,
+                    "example": 173.12
+                },
+                "initialBalanceDate": {
+                    "description": "Date of the initial balance",
+                    "type": "string",
+                    "example": "2017-05-12T00:00:00Z"
+                },
+                "name": {
+                    "description": "Name of the account",
+                    "type": "string",
+                    "example": "Cash"
+                },
+                "note": {
+                    "description": "A longer description for the account",
+                    "type": "string",
+                    "example": "Money in my wallet"
+                },
+                "onBudget": {
+                    "description": "Does the account factor into the available budget? Always false when external: true",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                }
+            }
+        },
         "controllers.AccountListResponse": {
             "type": "object",
             "properties": {
@@ -7158,6 +7212,32 @@ const docTemplate = `{
                 }
             }
         },
+        "controllers.CategoryCreateV3": {
+            "type": "object",
+            "properties": {
+                "archived": {
+                    "description": "Is the category hidden?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "budgetId": {
+                    "description": "ID of the budget the category belongs to",
+                    "type": "string",
+                    "example": "52d967d3-33f4-4b04-9ba7-772e5ab9d0ce"
+                },
+                "name": {
+                    "description": "Name of the category",
+                    "type": "string",
+                    "example": "Saving"
+                },
+                "note": {
+                    "description": "Notes about the category",
+                    "type": "string",
+                    "example": "All envelopes for long-term saving"
+                }
+            }
+        },
         "controllers.CategoryEnvelopesV3": {
             "type": "object",
             "properties": {
@@ -7464,6 +7544,32 @@ const docTemplate = `{
                     "description": "The error, if any occurred",
                     "type": "string",
                     "example": "the specified resource ID is not a valid UUID"
+                }
+            }
+        },
+        "controllers.EnvelopeCreateV3": {
+            "type": "object",
+            "properties": {
+                "archived": {
+                    "description": "Is the envelope hidden?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "categoryId": {
+                    "description": "ID of the category the envelope belongs to",
+                    "type": "string",
+                    "example": "878c831f-af99-4a71-b3ca-80deb7d793c1"
+                },
+                "name": {
+                    "description": "Name of the envelope",
+                    "type": "string",
+                    "example": "Groceries"
+                },
+                "note": {
+                    "description": "Notes about the envelope",
+                    "type": "string",
+                    "example": "For stuff bought at supermarkets and drugstores"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -4026,7 +4026,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.AccountCreate"
+                                "$ref": "#/definitions/controllers.AccountCreateV3"
                             }
                         }
                     }
@@ -4221,7 +4221,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.AccountCreate"
+                            "$ref": "#/definitions/controllers.AccountCreateV3"
                         }
                     }
                 ],
@@ -4648,7 +4648,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.CategoryCreate"
+                                "$ref": "#/definitions/controllers.CategoryCreateV3"
                             }
                         }
                     }
@@ -4843,7 +4843,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.CategoryCreate"
+                            "$ref": "#/definitions/controllers.CategoryCreateV3"
                         }
                     }
                 ],
@@ -4968,7 +4968,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.EnvelopeCreate"
+                                "$ref": "#/definitions/controllers.EnvelopeCreateV3"
                             }
                         }
                     }
@@ -5163,7 +5163,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.EnvelopeCreate"
+                            "$ref": "#/definitions/controllers.EnvelopeCreateV3"
                         }
                     }
                 ],
@@ -6512,6 +6512,60 @@
                 }
             }
         },
+        "controllers.AccountCreateV3": {
+            "type": "object",
+            "properties": {
+                "archived": {
+                    "description": "Is the account archived?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "budgetId": {
+                    "description": "ID of the budget this account belongs to",
+                    "type": "string",
+                    "example": "550dc009-cea6-4c12-b2a5-03446eb7b7cf"
+                },
+                "external": {
+                    "description": "Does the account belong to the budget owner or not?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": false
+                },
+                "importHash": {
+                    "description": "The SHA256 hash of a unique combination of values to use in duplicate detection",
+                    "type": "string",
+                    "example": "867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70"
+                },
+                "initialBalance": {
+                    "description": "Balance of the account before any transactions were recorded",
+                    "type": "number",
+                    "default": 0,
+                    "example": 173.12
+                },
+                "initialBalanceDate": {
+                    "description": "Date of the initial balance",
+                    "type": "string",
+                    "example": "2017-05-12T00:00:00Z"
+                },
+                "name": {
+                    "description": "Name of the account",
+                    "type": "string",
+                    "example": "Cash"
+                },
+                "note": {
+                    "description": "A longer description for the account",
+                    "type": "string",
+                    "example": "Money in my wallet"
+                },
+                "onBudget": {
+                    "description": "Does the account factor into the available budget? Always false when external: true",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                }
+            }
+        },
         "controllers.AccountListResponse": {
             "type": "object",
             "properties": {
@@ -7147,6 +7201,32 @@
                 }
             }
         },
+        "controllers.CategoryCreateV3": {
+            "type": "object",
+            "properties": {
+                "archived": {
+                    "description": "Is the category hidden?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "budgetId": {
+                    "description": "ID of the budget the category belongs to",
+                    "type": "string",
+                    "example": "52d967d3-33f4-4b04-9ba7-772e5ab9d0ce"
+                },
+                "name": {
+                    "description": "Name of the category",
+                    "type": "string",
+                    "example": "Saving"
+                },
+                "note": {
+                    "description": "Notes about the category",
+                    "type": "string",
+                    "example": "All envelopes for long-term saving"
+                }
+            }
+        },
         "controllers.CategoryEnvelopesV3": {
             "type": "object",
             "properties": {
@@ -7453,6 +7533,32 @@
                     "description": "The error, if any occurred",
                     "type": "string",
                     "example": "the specified resource ID is not a valid UUID"
+                }
+            }
+        },
+        "controllers.EnvelopeCreateV3": {
+            "type": "object",
+            "properties": {
+                "archived": {
+                    "description": "Is the envelope hidden?",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "categoryId": {
+                    "description": "ID of the category the envelope belongs to",
+                    "type": "string",
+                    "example": "878c831f-af99-4a71-b3ca-80deb7d793c1"
+                },
+                "name": {
+                    "description": "Name of the envelope",
+                    "type": "string",
+                    "example": "Groceries"
+                },
+                "note": {
+                    "description": "Notes about the envelope",
+                    "type": "string",
+                    "example": "For stuff bought at supermarkets and drugstores"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -103,6 +103,51 @@ definitions:
         example: the specified resource ID is not a valid UUID
         type: string
     type: object
+  controllers.AccountCreateV3:
+    properties:
+      archived:
+        default: false
+        description: Is the account archived?
+        example: true
+        type: boolean
+      budgetId:
+        description: ID of the budget this account belongs to
+        example: 550dc009-cea6-4c12-b2a5-03446eb7b7cf
+        type: string
+      external:
+        default: false
+        description: Does the account belong to the budget owner or not?
+        example: false
+        type: boolean
+      importHash:
+        description: The SHA256 hash of a unique combination of values to use in duplicate
+          detection
+        example: 867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70
+        type: string
+      initialBalance:
+        default: 0
+        description: Balance of the account before any transactions were recorded
+        example: 173.12
+        type: number
+      initialBalanceDate:
+        description: Date of the initial balance
+        example: "2017-05-12T00:00:00Z"
+        type: string
+      name:
+        description: Name of the account
+        example: Cash
+        type: string
+      note:
+        description: A longer description for the account
+        example: Money in my wallet
+        type: string
+      onBudget:
+        default: false
+        description: 'Does the account factor into the available budget? Always false
+          when external: true'
+        example: true
+        type: boolean
+    type: object
   controllers.AccountListResponse:
     properties:
       data:
@@ -572,6 +617,26 @@ definitions:
         example: the specified resource ID is not a valid UUID
         type: string
     type: object
+  controllers.CategoryCreateV3:
+    properties:
+      archived:
+        default: false
+        description: Is the category hidden?
+        example: true
+        type: boolean
+      budgetId:
+        description: ID of the budget the category belongs to
+        example: 52d967d3-33f4-4b04-9ba7-772e5ab9d0ce
+        type: string
+      name:
+        description: Name of the category
+        example: Saving
+        type: string
+      note:
+        description: Notes about the category
+        example: All envelopes for long-term saving
+        type: string
+    type: object
   controllers.CategoryEnvelopesV3:
     properties:
       allocation:
@@ -799,6 +864,26 @@ definitions:
       error:
         description: The error, if any occurred
         example: the specified resource ID is not a valid UUID
+        type: string
+    type: object
+  controllers.EnvelopeCreateV3:
+    properties:
+      archived:
+        default: false
+        description: Is the envelope hidden?
+        example: true
+        type: boolean
+      categoryId:
+        description: ID of the category the envelope belongs to
+        example: 878c831f-af99-4a71-b3ca-80deb7d793c1
+        type: string
+      name:
+        description: Name of the envelope
+        example: Groceries
+        type: string
+      note:
+        description: Notes about the envelope
+        example: For stuff bought at supermarkets and drugstores
         type: string
     type: object
   controllers.EnvelopeListResponse:
@@ -5170,7 +5255,7 @@ paths:
         required: true
         schema:
           items:
-            $ref: '#/definitions/models.AccountCreate'
+            $ref: '#/definitions/controllers.AccountCreateV3'
           type: array
       produces:
       - application/json
@@ -5293,7 +5378,7 @@ paths:
         name: account
         required: true
         schema:
-          $ref: '#/definitions/models.AccountCreate'
+          $ref: '#/definitions/controllers.AccountCreateV3'
       produces:
       - application/json
       responses:
@@ -5587,7 +5672,7 @@ paths:
         required: true
         schema:
           items:
-            $ref: '#/definitions/models.CategoryCreate'
+            $ref: '#/definitions/controllers.CategoryCreateV3'
           type: array
       produces:
       - application/json
@@ -5711,7 +5796,7 @@ paths:
         name: category
         required: true
         schema:
-          $ref: '#/definitions/models.CategoryCreate'
+          $ref: '#/definitions/controllers.CategoryCreateV3'
       produces:
       - application/json
       responses:
@@ -5802,7 +5887,7 @@ paths:
         required: true
         schema:
           items:
-            $ref: '#/definitions/models.EnvelopeCreate'
+            $ref: '#/definitions/controllers.EnvelopeCreateV3'
           type: array
       produces:
       - application/json
@@ -5926,7 +6011,7 @@ paths:
         name: envelope
         required: true
         schema:
-          $ref: '#/definitions/models.EnvelopeCreate'
+          $ref: '#/definitions/controllers.EnvelopeCreateV3'
       produces:
       - application/json
       responses:

--- a/pkg/controllers/cleanup_v3_test.go
+++ b/pkg/controllers/cleanup_v3_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/envelope-zero/backend/v3/internal/types"
+	"github.com/envelope-zero/backend/v3/pkg/controllers"
 	"github.com/envelope-zero/backend/v3/pkg/models"
 	"github.com/envelope-zero/backend/v3/test"
 	"github.com/shopspring/decimal"
@@ -15,9 +16,9 @@ import (
 
 func (suite *TestSuiteStandard) TestCleanupV3() {
 	_ = suite.createTestBudget(models.BudgetCreate{})
-	account := suite.createTestAccountV3(suite.T(), models.AccountCreate{Name: "TestCleanup"})
-	_ = suite.createTestCategoryV3(suite.T(), models.CategoryCreate{})
-	envelope := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{})
+	account := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{Name: "TestCleanup"})
+	_ = suite.createTestCategoryV3(suite.T(), controllers.CategoryCreateV3{})
+	envelope := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{})
 	_ = suite.createTestAllocation(models.AllocationCreate{})
 	_ = suite.createTestTransaction(models.TransactionCreate{Amount: decimal.NewFromFloat(17.32)})
 	_ = suite.createTestMonthConfig(envelope.Data.ID, types.NewMonth(time.Now().Year(), time.Now().Month()), models.MonthConfigCreate{})

--- a/pkg/controllers/import_v3_test.go
+++ b/pkg/controllers/import_v3_test.go
@@ -33,7 +33,7 @@ func (suite *TestSuiteStandard) parseCsvV3(t *testing.T, accountID uuid.UUID, fi
 
 // TestImportV3Success verifies successful imports for all import types.
 func (suite *TestSuiteStandard) TestImportV3Success() {
-	accountID := suite.createTestAccountV3(suite.T(), models.AccountCreate{Name: "TestImport"}).Data.ID.String()
+	accountID := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{Name: "TestImport"}).Data.ID.String()
 
 	tests := []struct {
 		name   string
@@ -101,7 +101,7 @@ func (suite *TestSuiteStandard) TestImportYnab4V3Fails() {
 
 // TestImportYnabImportPreviewV3Fails tests failing requests for the YNAB import format preview endpoint.
 func (suite *TestSuiteStandard) TestImportYnabImportPreviewV3Fails() {
-	accountID := suite.createTestAccountV3(suite.T(), models.AccountCreate{Name: "TestImportYnabImportPreviewV3Fails"}).Data.ID.String()
+	accountID := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{Name: "TestImportYnabImportPreviewV3Fails"}).Data.ID.String()
 
 	tests := []struct {
 		name          string
@@ -140,7 +140,7 @@ func (suite *TestSuiteStandard) TestImportYnabImportPreviewV3Fails() {
 
 func (suite *TestSuiteStandard) TestImportYnabImportPreviewV3DuplicateDetection() {
 	// Create test account
-	account := suite.createTestAccountV3(suite.T(), models.AccountCreate{Name: "TestImportYnabImportPreviewV3DuplicateDetection"})
+	account := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{Name: "TestImportYnabImportPreviewV3DuplicateDetection"})
 
 	// Get the import hash of the first transaction and create one with the same import hash
 	preview := suite.parseCsvV3(suite.T(), account.Data.ID, "comdirect-ynap.csv")
@@ -152,7 +152,7 @@ func (suite *TestSuiteStandard) TestImportYnabImportPreviewV3DuplicateDetection(
 	})
 
 	_ = suite.createTestTransactionV3(suite.T(), models.TransactionCreate{
-		SourceAccountID: suite.createTestAccountV3(suite.T(), models.AccountCreate{Note: "This account is in a different Budget, but has the same ImportHash", Name: "TestYnabImportPreviewDuplicateDetection Different Budget"}).Data.ID,
+		SourceAccountID: suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{Note: "This account is in a different Budget, but has the same ImportHash", Name: "TestYnabImportPreviewDuplicateDetection Different Budget"}).Data.ID,
 		ImportHash:      preview.Data[0].Transaction.ImportHash,
 		Amount:          decimal.NewFromFloat(42.23),
 	})
@@ -165,7 +165,7 @@ func (suite *TestSuiteStandard) TestImportYnabImportPreviewV3DuplicateDetection(
 
 func (suite *TestSuiteStandard) TestImportYnabImportPreviewV3AvailableFrom() {
 	// Create test account
-	account := suite.createTestAccountV3(suite.T(), models.AccountCreate{Name: "TestImportYnabImportPreviewV3AvailableFrom"})
+	account := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{Name: "TestImportYnabImportPreviewV3AvailableFrom"})
 	preview := suite.parseCsvV3(suite.T(), account.Data.ID, "available-from-test.csv")
 
 	dates := []types.Month{
@@ -182,17 +182,17 @@ func (suite *TestSuiteStandard) TestImportYnabImportPreviewV3AvailableFrom() {
 func (suite *TestSuiteStandard) TestImportYnabImportPreviewV3FindAccounts() {
 	// Create a budget and two existing accounts to use
 	budget := suite.createTestBudgetV3(suite.T(), models.BudgetCreate{})
-	edeka := suite.createTestAccountV3(suite.T(), models.AccountCreate{BudgetID: budget.Data.ID, Name: "Edeka", External: true})
+	edeka := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{BudgetID: budget.Data.ID, Name: "Edeka", External: true})
 
 	// Create an account named "Edeka" in another budget to ensure it is not found. If it were found, the tests for the non-archived
 	// Edeka account being found would fail since we do not use an account if we find more than one with the same name
-	_ = suite.createTestAccountV3(suite.T(), models.AccountCreate{Name: "Edeka"})
+	_ = suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{Name: "Edeka"})
 
 	// Account we import to
-	internalAccount := suite.createTestAccountV3(suite.T(), models.AccountCreate{BudgetID: budget.Data.ID, Name: "Envelope Zero Account"})
+	internalAccount := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{BudgetID: budget.Data.ID, Name: "Envelope Zero Account"})
 
 	// Test envelope and  test transaction to the Edeka account with an envelope to test the envelope prefill
-	envelope := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{CategoryID: suite.createTestCategoryV3(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID}).Data.ID})
+	envelope := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{CategoryID: suite.createTestCategoryV3(suite.T(), controllers.CategoryCreateV3{BudgetID: budget.Data.ID}).Data.ID})
 	envelopeID := envelope.Data.ID
 	_ = suite.createTestTransactionV3(suite.T(), models.TransactionCreate{BudgetID: budget.Data.ID, SourceAccountID: internalAccount.Data.ID, DestinationAccountID: edeka.Data.ID, EnvelopeID: &envelopeID, Amount: decimal.NewFromFloat(12.00)})
 
@@ -242,14 +242,14 @@ func (suite *TestSuiteStandard) TestImportYnabImportPreviewV3FindAccounts() {
 func (suite *TestSuiteStandard) TestImportYnabImportPreviewV3Match() {
 	// Create a budget and two existing accounts to use
 	budget := suite.createTestBudgetV3(suite.T(), models.BudgetCreate{})
-	edeka := suite.createTestAccountV3(suite.T(), models.AccountCreate{BudgetID: budget.Data.ID, Name: "Edeka", External: true})
-	bahn := suite.createTestAccountV3(suite.T(), models.AccountCreate{BudgetID: budget.Data.ID, Name: "Deutsche Bahn", External: true})
+	edeka := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{BudgetID: budget.Data.ID, Name: "Edeka", External: true})
+	bahn := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{BudgetID: budget.Data.ID, Name: "Deutsche Bahn", External: true})
 
 	// Account we import to
-	internalAccount := suite.createTestAccountV3(suite.T(), models.AccountCreate{BudgetID: budget.Data.ID, Name: "Envelope Zero Account"})
+	internalAccount := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{BudgetID: budget.Data.ID, Name: "Envelope Zero Account"})
 
 	// Test envelope and  test transaction to the Edeka account with an envelope to test the envelope prefill
-	envelope := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{CategoryID: suite.createTestCategoryV3(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID}).Data.ID})
+	envelope := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{CategoryID: suite.createTestCategoryV3(suite.T(), controllers.CategoryCreateV3{BudgetID: budget.Data.ID}).Data.ID})
 	envelopeID := envelope.Data.ID
 	_ = suite.createTestTransactionV3(suite.T(), models.TransactionCreate{BudgetID: budget.Data.ID, SourceAccountID: internalAccount.Data.ID, DestinationAccountID: edeka.Data.ID, EnvelopeID: &envelopeID, Amount: decimal.NewFromFloat(12.00)})
 

--- a/pkg/controllers/match_rule_v3_test.go
+++ b/pkg/controllers/match_rule_v3_test.go
@@ -32,7 +32,7 @@ func (suite *TestSuiteStandard) createTestMatchRuleV3(t *testing.T, c models.Mat
 }
 
 func (suite *TestSuiteStandard) TestMatchRuleV3Create() {
-	a := suite.createTestAccountV3(suite.T(), models.AccountCreate{Name: "TestMatchRuleCreate"})
+	a := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{Name: "TestMatchRuleCreate"})
 
 	tests := []struct {
 		name           string
@@ -127,7 +127,7 @@ func (suite *TestSuiteStandard) TestMatchRulesV3Options() {
 			"",
 			func(t *testing.T) string {
 				return suite.createTestMatchRuleV3(t, models.MatchRuleCreate{
-					AccountID: suite.createTestAccountV3(t, models.AccountCreate{}).Data.ID,
+					AccountID: suite.createTestAccountV3(t, controllers.AccountCreateV3{}).Data.ID,
 					Match:     "TestMatch*",
 				}).Data.Links.Self
 			},
@@ -185,8 +185,8 @@ func (suite *TestSuiteStandard) TestMatchRulesV3DatabaseError() {
 func (suite *TestSuiteStandard) TestMatchRulesV3GetFilter() {
 	b := suite.createTestBudgetV3(suite.T(), models.BudgetCreate{})
 
-	a1 := suite.createTestAccountV3(suite.T(), models.AccountCreate{BudgetID: b.Data.ID, Name: "TestMatchRulesV3GetFilter 1"})
-	a2 := suite.createTestAccountV3(suite.T(), models.AccountCreate{BudgetID: b.Data.ID, Name: "TestMatchRulesV3GetFilter 2"})
+	a1 := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{BudgetID: b.Data.ID, Name: "TestMatchRulesV3GetFilter 1"})
+	a2 := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{BudgetID: b.Data.ID, Name: "TestMatchRulesV3GetFilter 2"})
 
 	_ = suite.createTestMatchRuleV3(suite.T(), models.MatchRuleCreate{
 		Priority:  1,
@@ -237,8 +237,8 @@ func (suite *TestSuiteStandard) TestMatchRulesV3GetFilter() {
 func (suite *TestSuiteStandard) TestMatchRulesV3GetFilterErrors() {
 	b := suite.createTestBudgetV3(suite.T(), models.BudgetCreate{})
 
-	a1 := suite.createTestAccountV3(suite.T(), models.AccountCreate{BudgetID: b.Data.ID, Name: "TestMatchRulesV3GetFilter 1"})
-	a2 := suite.createTestAccountV3(suite.T(), models.AccountCreate{BudgetID: b.Data.ID, Name: "TestMatchRulesV3GetFilter 2"})
+	a1 := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{BudgetID: b.Data.ID, Name: "TestMatchRulesV3GetFilter 1"})
+	a2 := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{BudgetID: b.Data.ID, Name: "TestMatchRulesV3GetFilter 2"})
 
 	_ = suite.createTestMatchRuleV3(suite.T(), models.MatchRuleCreate{
 		Priority:  1,
@@ -293,7 +293,7 @@ func (suite *TestSuiteStandard) TestMatchRulesV3CreateInvalidBody() {
 // TestMatchRulesV3Create verifies that transaction creation works.
 func (suite *TestSuiteStandard) TestMatchRulesV3Create() {
 	budget := suite.createTestBudgetV3(suite.T(), models.BudgetCreate{})
-	internalAccount := suite.createTestAccountV3(suite.T(), models.AccountCreate{External: false, BudgetID: budget.Data.ID, Name: "TestMatchRulesV3Create Internal"})
+	internalAccount := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{External: false, BudgetID: budget.Data.ID, Name: "TestMatchRulesV3Create Internal"})
 
 	tests := []struct {
 		name           string
@@ -374,7 +374,7 @@ func (suite *TestSuiteStandard) TestMatchRulesV3GetSingle() {
 			http.StatusOK,
 			"",
 			func(t *testing.T) string {
-				return suite.createTestMatchRuleV3(t, models.MatchRuleCreate{AccountID: suite.createTestAccountV3(t, models.AccountCreate{}).Data.ID}).Data.Links.Self
+				return suite.createTestMatchRuleV3(t, models.MatchRuleCreate{AccountID: suite.createTestAccountV3(t, controllers.AccountCreateV3{}).Data.ID}).Data.Links.Self
 			},
 		},
 		{
@@ -403,7 +403,7 @@ func (suite *TestSuiteStandard) TestMatchRulesV3GetSingle() {
 // TestMatchRulesV3UpdateFail verifies that transaction updates fail where they should.
 func (suite *TestSuiteStandard) TestMatchRulesV3UpdateFail() {
 	m := suite.createTestMatchRuleV3(suite.T(), models.MatchRuleCreate{
-		AccountID: suite.createTestAccountV3(suite.T(), models.AccountCreate{}).Data.ID,
+		AccountID: suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{}).Data.ID,
 		Match:     "Some match*",
 	})
 
@@ -452,11 +452,11 @@ func (suite *TestSuiteStandard) TestMatchRulesV3UpdateFail() {
 // TestMatchRulesV3Update verifies that transaction updates are successful.
 func (suite *TestSuiteStandard) TestMatchRulesV3Update() {
 	m := suite.createTestMatchRuleV3(suite.T(), models.MatchRuleCreate{
-		AccountID: suite.createTestAccountV3(suite.T(), models.AccountCreate{}).Data.ID,
+		AccountID: suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{}).Data.ID,
 		Match:     "Some match*",
 	})
 
-	newAccount := suite.createTestAccountV3(suite.T(), models.AccountCreate{})
+	newAccount := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{})
 
 	tests := []struct {
 		name string // Name for the test
@@ -503,7 +503,7 @@ func (suite *TestSuiteStandard) TestMatchRulesV3Delete() {
 			"Standard deletion",
 			http.StatusNoContent,
 			suite.createTestMatchRuleV3(suite.T(), models.MatchRuleCreate{
-				AccountID: suite.createTestAccountV3(suite.T(), models.AccountCreate{}).Data.ID,
+				AccountID: suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{}).Data.ID,
 				Match:     "Some match*",
 			}).Data.ID.String(),
 		},
@@ -537,7 +537,7 @@ func (suite *TestSuiteStandard) TestMatchRulesV3Delete() {
 // TestMatchRulesV3GetSorted verifies that Match Rules are sorted as expected.
 func (suite *TestSuiteStandard) TestMatchRulesV3GetSorted() {
 	b := suite.createTestBudgetV3(suite.T(), models.BudgetCreate{})
-	a := suite.createTestAccountV3(suite.T(), models.AccountCreate{BudgetID: b.Data.ID, Name: "TestMatchRulesV3GetFilter 1"})
+	a := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{BudgetID: b.Data.ID, Name: "TestMatchRulesV3GetFilter 1"})
 
 	m1 := suite.createTestMatchRuleV3(suite.T(), models.MatchRuleCreate{
 		Priority:  1,

--- a/pkg/controllers/month_config_v3_test.go
+++ b/pkg/controllers/month_config_v3_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (suite *TestSuiteStandard) TestMonthConfigsV3GetSingle() {
-	envelope := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{})
+	envelope := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{})
 	someMonth := types.NewMonth(2020, 3)
 
 	suite.controller.DB.Create(&models.MonthConfig{
@@ -62,7 +62,7 @@ func (suite *TestSuiteStandard) TestMonthConfigsV3GetSingle() {
 }
 
 func (suite *TestSuiteStandard) TestMonthConfigsV3Options() {
-	envelope := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{})
+	envelope := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{})
 
 	tests := []struct {
 		name     string
@@ -92,7 +92,7 @@ func (suite *TestSuiteStandard) TestMonthConfigsV3Options() {
 }
 
 func (suite *TestSuiteStandard) TestMonthConfigsV3Update() {
-	envelope := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{})
+	envelope := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{})
 	month := types.NewMonth(time.Now().Year(), time.Now().Month())
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, fmt.Sprintf("http://example.com/v3/envelopes/%s/%s", envelope.Data.ID, month), models.MonthConfigCreate{
@@ -106,7 +106,7 @@ func (suite *TestSuiteStandard) TestMonthConfigsV3Update() {
 }
 
 func (suite *TestSuiteStandard) TestMonthConfigsV3UpdateFails() {
-	envelope := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{})
+	envelope := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{})
 	month := types.NewMonth(2022, 3)
 
 	tests := []struct {
@@ -135,7 +135,7 @@ func (suite *TestSuiteStandard) TestMonthConfigsV3UpdateFails() {
 }
 
 func (suite *TestSuiteStandard) TestMonthConfigsV3UpdateAllocationCreatesResource() {
-	envelope := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{})
+	envelope := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{})
 	month := types.NewMonth(time.Now().Year(), time.Now().Month())
 
 	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, fmt.Sprintf("http://example.com/v3/envelopes/%s/%s", envelope.Data.ID, month), controllers.MonthConfigCreateV3{

--- a/pkg/controllers/month_v3_test.go
+++ b/pkg/controllers/month_v3_test.go
@@ -27,8 +27,8 @@ func (suite *TestSuiteStandard) TestMonthGetV3EnvelopeAllocationLink() {
 	var month controllers.MonthResponseV3
 
 	budget := suite.createTestBudgetV3(suite.T(), models.BudgetCreate{})
-	category := suite.createTestCategoryV3(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
-	envelope := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
+	category := suite.createTestCategoryV3(suite.T(), controllers.CategoryCreateV3{BudgetID: budget.Data.ID})
+	envelope := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{CategoryID: category.Data.ID})
 	_ = suite.createTestAllocation(models.AllocationCreate{Amount: decimal.NewFromFloat(10), EnvelopeID: envelope.Data.ID, Month: types.NewMonth(2022, 1)})
 
 	r := test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.Month, "YYYY-MM", "2022-01", 1), "")
@@ -53,7 +53,7 @@ func (suite *TestSuiteStandard) TestMonthGetV3NotNil() {
 	suite.Assert().Empty(month.Data.Categories)
 
 	// Verify that the envelopes list is empty, not nil
-	_ = suite.createTestCategoryV3(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
+	_ = suite.createTestCategoryV3(suite.T(), controllers.CategoryCreateV3{BudgetID: budget.Data.ID})
 
 	r = test.Request(suite.controller, suite.T(), http.MethodGet, strings.Replace(budget.Data.Links.Month, "YYYY-MM", "2022-01", 1), "")
 	assertHTTPStatus(suite.T(), &r, http.StatusOK)
@@ -104,9 +104,9 @@ func (suite *TestSuiteStandard) TestMonthGetV3DBFail() {
 
 func (suite *TestSuiteStandard) TestMonthGetV3Delete() {
 	budget := suite.createTestBudgetV3(suite.T(), models.BudgetCreate{})
-	category := suite.createTestCategoryV3(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
-	envelope1 := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
-	envelope2 := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
+	category := suite.createTestCategoryV3(suite.T(), controllers.CategoryCreateV3{BudgetID: budget.Data.ID})
+	envelope1 := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{CategoryID: category.Data.ID})
+	envelope2 := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{CategoryID: category.Data.ID})
 
 	allocation1 := suite.createTestAllocation(models.AllocationCreate{
 		Month:      types.NewMonth(2022, 1),
@@ -150,10 +150,10 @@ func (suite *TestSuiteStandard) TestMonthV3DeleteFail() {
 
 func (suite *TestSuiteStandard) TestMonthV3AllocateBudgeted() {
 	budget := suite.createTestBudgetV3(suite.T(), models.BudgetCreate{})
-	category := suite.createTestCategoryV3(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
-	envelope1 := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
-	envelope2 := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
-	archivedEnvelope := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID, Hidden: true})
+	category := suite.createTestCategoryV3(suite.T(), controllers.CategoryCreateV3{BudgetID: budget.Data.ID})
+	envelope1 := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{CategoryID: category.Data.ID})
+	envelope2 := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{CategoryID: category.Data.ID})
+	archivedEnvelope := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{CategoryID: category.Data.ID, Archived: true})
 
 	e1Amount := decimal.NewFromFloat(30)
 	e2Amount := decimal.NewFromFloat(40)
@@ -214,11 +214,11 @@ func (suite *TestSuiteStandard) TestMonthV3AllocateBudgeted() {
 
 func (suite *TestSuiteStandard) TestMonthV3AllocateSpend() {
 	budget := suite.createTestBudgetV3(suite.T(), models.BudgetCreate{})
-	cashAccount := suite.createTestAccountV3(suite.T(), models.AccountCreate{External: false, OnBudget: true, Name: "TestSetMonthSpend Cash"})
-	externalAccount := suite.createTestAccountV3(suite.T(), models.AccountCreate{External: true, Name: "TestSetMonthSpend External"})
-	category := suite.createTestCategoryV3(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID})
-	envelope1 := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
-	envelope2 := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID})
+	cashAccount := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{External: false, OnBudget: true, Name: "TestSetMonthSpend Cash"})
+	externalAccount := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{External: true, Name: "TestSetMonthSpend External"})
+	category := suite.createTestCategoryV3(suite.T(), controllers.CategoryCreateV3{BudgetID: budget.Data.ID})
+	envelope1 := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{CategoryID: category.Data.ID})
+	envelope2 := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{CategoryID: category.Data.ID})
 
 	_ = suite.createTestAllocation(models.AllocationCreate{
 		Month:      types.NewMonth(2022, 1),
@@ -293,10 +293,10 @@ func (suite *TestSuiteStandard) TestMonthsV3PostFails() {
 // TestMonthsV3 verifies that the monthly calculations are correct.
 func (suite *TestSuiteStandard) TestMonthsV3() {
 	budget := suite.createTestBudgetV3(suite.T(), models.BudgetCreate{})
-	category := suite.createTestCategoryV3(suite.T(), models.CategoryCreate{BudgetID: budget.Data.ID, Name: "Upkeep"})
-	envelope := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{CategoryID: category.Data.ID, Name: "Utilities"})
-	account := suite.createTestAccountV3(suite.T(), models.AccountCreate{BudgetID: budget.Data.ID, OnBudget: true, Name: "TestMonth"})
-	externalAccount := suite.createTestAccountV3(suite.T(), models.AccountCreate{BudgetID: budget.Data.ID, External: true})
+	category := suite.createTestCategoryV3(suite.T(), controllers.CategoryCreateV3{BudgetID: budget.Data.ID, Name: "Upkeep"})
+	envelope := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{CategoryID: category.Data.ID, Name: "Utilities"})
+	account := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{BudgetID: budget.Data.ID, OnBudget: true, Name: "TestMonth"})
+	externalAccount := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{BudgetID: budget.Data.ID, External: true})
 
 	// Allocate funds to the months
 	// TODO: Replace this with createTestMonthConfigV3 once Allocations are integrated and not transparently created by API v3

--- a/pkg/controllers/transaction_v3_test.go
+++ b/pkg/controllers/transaction_v3_test.go
@@ -156,14 +156,14 @@ func (suite *TestSuiteStandard) TestTransactionsV3Get() {
 func (suite *TestSuiteStandard) TestTransactionsV3GetFilter() {
 	b := suite.createTestBudgetV3(suite.T(), models.BudgetCreate{})
 
-	a1 := suite.createTestAccountV3(suite.T(), models.AccountCreate{BudgetID: b.Data.ID, Name: "TestTransactionsV3GetFilter 1"})
-	a2 := suite.createTestAccountV3(suite.T(), models.AccountCreate{BudgetID: b.Data.ID, Name: "TestTransactionsV3GetFilter 2"})
-	a3 := suite.createTestAccountV3(suite.T(), models.AccountCreate{BudgetID: b.Data.ID, Name: "TestTransactionsV3GetFilter 3"})
+	a1 := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{BudgetID: b.Data.ID, Name: "TestTransactionsV3GetFilter 1"})
+	a2 := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{BudgetID: b.Data.ID, Name: "TestTransactionsV3GetFilter 2"})
+	a3 := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{BudgetID: b.Data.ID, Name: "TestTransactionsV3GetFilter 3"})
 
-	c := suite.createTestCategoryV3(suite.T(), models.CategoryCreate{BudgetID: b.Data.ID})
+	c := suite.createTestCategoryV3(suite.T(), controllers.CategoryCreateV3{BudgetID: b.Data.ID})
 
-	e1 := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{CategoryID: c.Data.ID})
-	e2 := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{CategoryID: c.Data.ID})
+	e1 := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{CategoryID: c.Data.ID})
+	e2 := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{CategoryID: c.Data.ID})
 
 	e1ID := &e1.Data.ID
 	e2ID := &e2.Data.ID
@@ -310,8 +310,8 @@ func (suite *TestSuiteStandard) TestTransactionsV3CreateInvalidBody() {
 // TestTransactionsV3Create verifies that transaction creation works.
 func (suite *TestSuiteStandard) TestTransactionsV3Create() {
 	budget := suite.createTestBudgetV3(suite.T(), models.BudgetCreate{})
-	internalAccount := suite.createTestAccountV3(suite.T(), models.AccountCreate{External: false, BudgetID: budget.Data.ID, Name: "TestTransactionsV3Create Internal"})
-	externalAccount := suite.createTestAccountV3(suite.T(), models.AccountCreate{External: true, BudgetID: budget.Data.ID, Name: "TestTransactionsV3Create External"})
+	internalAccount := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{External: false, BudgetID: budget.Data.ID, Name: "TestTransactionsV3Create Internal"})
+	externalAccount := suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{External: true, BudgetID: budget.Data.ID, Name: "TestTransactionsV3Create External"})
 
 	tests := []struct {
 		name           string
@@ -533,13 +533,13 @@ func (suite *TestSuiteStandard) TestUpdateNonExistingTransactionV3() {
 
 // TestTransactionsV3Update verifies that transaction updates are successful.
 func (suite *TestSuiteStandard) TestTransactionsV3Update() {
-	envelope := suite.createTestEnvelopeV3(suite.T(), models.EnvelopeCreate{})
+	envelope := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{})
 	transaction := suite.createTestTransactionV3(suite.T(), models.TransactionCreate{
 		Amount:               decimal.NewFromFloat(23.14),
 		Note:                 "Test note for transaction",
 		BudgetID:             suite.createTestBudgetV3(suite.T(), models.BudgetCreate{Name: "Testing budget for updating of outgoing transfer"}).Data.ID,
-		SourceAccountID:      suite.createTestAccountV3(suite.T(), models.AccountCreate{Name: "Internal Source Account", External: false}).Data.ID,
-		DestinationAccountID: suite.createTestAccountV3(suite.T(), models.AccountCreate{Name: "External destination account", External: true}).Data.ID,
+		SourceAccountID:      suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{Name: "Internal Source Account", External: false}).Data.ID,
+		DestinationAccountID: suite.createTestAccountV3(suite.T(), controllers.AccountCreateV3{Name: "External destination account", External: true}).Data.ID,
 		EnvelopeID:           &envelope.Data.ID,
 	})
 


### PR DESCRIPTION
This fixes a bug where the archived parameter was ignored on resource creation and updates.
