### PR TITLE
fix: improve foreign key and not found messages in API v3

### DIFF
--- a/pkg/controllers/test_helpers_test.go
+++ b/pkg/controllers/test_helpers_test.go
@@ -28,3 +28,11 @@ func (suite *TestSuiteStandard) decodeResponse(r *httptest.ResponseRecorder, tar
 		assert.FailNow(suite.T(), "Parsing error", "Unable to parse response from server %q into %v, '%v', Request ID: %s", r.Body, reflect.TypeOf(target), err, r.Result().Header.Get("x-request-id"))
 	}
 }
+
+// decodeResponse decodes an HTTP response into a target struct.
+func decodeResponse(t *testing.T, r *httptest.ResponseRecorder, target interface{}) {
+	err := json.NewDecoder(r.Body).Decode(target)
+	if err != nil {
+		assert.FailNow(t, "Parsing error", "Unable to parse response from server %q into %v, '%v', Request ID: %s", r.Body, reflect.TypeOf(target), err, r.Result().Header.Get("x-request-id"))
+	}
+}


### PR DESCRIPTION
This improves the handling of foreign key errors and not found messages in APIv3.

It also moves errors for resource creation to the specific resource, so that
a failure on creation of one resource does not affect all other resources.

With this, the status code for references to non-existing resources is also updated to
404 Not Found, instead of 400 Bad Request.
