### PR TITLE
feat: trim whitespace from string fields

### DIFF
--- a/pkg/models/account.go
+++ b/pkg/models/account.go
@@ -72,11 +72,21 @@ func (a Account) BeforeUpdate(tx *gorm.DB) (err error) {
 	return nil
 }
 
-// BeforeSave sets OnBudget to false when External is true.
-func (a *Account) BeforeSave(_ *gorm.DB) (err error) {
+// BeforeSave ensures consistency for the account
+//
+// It enforces OnBudget to be false when the account
+// is external.
+//
+// It trims whitespace from all strings
+func (a *Account) BeforeSave(_ *gorm.DB) error {
 	if a.External {
 		a.OnBudget = false
 	}
+
+	a.Name = strings.TrimSpace(a.Name)
+	a.Note = strings.TrimSpace(a.Note)
+	a.ImportHash = strings.TrimSpace(a.ImportHash)
+
 	return nil
 }
 

--- a/pkg/models/account_test.go
+++ b/pkg/models/account_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/envelope-zero/backend/v3/internal/types"
@@ -10,6 +11,23 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 )
+
+func (suite *TestSuiteStandard) TestAccountTrimWhitespace() {
+	name := "\t Whitespace galore!   "
+	note := " Some more whitespace in the notes    "
+	importHash := "  867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70  \t"
+
+	account := suite.createTestAccount(models.AccountCreate{
+		Name:       name,
+		Note:       note,
+		ImportHash: importHash,
+		BudgetID:   suite.createTestBudget(models.BudgetCreate{}).ID,
+	})
+
+	assert.Equal(suite.T(), strings.TrimSpace(name), account.Name)
+	assert.Equal(suite.T(), strings.TrimSpace(note), account.Note)
+	assert.Equal(suite.T(), strings.TrimSpace(importHash), account.ImportHash)
+}
 
 func (suite *TestSuiteStandard) TestAccountCalculations() {
 	budget := suite.createTestBudget(models.BudgetCreate{})

--- a/pkg/models/budget.go
+++ b/pkg/models/budget.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/envelope-zero/backend/v3/internal/types"
 	"github.com/envelope-zero/backend/v3/pkg/database"
@@ -27,6 +28,14 @@ type BudgetCreate struct {
 	Name     string `json:"name" example:"Morre's Budget" default:""`       // Name of the budget
 	Note     string `json:"note" example:"My personal expenses" default:""` // A longer description of the budget
 	Currency string `json:"currency" example:"€" default:""`                // The currency for the budget
+}
+
+func (b *Budget) BeforeSave(_ *gorm.DB) error {
+	b.Name = strings.TrimSpace(b.Name)
+	b.Note = strings.TrimSpace(b.Note)
+	b.Currency = strings.TrimSpace(b.Currency)
+
+	return nil
 }
 
 // Balance calculates the balance for a budget.

--- a/pkg/models/budget_test.go
+++ b/pkg/models/budget_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +11,22 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 )
+
+func (suite *TestSuiteStandard) TestBudgetTrimWhitespace() {
+	name := "\t Whitespace galore!   "
+	note := " Some more whitespace in the notes    "
+	currency := "  €"
+
+	budget := suite.createTestBudget(models.BudgetCreate{
+		Name:     name,
+		Note:     note,
+		Currency: currency,
+	})
+
+	assert.Equal(suite.T(), strings.TrimSpace(name), budget.Name)
+	assert.Equal(suite.T(), strings.TrimSpace(note), budget.Note)
+	assert.Equal(suite.T(), strings.TrimSpace(currency), budget.Currency)
+}
 
 func (suite *TestSuiteStandard) TestBudgetAfterFind() {
 	budget := suite.createTestBudget(models.BudgetCreate{})

--- a/pkg/models/category.go
+++ b/pkg/models/category.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"strings"
+
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
@@ -22,6 +24,13 @@ type CategoryCreate struct {
 
 func (c Category) Self() string {
 	return "Category"
+}
+
+func (c *Category) BeforeSave(_ *gorm.DB) error {
+	c.Name = strings.TrimSpace(c.Name)
+	c.Note = strings.TrimSpace(c.Note)
+
+	return nil
 }
 
 func (c *Category) AfterFind(_ *gorm.DB) (err error) {

--- a/pkg/models/category_test.go
+++ b/pkg/models/category_test.go
@@ -1,9 +1,25 @@
 package models_test
 
 import (
+	"strings"
+
 	"github.com/envelope-zero/backend/v3/pkg/models"
 	"github.com/stretchr/testify/assert"
 )
+
+func (suite *TestSuiteStandard) TestCategoryTrimWhitespace() {
+	name := "\t Whitespace galore!   "
+	note := " Some more whitespace in the notes    "
+
+	category := suite.createTestCategory(models.CategoryCreate{
+		Name:     name,
+		Note:     note,
+		BudgetID: suite.createTestBudget(models.BudgetCreate{}).ID,
+	})
+
+	assert.Equal(suite.T(), strings.TrimSpace(name), category.Name)
+	assert.Equal(suite.T(), strings.TrimSpace(note), category.Note)
+}
 
 func (suite *TestSuiteStandard) TestCategoryArchiveArchivesEnvelopes() {
 	category := suite.createTestCategory(models.CategoryCreate{

--- a/pkg/models/envelope.go
+++ b/pkg/models/envelope.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/envelope-zero/backend/v3/internal/types"
@@ -27,6 +28,13 @@ type EnvelopeCreate struct {
 
 func (e Envelope) Self() string {
 	return "Envelope"
+}
+
+func (e *Envelope) BeforeSave(_ *gorm.DB) error {
+	e.Name = strings.TrimSpace(e.Name)
+	e.Note = strings.TrimSpace(e.Note)
+
+	return nil
 }
 
 func (e *Envelope) AfterFind(_ *gorm.DB) (err error) {

--- a/pkg/models/envelope_test.go
+++ b/pkg/models/envelope_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +11,22 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 )
+
+func (suite *TestSuiteStandard) TestEnvelopeTrimWhitespace() {
+	name := "\t Whitespace galore!   "
+	note := " Some more whitespace in the notes    "
+
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{
+		Name: name,
+		Note: note,
+		CategoryID: suite.createTestCategory(models.CategoryCreate{
+			BudgetID: suite.createTestBudget(models.BudgetCreate{}).ID,
+		}).ID,
+	})
+
+	assert.Equal(suite.T(), strings.TrimSpace(name), envelope.Name)
+	assert.Equal(suite.T(), strings.TrimSpace(note), envelope.Note)
+}
 
 func (suite *TestSuiteStandard) TestEnvelopeMonthSum() {
 	budget := suite.createTestBudget(models.BudgetCreate{})

--- a/pkg/models/month_config.go
+++ b/pkg/models/month_config.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/envelope-zero/backend/v3/internal/types"
 	"github.com/google/uuid"
@@ -32,6 +33,12 @@ type MonthConfigCreate struct {
 
 func (m MonthConfig) Self() string {
 	return "Month Config"
+}
+
+func (m *MonthConfig) BeforeSave(_ *gorm.DB) error {
+	m.Note = strings.TrimSpace(m.Note)
+
+	return nil
 }
 
 func (m *MonthConfig) AfterFind(tx *gorm.DB) error {

--- a/pkg/models/month_config_test.go
+++ b/pkg/models/month_config_test.go
@@ -1,10 +1,29 @@
 package models_test
 
 import (
+	"strings"
+
 	"github.com/envelope-zero/backend/v3/pkg/models"
 	"github.com/stretchr/testify/assert"
 )
 
 func (suite *TestSuiteStandard) TestMonthConfigSelf() {
 	assert.Equal(suite.T(), "Month Config", models.MonthConfig{}.Self())
+}
+
+func (suite *TestSuiteStandard) TestMonthConfigTrimWhitespace() {
+	note := " Some more whitespace in the notes    "
+
+	account := suite.createTestMonthConfig(models.MonthConfig{
+		MonthConfigCreate: models.MonthConfigCreate{
+			Note: note,
+		},
+		EnvelopeID: suite.createTestEnvelope(models.EnvelopeCreate{
+			CategoryID: suite.createTestCategory(models.CategoryCreate{
+				BudgetID: suite.createTestBudget(models.BudgetCreate{}).ID,
+			}).ID,
+		}).ID,
+	})
+
+	assert.Equal(suite.T(), strings.TrimSpace(note), account.Note)
 }

--- a/pkg/models/test_suite_test.go
+++ b/pkg/models/test_suite_test.go
@@ -140,3 +140,12 @@ func (suite *TestSuiteStandard) createTestTransaction(c models.TransactionCreate
 
 	return transaction
 }
+
+func (suite *TestSuiteStandard) createTestMonthConfig(c models.MonthConfig) models.MonthConfig {
+	err := suite.db.Save(&c).Error
+	if err != nil {
+		suite.Assert().FailNow("MonthConfig could not be saved", "Error: %s, Transaction: %#v", err, c)
+	}
+
+	return c
+}

--- a/pkg/models/transaction.go
+++ b/pkg/models/transaction.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/envelope-zero/backend/v3/internal/types"
@@ -61,7 +62,11 @@ func (t *Transaction) AfterFind(tx *gorm.DB) (err error) {
 // BeforeSave
 //   - sets the timezone for the Date for UTC
 //   - ensures that ReconciledSource and ReconciledDestination are set to valid values
+//   - trims whitespace from string fields
 func (t *Transaction) BeforeSave(tx *gorm.DB) (err error) {
+	t.Note = strings.TrimSpace(t.Note)
+	t.ImportHash = strings.TrimSpace(t.ImportHash)
+
 	// Ensure that the Envelope ID is nil and not a pointer to a nil UUID
 	// when it is set
 	if t.EnvelopeID != nil && *t.EnvelopeID == uuid.Nil {

--- a/pkg/models/transaction_test.go
+++ b/pkg/models/transaction_test.go
@@ -11,6 +11,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func (suite *TestSuiteStandard) TestTransactionTrimWhitespace() {
+	note := " Some more whitespace in the notes    "
+	importHash := "  867e3a26dc0baf73f4bff506f31a97f6c32088917e9e5cf1a5ed6f3f84a6fa70  \t"
+
+	budgetID := suite.createTestBudget(models.BudgetCreate{}).ID
+
+	transaction := suite.createTestTransaction(models.TransactionCreate{
+		Note:                 note,
+		ImportHash:           importHash,
+		BudgetID:             budgetID,
+		SourceAccountID:      suite.createTestAccount(models.AccountCreate{BudgetID: budgetID}).ID,
+		DestinationAccountID: suite.createTestAccount(models.AccountCreate{BudgetID: budgetID}).ID,
+	})
+
+	assert.Equal(suite.T(), strings.TrimSpace(note), transaction.Note)
+	assert.Equal(suite.T(), strings.TrimSpace(importHash), transaction.ImportHash)
+}
+
 func (suite *TestSuiteStandard) TestTransactionFindTimeUTC() {
 	tz, _ := time.LoadLocation("Europe/Berlin")
 


### PR DESCRIPTION
With this change, all string fields will have whitespace trimmed from the start and end of the string.

This is especially useful when resource names must be unique as it is the case for categories, envelopes and accounts.

Resolves #887.