### PR TITLE
fix: Month JSON unmarshaling now enforcing year and month only

### DIFF
--- a/internal/types/month.go
+++ b/internal/types/month.go
@@ -29,8 +29,17 @@ func (m Month) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 // The month is expected to be a string in a format accepted by ParseDate.
+// From the parsed string, everything is then ignored except the year and month
 func (m *Month) UnmarshalJSON(data []byte) error {
-	return (*time.Time)(m).UnmarshalJSON(data)
+	var date time.Time
+	err := date.UnmarshalJSON(data)
+	if err != nil {
+		return err
+	}
+
+	month := NewMonth(date.Year(), date.Month())
+	*m = month
+	return nil
 }
 
 // MonthOf returns the Month in which a time occurs in that time's location.

--- a/internal/types/month_test.go
+++ b/internal/types/month_test.go
@@ -1,0 +1,21 @@
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/envelope-zero/backend/v3/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMonthUnmarshalJSON(t *testing.T) {
+	var target struct {
+		Month types.Month
+	}
+	jsonString := []byte(`{ "month": "2024-05-12T17:59:23+02:00" }`)
+
+	err := json.Unmarshal(jsonString, &target)
+
+	assert.Nil(t, err)
+	assert.Equal(t, types.NewMonth(2024, 5), target.Month)
+}


### PR DESCRIPTION
This fixes an issue where a variable of type types.Month could have
other parts than just year and month set, which was possible when
parsing it from user input.

This never surfaced since this has not been unmarshaled from user input yet
where the input could contain this.

However, this will be the case starting with goals.
Therefore, this bug is fixed now.
