### PR TITLE
feat: add goals

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -5355,6 +5355,362 @@ const docTemplate = `{
                 }
             }
         },
+        "/v3/goals": {
+            "get": {
+                "description": "Returns a list of goals",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Goals"
+                ],
+                "summary": "Get goals",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by note",
+                        "name": "note",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search for this text in name and note",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Is the goal archived?",
+                        "name": "archived",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by envelope ID",
+                        "name": "envelope",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Month of the goal. Ignores exact time, matches on the month of the RFC3339 timestamp provided.",
+                        "name": "month",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Goals for this and later months. Ignores exact time, matches on the month of the RFC3339 timestamp provided.",
+                        "name": "fromMonth",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Goals for this and earlier months. Ignores exact time, matches on the month of the RFC3339 timestamp provided.",
+                        "name": "untilMonth",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by amount",
+                        "name": "amount",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Amount less than or equal to this",
+                        "name": "amountLessOrEqual",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Amount more than or equal to this",
+                        "name": "amountMoreOrEqual",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The offset of the first goal returned. Defaults to 0.",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of goal to return. Defaults to 50.",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalListResponseV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalListResponseV3"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalListResponseV3"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates new goals",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Goals"
+                ],
+                "summary": "Create goals",
+                "parameters": [
+                    {
+                        "description": "Goals",
+                        "name": "goals",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/controllers.GoalV3Editable"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalCreateResponseV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalCreateResponseV3"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalCreateResponseV3"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalCreateResponseV3"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "tags": [
+                    "Goals"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/v3/goals/{id}": {
+            "get": {
+                "description": "Returns a specific goal",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Goals"
+                ],
+                "summary": "Get goal",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID formatted as string",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalResponseV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalResponseV3"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalResponseV3"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalResponseV3"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes a goal",
+                "tags": [
+                    "Goals"
+                ],
+                "summary": "Delete goal",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID formatted as string",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "tags": [
+                    "Goals"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID formatted as string",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Updates an existing goal. Only values to be updated need to be specified.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Goals"
+                ],
+                "summary": "Update goal",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID formatted as string",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Goal",
+                        "name": "goal",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalV3Editable"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalResponseV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalResponseV3"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalResponseV3"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalResponseV3"
+                        }
+                    }
+                }
+            }
+        },
         "/v3/import": {
             "get": {
                 "description": "Returns general information about the v3 API",
@@ -7792,6 +8148,178 @@ const docTemplate = `{
                 }
             }
         },
+        "controllers.GoalCreateResponseV3": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "List of created resources",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.GoalResponseV3"
+                    }
+                },
+                "error": {
+                    "description": "The error, if any occurred",
+                    "type": "string",
+                    "example": "the specified resource ID is not a valid UUID"
+                }
+            }
+        },
+        "controllers.GoalListResponseV3": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "List of resources",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.GoalV3"
+                    }
+                },
+                "error": {
+                    "description": "The error, if any occurred",
+                    "type": "string",
+                    "example": "the specified resource ID is not a valid UUID"
+                },
+                "pagination": {
+                    "description": "Pagination information",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/controllers.Pagination"
+                        }
+                    ]
+                }
+            }
+        },
+        "controllers.GoalResponseV3": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "The resource",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/controllers.GoalV3"
+                        }
+                    ]
+                },
+                "error": {
+                    "description": "The error, if any occurred",
+                    "type": "string",
+                    "example": "the specified resource ID is not a valid UUID"
+                }
+            }
+        },
+        "controllers.GoalV3": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "How much money should be saved for this goal?",
+                    "type": "number",
+                    "default": 0,
+                    "example": 127
+                },
+                "archived": {
+                    "description": "If this goal is still in use or not",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "createdAt": {
+                    "description": "Time the resource was created",
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
+                "envelopeId": {
+                    "description": "The ID of the envelope this goal is for",
+                    "type": "string",
+                    "example": "f81566d9-af4d-4f13-9830-c62c4b5e4c7e"
+                },
+                "id": {
+                    "description": "UUID for the resource",
+                    "type": "string",
+                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
+                },
+                "links": {
+                    "$ref": "#/definitions/controllers.GoalV3Links"
+                },
+                "month": {
+                    "description": "The month the balance of the envelope should be the set amount",
+                    "type": "string",
+                    "example": "2024-07-01T00:00:00.000000Z"
+                },
+                "name": {
+                    "description": "Name of the goal",
+                    "type": "string",
+                    "example": "New TV"
+                },
+                "note": {
+                    "description": "Note about the goal",
+                    "type": "string",
+                    "example": "We want to replace the old CRT TV soon-ish"
+                },
+                "updatedAt": {
+                    "description": "Last time the resource was updated",
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
+                }
+            }
+        },
+        "controllers.GoalV3Editable": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "How much money should be saved for this goal?",
+                    "type": "number",
+                    "default": 0,
+                    "example": 127
+                },
+                "archived": {
+                    "description": "If this goal is still in use or not",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "envelopeId": {
+                    "description": "The ID of the envelope this goal is for",
+                    "type": "string",
+                    "example": "f81566d9-af4d-4f13-9830-c62c4b5e4c7e"
+                },
+                "month": {
+                    "description": "The month the balance of the envelope should be the set amount",
+                    "type": "string",
+                    "example": "2024-07-01T00:00:00.000000Z"
+                },
+                "name": {
+                    "description": "Name of the goal",
+                    "type": "string",
+                    "example": "New TV"
+                },
+                "note": {
+                    "description": "Note about the goal",
+                    "type": "string",
+                    "example": "We want to replace the old CRT TV soon-ish"
+                }
+            }
+        },
+        "controllers.GoalV3Links": {
+            "type": "object",
+            "properties": {
+                "envelope": {
+                    "description": "The Envelope this goal references",
+                    "type": "string",
+                    "example": "https://example.com/api/v3/envelopes/c1a96ae4-80e3-4827-8ed0-c7656f224fee"
+                },
+                "self": {
+                    "description": "The Goal itself",
+                    "type": "string",
+                    "example": "https://example.com/api/v3/goals/438cc6c0-9baf-49fd-a75a-d76bd5cab19c"
+                }
+            }
+        },
         "controllers.ImportPreviewList": {
             "type": "object",
             "properties": {
@@ -9628,6 +10156,11 @@ const docTemplate = `{
                     "description": "URL of Envelope collection endpoint",
                     "type": "string",
                     "example": "https://example.com/api/v3/envelopes"
+                },
+                "goals": {
+                    "description": "URL of goal collection endpoint",
+                    "type": "string",
+                    "example": "https://example.com/api/v3/goals"
                 },
                 "import": {
                     "description": "URL of import list endpoint",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -5344,6 +5344,362 @@
                 }
             }
         },
+        "/v3/goals": {
+            "get": {
+                "description": "Returns a list of goals",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Goals"
+                ],
+                "summary": "Get goals",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by note",
+                        "name": "note",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search for this text in name and note",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Is the goal archived?",
+                        "name": "archived",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by envelope ID",
+                        "name": "envelope",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Month of the goal. Ignores exact time, matches on the month of the RFC3339 timestamp provided.",
+                        "name": "month",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Goals for this and later months. Ignores exact time, matches on the month of the RFC3339 timestamp provided.",
+                        "name": "fromMonth",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Goals for this and earlier months. Ignores exact time, matches on the month of the RFC3339 timestamp provided.",
+                        "name": "untilMonth",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by amount",
+                        "name": "amount",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Amount less than or equal to this",
+                        "name": "amountLessOrEqual",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Amount more than or equal to this",
+                        "name": "amountMoreOrEqual",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The offset of the first goal returned. Defaults to 0.",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of goal to return. Defaults to 50.",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalListResponseV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalListResponseV3"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalListResponseV3"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates new goals",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Goals"
+                ],
+                "summary": "Create goals",
+                "parameters": [
+                    {
+                        "description": "Goals",
+                        "name": "goals",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/controllers.GoalV3Editable"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalCreateResponseV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalCreateResponseV3"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalCreateResponseV3"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalCreateResponseV3"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "tags": [
+                    "Goals"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/v3/goals/{id}": {
+            "get": {
+                "description": "Returns a specific goal",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Goals"
+                ],
+                "summary": "Get goal",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID formatted as string",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalResponseV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalResponseV3"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalResponseV3"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalResponseV3"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes a goal",
+                "tags": [
+                    "Goals"
+                ],
+                "summary": "Delete goal",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID formatted as string",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "tags": [
+                    "Goals"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID formatted as string",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httperrors.HTTPError"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Updates an existing goal. Only values to be updated need to be specified.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Goals"
+                ],
+                "summary": "Update goal",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID formatted as string",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Goal",
+                        "name": "goal",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalV3Editable"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalResponseV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalResponseV3"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalResponseV3"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GoalResponseV3"
+                        }
+                    }
+                }
+            }
+        },
         "/v3/import": {
             "get": {
                 "description": "Returns general information about the v3 API",
@@ -7781,6 +8137,178 @@
                 }
             }
         },
+        "controllers.GoalCreateResponseV3": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "List of created resources",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.GoalResponseV3"
+                    }
+                },
+                "error": {
+                    "description": "The error, if any occurred",
+                    "type": "string",
+                    "example": "the specified resource ID is not a valid UUID"
+                }
+            }
+        },
+        "controllers.GoalListResponseV3": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "List of resources",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.GoalV3"
+                    }
+                },
+                "error": {
+                    "description": "The error, if any occurred",
+                    "type": "string",
+                    "example": "the specified resource ID is not a valid UUID"
+                },
+                "pagination": {
+                    "description": "Pagination information",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/controllers.Pagination"
+                        }
+                    ]
+                }
+            }
+        },
+        "controllers.GoalResponseV3": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "The resource",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/controllers.GoalV3"
+                        }
+                    ]
+                },
+                "error": {
+                    "description": "The error, if any occurred",
+                    "type": "string",
+                    "example": "the specified resource ID is not a valid UUID"
+                }
+            }
+        },
+        "controllers.GoalV3": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "How much money should be saved for this goal?",
+                    "type": "number",
+                    "default": 0,
+                    "example": 127
+                },
+                "archived": {
+                    "description": "If this goal is still in use or not",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "createdAt": {
+                    "description": "Time the resource was created",
+                    "type": "string",
+                    "example": "2022-04-02T19:28:44.491514Z"
+                },
+                "deletedAt": {
+                    "description": "Time the resource was marked as deleted",
+                    "type": "string",
+                    "example": "2022-04-22T21:01:05.058161Z"
+                },
+                "envelopeId": {
+                    "description": "The ID of the envelope this goal is for",
+                    "type": "string",
+                    "example": "f81566d9-af4d-4f13-9830-c62c4b5e4c7e"
+                },
+                "id": {
+                    "description": "UUID for the resource",
+                    "type": "string",
+                    "example": "65392deb-5e92-4268-b114-297faad6cdce"
+                },
+                "links": {
+                    "$ref": "#/definitions/controllers.GoalV3Links"
+                },
+                "month": {
+                    "description": "The month the balance of the envelope should be the set amount",
+                    "type": "string",
+                    "example": "2024-07-01T00:00:00.000000Z"
+                },
+                "name": {
+                    "description": "Name of the goal",
+                    "type": "string",
+                    "example": "New TV"
+                },
+                "note": {
+                    "description": "Note about the goal",
+                    "type": "string",
+                    "example": "We want to replace the old CRT TV soon-ish"
+                },
+                "updatedAt": {
+                    "description": "Last time the resource was updated",
+                    "type": "string",
+                    "example": "2022-04-17T20:14:01.048145Z"
+                }
+            }
+        },
+        "controllers.GoalV3Editable": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "How much money should be saved for this goal?",
+                    "type": "number",
+                    "default": 0,
+                    "example": 127
+                },
+                "archived": {
+                    "description": "If this goal is still in use or not",
+                    "type": "boolean",
+                    "default": false,
+                    "example": true
+                },
+                "envelopeId": {
+                    "description": "The ID of the envelope this goal is for",
+                    "type": "string",
+                    "example": "f81566d9-af4d-4f13-9830-c62c4b5e4c7e"
+                },
+                "month": {
+                    "description": "The month the balance of the envelope should be the set amount",
+                    "type": "string",
+                    "example": "2024-07-01T00:00:00.000000Z"
+                },
+                "name": {
+                    "description": "Name of the goal",
+                    "type": "string",
+                    "example": "New TV"
+                },
+                "note": {
+                    "description": "Note about the goal",
+                    "type": "string",
+                    "example": "We want to replace the old CRT TV soon-ish"
+                }
+            }
+        },
+        "controllers.GoalV3Links": {
+            "type": "object",
+            "properties": {
+                "envelope": {
+                    "description": "The Envelope this goal references",
+                    "type": "string",
+                    "example": "https://example.com/api/v3/envelopes/c1a96ae4-80e3-4827-8ed0-c7656f224fee"
+                },
+                "self": {
+                    "description": "The Goal itself",
+                    "type": "string",
+                    "example": "https://example.com/api/v3/goals/438cc6c0-9baf-49fd-a75a-d76bd5cab19c"
+                }
+            }
+        },
         "controllers.ImportPreviewList": {
             "type": "object",
             "properties": {
@@ -9617,6 +10145,11 @@
                     "description": "URL of Envelope collection endpoint",
                     "type": "string",
                     "example": "https://example.com/api/v3/envelopes"
+                },
+                "goals": {
+                    "description": "URL of goal collection endpoint",
+                    "type": "string",
+                    "example": "https://example.com/api/v3/goals"
                 },
                 "import": {
                     "description": "URL of import list endpoint",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1043,6 +1043,132 @@ definitions:
         example: "2022-04-17T20:14:01.048145Z"
         type: string
     type: object
+  controllers.GoalCreateResponseV3:
+    properties:
+      data:
+        description: List of created resources
+        items:
+          $ref: '#/definitions/controllers.GoalResponseV3'
+        type: array
+      error:
+        description: The error, if any occurred
+        example: the specified resource ID is not a valid UUID
+        type: string
+    type: object
+  controllers.GoalListResponseV3:
+    properties:
+      data:
+        description: List of resources
+        items:
+          $ref: '#/definitions/controllers.GoalV3'
+        type: array
+      error:
+        description: The error, if any occurred
+        example: the specified resource ID is not a valid UUID
+        type: string
+      pagination:
+        allOf:
+        - $ref: '#/definitions/controllers.Pagination'
+        description: Pagination information
+    type: object
+  controllers.GoalResponseV3:
+    properties:
+      data:
+        allOf:
+        - $ref: '#/definitions/controllers.GoalV3'
+        description: The resource
+      error:
+        description: The error, if any occurred
+        example: the specified resource ID is not a valid UUID
+        type: string
+    type: object
+  controllers.GoalV3:
+    properties:
+      amount:
+        default: 0
+        description: How much money should be saved for this goal?
+        example: 127
+        type: number
+      archived:
+        default: false
+        description: If this goal is still in use or not
+        example: true
+        type: boolean
+      createdAt:
+        description: Time the resource was created
+        example: "2022-04-02T19:28:44.491514Z"
+        type: string
+      deletedAt:
+        description: Time the resource was marked as deleted
+        example: "2022-04-22T21:01:05.058161Z"
+        type: string
+      envelopeId:
+        description: The ID of the envelope this goal is for
+        example: f81566d9-af4d-4f13-9830-c62c4b5e4c7e
+        type: string
+      id:
+        description: UUID for the resource
+        example: 65392deb-5e92-4268-b114-297faad6cdce
+        type: string
+      links:
+        $ref: '#/definitions/controllers.GoalV3Links'
+      month:
+        description: The month the balance of the envelope should be the set amount
+        example: "2024-07-01T00:00:00.000000Z"
+        type: string
+      name:
+        description: Name of the goal
+        example: New TV
+        type: string
+      note:
+        description: Note about the goal
+        example: We want to replace the old CRT TV soon-ish
+        type: string
+      updatedAt:
+        description: Last time the resource was updated
+        example: "2022-04-17T20:14:01.048145Z"
+        type: string
+    type: object
+  controllers.GoalV3Editable:
+    properties:
+      amount:
+        default: 0
+        description: How much money should be saved for this goal?
+        example: 127
+        type: number
+      archived:
+        default: false
+        description: If this goal is still in use or not
+        example: true
+        type: boolean
+      envelopeId:
+        description: The ID of the envelope this goal is for
+        example: f81566d9-af4d-4f13-9830-c62c4b5e4c7e
+        type: string
+      month:
+        description: The month the balance of the envelope should be the set amount
+        example: "2024-07-01T00:00:00.000000Z"
+        type: string
+      name:
+        description: Name of the goal
+        example: New TV
+        type: string
+      note:
+        description: Note about the goal
+        example: We want to replace the old CRT TV soon-ish
+        type: string
+    type: object
+  controllers.GoalV3Links:
+    properties:
+      envelope:
+        description: The Envelope this goal references
+        example: https://example.com/api/v3/envelopes/c1a96ae4-80e3-4827-8ed0-c7656f224fee
+        type: string
+      self:
+        description: The Goal itself
+        example: https://example.com/api/v3/goals/438cc6c0-9baf-49fd-a75a-d76bd5cab19c
+        type: string
+    type: object
   controllers.ImportPreviewList:
     properties:
       data:
@@ -2449,6 +2575,10 @@ definitions:
       envelopes:
         description: URL of Envelope collection endpoint
         example: https://example.com/api/v3/envelopes
+        type: string
+      goals:
+        description: URL of goal collection endpoint
+        example: https://example.com/api/v3/goals
         type: string
       import:
         description: URL of import list endpoint
@@ -6136,6 +6266,248 @@ paths:
       summary: Update MonthConfig
       tags:
       - Envelopes
+  /v3/goals:
+    get:
+      description: Returns a list of goals
+      parameters:
+      - description: Filter by name
+        in: query
+        name: name
+        type: string
+      - description: Filter by note
+        in: query
+        name: note
+        type: string
+      - description: Search for this text in name and note
+        in: query
+        name: search
+        type: string
+      - description: Is the goal archived?
+        in: query
+        name: archived
+        type: boolean
+      - description: Filter by envelope ID
+        in: query
+        name: envelope
+        type: string
+      - description: Month of the goal. Ignores exact time, matches on the month of
+          the RFC3339 timestamp provided.
+        in: query
+        name: month
+        type: string
+      - description: Goals for this and later months. Ignores exact time, matches
+          on the month of the RFC3339 timestamp provided.
+        in: query
+        name: fromMonth
+        type: string
+      - description: Goals for this and earlier months. Ignores exact time, matches
+          on the month of the RFC3339 timestamp provided.
+        in: query
+        name: untilMonth
+        type: string
+      - description: Filter by amount
+        in: query
+        name: amount
+        type: string
+      - description: Amount less than or equal to this
+        in: query
+        name: amountLessOrEqual
+        type: string
+      - description: Amount more than or equal to this
+        in: query
+        name: amountMoreOrEqual
+        type: string
+      - description: The offset of the first goal returned. Defaults to 0.
+        in: query
+        name: offset
+        type: integer
+      - description: Maximum number of goal to return. Defaults to 50.
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.GoalListResponseV3'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controllers.GoalListResponseV3'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controllers.GoalListResponseV3'
+      summary: Get goals
+      tags:
+      - Goals
+    options:
+      description: Returns an empty response with the HTTP Header "allow" set to the
+        allowed HTTP verbs
+      responses:
+        "204":
+          description: No Content
+      summary: Allowed HTTP verbs
+      tags:
+      - Goals
+    post:
+      description: Creates new goals
+      parameters:
+      - description: Goals
+        in: body
+        name: goals
+        required: true
+        schema:
+          items:
+            $ref: '#/definitions/controllers.GoalV3Editable'
+          type: array
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/controllers.GoalCreateResponseV3'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controllers.GoalCreateResponseV3'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/controllers.GoalCreateResponseV3'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controllers.GoalCreateResponseV3'
+      summary: Create goals
+      tags:
+      - Goals
+  /v3/goals/{id}:
+    delete:
+      description: Deletes a goal
+      parameters:
+      - description: ID formatted as string
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Delete goal
+      tags:
+      - Goals
+    get:
+      description: Returns a specific goal
+      parameters:
+      - description: ID formatted as string
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.GoalResponseV3'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controllers.GoalResponseV3'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/controllers.GoalResponseV3'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controllers.GoalResponseV3'
+      summary: Get goal
+      tags:
+      - Goals
+    options:
+      description: Returns an empty response with the HTTP Header "allow" set to the
+        allowed HTTP verbs
+      parameters:
+      - description: ID formatted as string
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httperrors.HTTPError'
+      summary: Allowed HTTP verbs
+      tags:
+      - Goals
+    patch:
+      consumes:
+      - application/json
+      description: Updates an existing goal. Only values to be updated need to be
+        specified.
+      parameters:
+      - description: ID formatted as string
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Goal
+        in: body
+        name: goal
+        required: true
+        schema:
+          $ref: '#/definitions/controllers.GoalV3Editable'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.GoalResponseV3'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controllers.GoalResponseV3'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/controllers.GoalResponseV3'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controllers.GoalResponseV3'
+      summary: Update goal
+      tags:
+      - Goals
   /v3/import:
     get:
       description: Returns general information about the v3 API

--- a/internal/types/month.go
+++ b/internal/types/month.go
@@ -48,9 +48,19 @@ func MonthOf(t time.Time) Month {
 	return Month(time.Date(year, month, 1, 0, 0, 0, 0, time.Time(t).Location()))
 }
 
-// ParseMonth parses a string in RFC3339 full-date format and returns the Month value it represents.
-func ParseMonth(s string) (Month, error) {
+// ParseDateToMonth parses a string in RFC3339 full-date format and returns the Month value it represents.
+func ParseDateToMonth(s string) (Month, error) {
 	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return Month{}, err
+	}
+
+	return MonthOf(t), nil
+}
+
+// ParseMonth parses a "YYYY-MM" string and returns the Month value it represents
+func ParseMonth(s string) (Month, error) {
+	t, err := time.Parse("2006-01", s)
 	if err != nil {
 		return Month{}, err
 	}

--- a/pkg/controllers/goals_v3.go
+++ b/pkg/controllers/goals_v3.go
@@ -1,0 +1,397 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/envelope-zero/backend/v3/internal/types"
+	"github.com/envelope-zero/backend/v3/pkg/httperrors"
+	"github.com/envelope-zero/backend/v3/pkg/httputil"
+	"github.com/envelope-zero/backend/v3/pkg/models"
+	"github.com/gin-gonic/gin"
+	"golang.org/x/exp/slices"
+)
+
+func (co Controller) RegisterGoalRoutesV3(r *gin.RouterGroup) {
+	{
+		r.OPTIONS("", co.OptionsGoalsV3)
+		r.GET("", co.GetGoalsV3)
+		r.POST("", co.CreateGoalsV3)
+	}
+	{
+		r.OPTIONS("/:id", co.OptionsGoalDetailV3)
+
+		// FIMXE: These three
+		r.GET("/:id", co.GetGoalV3)
+		r.PATCH("/:id", co.UpdateGoalV3)
+		r.DELETE("/:id", co.DeleteGoalV3)
+	}
+}
+
+// @Summary		Allowed HTTP verbs
+// @Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
+// @Tags			Goals
+// @Success		204
+// @Router			/v3/goals [options]
+func (co Controller) OptionsGoalsV3(c *gin.Context) {
+	httputil.OptionsGetPost(c)
+}
+
+// @Summary		Allowed HTTP verbs
+// @Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
+// @Tags			Goals
+// @Success		204
+// @Failure		400	{object}	httperrors.HTTPError
+// @Failure		404	{object}	httperrors.HTTPError
+// @Failure		500	{object}	httperrors.HTTPError
+// @Param			id	path		string	true	"ID formatted as string"
+// @Router			/v3/goals/{id} [options]
+func (co Controller) OptionsGoalDetailV3(c *gin.Context) {
+	id, err := httputil.UUIDFromString(c.Param("id"))
+	if !err.Nil() {
+		c.JSON(err.Status, httperrors.HTTPError{
+			Error: err.Error(),
+		})
+		return
+	}
+
+	_, err = getResourceByID[models.Goal](c, co, id)
+	if !err.Nil() {
+		c.JSON(err.Status, httperrors.HTTPError{
+			Error: err.Error(),
+		})
+		return
+	}
+
+	httputil.OptionsGetPatchDelete(c)
+}
+
+// @Summary		Create goals
+// @Description	Creates new goals
+// @Tags			Goals
+// @Produce		json
+// @Success		201		{object}	GoalCreateResponseV3
+// @Failure		400		{object}	GoalCreateResponseV3
+// @Failure		404		{object}	GoalCreateResponseV3
+// @Failure		500		{object}	GoalCreateResponseV3
+// @Param			goals	body		[]GoalV3Editable	true	"Goals"
+// @Router			/v3/goals [post]
+func (co Controller) CreateGoalsV3(c *gin.Context) {
+	var goals []GoalV3Editable
+
+	// Bind data and return error if not possible
+	err := httputil.BindData(c, &goals)
+	if !err.Nil() {
+		e := err.Error()
+		c.JSON(err.Status, GoalCreateResponseV3{
+			Error: &e,
+		})
+		return
+	}
+
+	// The final http status. Will be modified when errors occur
+	status := http.StatusCreated
+	r := GoalCreateResponseV3{}
+
+	for _, create := range goals {
+		goal := create.model()
+
+		// Verify that the envelope exists. If not, append the error and move to the next goal
+		_, err := getResourceByID[models.Envelope](c, co, create.EnvelopeID)
+		if !err.Nil() {
+			status = r.appendError(err, status)
+			continue
+		}
+
+		dbErr := co.DB.Create(&goal).Error
+		if dbErr != nil {
+			err := httperrors.GenericDBError[models.Goal](goal, c, dbErr)
+			status = r.appendError(err, status)
+			continue
+		}
+
+		// Transform for the API and append
+		apiResource := newGoalV3(c, goal)
+		r.Data = append(r.Data, GoalResponseV3{Data: &apiResource})
+	}
+
+	c.JSON(status, r)
+}
+
+// @Summary		Get goals
+// @Description	Returns a list of goals
+// @Tags			Goals
+// @Produce		json
+// @Success		200	{object}	GoalListResponseV3
+// @Failure		400	{object}	GoalListResponseV3
+// @Failure		500	{object}	GoalListResponseV3
+// @Router			/v3/goals [get]
+// @Param			name				query	string	false	"Filter by name"
+// @Param			note				query	string	false	"Filter by note"
+// @Param			search				query	string	false	"Search for this text in name and note"
+// @Param			archived			query	bool	false	"Is the goal archived?"
+// @Param			envelope			query	string	false	"Filter by envelope ID"
+// @Param			month				query	string	false	"Month of the goal. Ignores exact time, matches on the month of the RFC3339 timestamp provided."
+// @Param			fromMonth			query	string	false	"Goals for this and later months. Ignores exact time, matches on the month of the RFC3339 timestamp provided."
+// @Param			untilMonth			query	string	false	"Goals for this and earlier months. Ignores exact time, matches on the month of the RFC3339 timestamp provided."
+// @Param			amount				query	string	false	"Filter by amount"
+// @Param			amountLessOrEqual	query	string	false	"Amount less than or equal to this"
+// @Param			amountMoreOrEqual	query	string	false	"Amount more than or equal to this"
+// @Param			offset				query	uint	false	"The offset of the first goal returned. Defaults to 0."
+// @Param			limit				query	int		false	"Maximum number of goal to return. Defaults to 50."
+func (co Controller) GetGoalsV3(c *gin.Context) {
+	var filter GoalQueryFilterV3
+
+	if err := c.Bind(&filter); err != nil {
+		s := err.Error()
+		c.JSON(http.StatusBadRequest, GoalListResponseV3{
+			Error: &s,
+		})
+		return
+	}
+
+	queryFields, setFields := httputil.GetURLFields(c.Request.URL, filter)
+
+	where, err := filter.model()
+	if !err.Nil() {
+		s := err.Error()
+		c.JSON(err.Status, GoalListResponseV3{
+			Error: &s,
+		})
+		return
+	}
+
+	q := co.DB.
+		Order("date(month) ASC, name ASC").
+		Where(&where, queryFields...)
+
+	q = stringFilters(co.DB, q, setFields, filter.Name, filter.Note, filter.Search)
+
+	// Set the offset. Does not need checking since the default is 0
+	q = q.Offset(int(filter.Offset))
+
+	// Default to 50 Accounts and set the limit
+	limit := 50
+	if slices.Contains(setFields, "Limit") {
+		limit = filter.Limit
+	}
+	q = q.Limit(limit)
+
+	if !where.Month.IsZero() {
+		q = q.Where("goals.month >= date(?)", where.Month).Where("goals.month < date(?)", where.Month.AddDate(0, 1))
+	}
+
+	if filter.FromMonth != "" {
+		fromMonth, e := types.ParseMonth(filter.FromMonth)
+		if e != nil {
+			s := e.Error()
+			c.JSON(http.StatusBadRequest, GoalListResponseV3{
+				Error: &s,
+			})
+		}
+		q = q.Where("goals.month >= date(?)", fromMonth)
+	}
+
+	if filter.UntilMonth != "" {
+		untilMonth, e := types.ParseMonth(filter.UntilMonth)
+		if e != nil {
+			s := e.Error()
+			c.JSON(http.StatusBadRequest, GoalListResponseV3{
+				Error: &s,
+			})
+		}
+		q = q.Where("goals.month < date(?)", untilMonth.AddDate(0, 1))
+	}
+
+	if !filter.AmountLessOrEqual.IsZero() {
+		q = q.Where("goals.amount <= ?", filter.AmountLessOrEqual)
+	}
+
+	if !filter.AmountMoreOrEqual.IsZero() {
+		q = q.Where("goals.amount >= ?", filter.AmountMoreOrEqual)
+	}
+
+	var goals []models.Goal
+	err = query(c, q.Find(&goals))
+
+	if !err.Nil() {
+		s := err.Error()
+		c.JSON(err.Status, GoalListResponseV3{
+			Error: &s,
+		})
+		return
+	}
+
+	var count int64
+	err = query(c, q.Limit(-1).Offset(-1).Count(&count))
+	if !err.Nil() {
+		e := err.Error()
+		c.JSON(err.Status, GoalListResponseV3{
+			Error: &e,
+		})
+		return
+	}
+
+	// Transform resources to their API representation
+	data := make([]GoalV3, 0, len(goals))
+	for _, goal := range goals {
+		data = append(data, newGoalV3(c, goal))
+	}
+
+	c.JSON(http.StatusOK, GoalListResponseV3{
+		Data: data,
+		Pagination: &Pagination{
+			Count:  len(data),
+			Total:  count,
+			Offset: filter.Offset,
+			Limit:  limit,
+		},
+	})
+}
+
+// @Summary		Get goal
+// @Description	Returns a specific goal
+// @Tags			Goals
+// @Produce		json
+// @Success		200	{object}	GoalResponseV3
+// @Failure		400	{object}	GoalResponseV3
+// @Failure		404	{object}	GoalResponseV3
+// @Failure		500	{object}	GoalResponseV3
+// @Param			id	path		string	true	"ID formatted as string"
+// @Router			/v3/goals/{id} [get]
+func (co Controller) GetGoalV3(c *gin.Context) {
+	id, err := httputil.UUIDFromString(c.Param("id"))
+	if !err.Nil() {
+		e := err.Error()
+		c.JSON(err.Status, GoalResponseV3{
+			Error: &e,
+		})
+		return
+	}
+
+	var goal models.Goal
+	err = query(c, co.DB.First(&goal, id))
+	if !err.Nil() {
+		e := err.Error()
+		c.JSON(err.Status, GoalResponseV3{
+			Error: &e,
+		})
+		return
+	}
+
+	apiResource := newGoalV3(c, goal)
+	c.JSON(http.StatusOK, GoalResponseV3{Data: &apiResource})
+}
+
+// @Summary		Update goal
+// @Description	Updates an existing goal. Only values to be updated need to be specified.
+// @Tags			Goals
+// @Accept			json
+// @Produce		json
+// @Success		200		{object}	GoalResponseV3
+// @Failure		400		{object}	GoalResponseV3
+// @Failure		404		{object}	GoalResponseV3
+// @Failure		500		{object}	GoalResponseV3
+// @Param			id		path		string			true	"ID formatted as string"
+// @Param			goal	body		GoalV3Editable	true	"Goal"
+// @Router			/v3/goals/{id} [patch]
+func (co Controller) UpdateGoalV3(c *gin.Context) {
+	id, err := httputil.UUIDFromString(c.Param("id"))
+	if !err.Nil() {
+		e := err.Error()
+		c.JSON(err.Status, GoalResponseV3{
+			Error: &e,
+		})
+		return
+	}
+
+	goal, err := getResourceByID[models.Goal](c, co, id)
+	if !err.Nil() {
+		e := err.Error()
+		c.JSON(err.Status, GoalResponseV3{
+			Error: &e,
+		})
+		return
+	}
+
+	// Get the fields that are set to be updated
+	updateFields, err := httputil.GetBodyFields(c, GoalV3Editable{})
+	if !err.Nil() {
+		e := err.Error()
+		c.JSON(err.Status, GoalResponseV3{
+			Error: &e,
+		})
+		return
+	}
+
+	// Bind the data for the patch
+	var data GoalV3Editable
+	err = httputil.BindData(c, &data)
+	if !err.Nil() {
+		e := err.Error()
+		c.JSON(err.Status, GoalResponseV3{
+			Error: &e,
+		})
+		return
+	}
+
+	// Check that the referenced envelope exists
+	if slices.Contains(updateFields, "EnvelopeID") {
+		_, err = getResourceByID[models.Envelope](c, co, data.EnvelopeID)
+		if !err.Nil() {
+			e := err.Error()
+			c.JSON(err.Status, GoalResponseV3{
+				Error: &e,
+			})
+			return
+		}
+	}
+
+	err = query(c, co.DB.Model(&goal).Select("", updateFields...).Updates(data.model()))
+	if !err.Nil() {
+		e := err.Error()
+		c.JSON(err.Status, GoalResponseV3{
+			Error: &e,
+		})
+		return
+	}
+
+	apiResource := newGoalV3(c, goal)
+	c.JSON(http.StatusOK, GoalResponseV3{Data: &apiResource})
+}
+
+// @Summary		Delete goal
+// @Description	Deletes a goal
+// @Tags			Goals
+// @Success		204
+// @Failure		400	{object}	httperrors.HTTPError
+// @Failure		404	{object}	httperrors.HTTPError
+// @Failure		500	{object}	httperrors.HTTPError
+// @Param			id	path		string	true	"ID formatted as string"
+// @Router			/v3/goals/{id} [delete]
+func (co Controller) DeleteGoalV3(c *gin.Context) {
+	id, err := httputil.UUIDFromString(c.Param("id"))
+	if !err.Nil() {
+		c.JSON(err.Status, httperrors.HTTPError{
+			Error: err.Error(),
+		})
+		return
+	}
+
+	goal, err := getResourceByID[models.Goal](c, co, id)
+	if !err.Nil() {
+		c.JSON(err.Status, httperrors.HTTPError{
+			Error: err.Error(),
+		})
+		return
+	}
+
+	err = query(c, co.DB.Delete(&goal))
+	if !err.Nil() {
+		c.JSON(err.Status, httperrors.HTTPError{
+			Error: err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+}

--- a/pkg/controllers/goals_v3_test.go
+++ b/pkg/controllers/goals_v3_test.go
@@ -1,0 +1,524 @@
+package controllers_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/envelope-zero/backend/v3/internal/types"
+	"github.com/envelope-zero/backend/v3/pkg/controllers"
+	"github.com/envelope-zero/backend/v3/pkg/httperrors"
+	"github.com/envelope-zero/backend/v3/pkg/models"
+	"github.com/envelope-zero/backend/v3/test"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *TestSuiteStandard) createTestGoalV3(t *testing.T, c controllers.GoalV3Editable, expectedStatus ...int) controllers.GoalResponseV3 {
+	// Default to 201 Created as expected status
+	if len(expectedStatus) == 0 {
+		expectedStatus = append(expectedStatus, http.StatusCreated)
+	}
+
+	if c.EnvelopeID == uuid.Nil {
+		c.EnvelopeID = suite.createTestEnvelopeV3(t, controllers.EnvelopeCreateV3{}).Data.ID
+	}
+
+	requestBody := []controllers.GoalV3Editable{c}
+
+	recorder := test.Request(suite.controller, t, http.MethodPost, "http://example.com/v3/goals", requestBody)
+	assertHTTPStatus(t, &recorder, expectedStatus...)
+
+	var response controllers.GoalCreateResponseV3
+	suite.decodeResponse(&recorder, &response)
+
+	return response.Data[0]
+}
+
+// TestGoalsV3Options verifies that the HTTP OPTIONS response for /v3/goals/{id} is correct.
+func (suite *TestSuiteStandard) TestGoalsV3Options() {
+	tests := []struct {
+		name     string        // Name for the test
+		status   int           // Expected HTTP status
+		id       string        // String to use as ID. Ignored when pathFunc is non-nil
+		pathFunc func() string // Function returning the path
+	}{
+		{
+			"Does not exist",
+			http.StatusNotFound,
+			uuid.New().String(),
+			nil,
+		},
+		{
+			"Invalid UUID",
+			http.StatusBadRequest,
+			"NotParseableAsUUID",
+			nil,
+		},
+		{
+			"Success",
+			http.StatusNoContent,
+			"",
+			func() string {
+				return suite.createTestGoalV3(suite.T(), controllers.GoalV3Editable{Amount: decimal.NewFromFloat(31)}).Data.Links.Self
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			var p string
+			if tt.pathFunc != nil {
+				p = tt.pathFunc()
+			} else {
+				p = fmt.Sprintf("%s/%s", "http://example.com/v3/goals", tt.id)
+			}
+
+			r := test.Request(suite.controller, t, http.MethodOptions, p, "")
+			assertHTTPStatus(t, &r, tt.status)
+
+			if tt.status == http.StatusNoContent {
+				assert.Equal(t, "OPTIONS, GET, PATCH, DELETE", r.Header().Get("allow"))
+			}
+		})
+	}
+}
+
+// TestGoalsV3DatabaseError verifies that the endpoints return the appropriate
+// error when the database is disconncted.
+func (suite *TestSuiteStandard) TestGoalsV3DatabaseError() {
+	tests := []struct {
+		name   string // Name of the test
+		path   string // Path to send request to
+		method string // HTTP method to use
+		body   string // The request body
+	}{
+		{"GET Collection", "", http.MethodGet, ""},
+		// Skipping POST Collection here since we need to check the indivdual transactions for that one
+		{"OPTIONS Single", fmt.Sprintf("/%s", uuid.New().String()), http.MethodOptions, ""},
+		{"GET Single", fmt.Sprintf("/%s", uuid.New().String()), http.MethodGet, ""},
+		{"PATCH Single", fmt.Sprintf("/%s", uuid.New().String()), http.MethodPatch, ""},
+		{"DELETE Single", fmt.Sprintf("/%s", uuid.New().String()), http.MethodDelete, ""},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			suite.CloseDB()
+
+			recorder := test.Request(suite.controller, t, tt.method, fmt.Sprintf("http://example.com/v3/goals%s", tt.path), tt.body)
+			assertHTTPStatus(t, &recorder, http.StatusInternalServerError)
+			assert.Equal(t, httperrors.ErrDatabaseClosed.Error(), test.DecodeError(t, recorder.Body.Bytes()))
+		})
+	}
+}
+
+// TestGoalsV3Get verifies that goals can be read from the API and
+// that the default sorting is correct.
+func (suite *TestSuiteStandard) TestGoalsV3Get() {
+	g1 := suite.createTestGoalV3(suite.T(), controllers.GoalV3Editable{
+		Amount: decimal.NewFromFloat(100),
+		Month:  types.NewMonth(2024, 1),
+		Name:   "Irrelevant",
+	})
+
+	_ = suite.createTestGoalV3(suite.T(), controllers.GoalV3Editable{
+		Amount: decimal.NewFromFloat(300),
+		Month:  types.NewMonth(2024, 2),
+		Name:   "First",
+	})
+
+	g3 := suite.createTestGoalV3(suite.T(), controllers.GoalV3Editable{
+		Amount: decimal.NewFromFloat(50),
+		Month:  types.NewMonth(2024, 2),
+		Name:   "Before g2",
+	})
+
+	recorder := test.Request(suite.controller, suite.T(), http.MethodGet, "http://example.com/v3/goals", "")
+
+	var response controllers.GoalListResponseV3
+	suite.decodeResponse(&recorder, &response)
+
+	assert.Equal(suite.T(), 200, recorder.Code)
+	assert.Len(suite.T(), response.Data, 3)
+
+	// Verify that the goal with the earlier month is the first in the list
+	assert.Equal(suite.T(), g1.Data.ID, response.Data[0].ID)
+
+	// Verify that the goal with the alphabetically earlier name is earlier
+	assert.Equal(suite.T(), g3.Data.ID, response.Data[1].ID)
+}
+
+// TestGoalsV3GetFilter verifies that filtering goals works as expected.
+func (suite *TestSuiteStandard) TestGoalsV3GetFilter() {
+	b := suite.createTestBudgetV3(suite.T(), models.BudgetCreate{})
+
+	c := suite.createTestCategoryV3(suite.T(), controllers.CategoryCreateV3{BudgetID: b.Data.ID})
+
+	e1 := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{CategoryID: c.Data.ID})
+	e2 := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{CategoryID: c.Data.ID})
+
+	_ = suite.createTestGoalV3(suite.T(), controllers.GoalV3Editable{
+		Name:       "Test Goal",
+		Note:       "So that we can go to X",
+		EnvelopeID: e1.Data.ID,
+		Amount:     decimal.NewFromFloat(100),
+		Month:      types.NewMonth(2024, 1),
+		Archived:   false,
+	})
+
+	_ = suite.createTestGoalV3(suite.T(), controllers.GoalV3Editable{
+		Name:       "Goal for something else",
+		EnvelopeID: e1.Data.ID,
+		Amount:     decimal.NewFromFloat(200),
+		Month:      types.NewMonth(2024, 2),
+		Archived:   true,
+	})
+
+	_ = suite.createTestGoalV3(suite.T(), controllers.GoalV3Editable{
+		Name:       "testing the filters",
+		Note:       "so that I know they work",
+		EnvelopeID: e2.Data.ID,
+		Amount:     decimal.NewFromFloat(1000),
+		Month:      types.NewMonth(2024, 1),
+		Archived:   false,
+	})
+
+	tests := []struct {
+		name  string
+		query string
+		len   int
+	}{
+		{"Same month", fmt.Sprintf("month=%s", types.NewMonth(2024, 1)), 2},
+		{"After month", fmt.Sprintf("fromMonth=%s", types.NewMonth(2024, 2)), 1},
+		{"Before month", fmt.Sprintf("untilMonth=%s", types.NewMonth(2024, 2)), 3},
+		{"After all months", fmt.Sprintf("fromMonth=%s", types.NewMonth(2024, 6)), 0},
+		{"Before all months", fmt.Sprintf("untilMonth=%s", types.NewMonth(2023, 6)), 0},
+		{"Impossible between two months", fmt.Sprintf("fromMonth=%s&untilMonth=%s", types.NewMonth(2024, 11), types.NewMonth(2024, 10)), 0},
+		{"Exact Amount", fmt.Sprintf("amount=%s", decimal.NewFromFloat(200).String()), 1},
+		{"Note", "note=can", 1},
+		{"No note", "note=", 1},
+		{"Fuzzy note", "note=so", 2},
+		{"Amount less or equal to 99", "amountLessOrEqual=99", 0},
+		{"Amount less or equal to 200", "amountLessOrEqual=200", 2},
+		{"Amount more or equal to 3", "amountMoreOrEqual=3", 3},
+		{"Amount more or equal to 500.813", "amountMoreOrEqual=500.813", 1},
+		{"Amount more or equal to 99999", "amountMoreOrEqual=99999", 0},
+		{"Amount more or equal to 100 and less than 10", "amountMoreOrEqual=100&amountLessOrEqual=10", 0},
+		{"Amount more or equal to 50 and less than 500", "amountMoreOrEqual=50&amountLessOrEqual=500", 2},
+		{"Limit positive", "limit=2", 2},
+		{"Limit zero", "limit=0", 0},
+		{"Limit unset", "limit=-1", 3},
+		{"Limit negative", "limit=-123", 3},
+		{"Offset zero", "offset=0", 3},
+		{"Offset positive", "offset=2", 1},
+		{"Offset higher than number", "offset=5", 0},
+		{"Limit and Offset", "limit=1&offset=1", 1},
+		{"Limit and Fuzzy Note", "limit=1&note=so", 1},
+		{"Offset and Fuzzy Note", "offset=2&note=they", 0},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			var re controllers.GoalListResponseV3
+			r := test.Request(suite.controller, t, http.MethodGet, fmt.Sprintf("/v3/goals?%s", tt.query), "")
+			assertHTTPStatus(t, &r, http.StatusOK)
+			suite.decodeResponse(&r, &re)
+
+			assert.Equal(t, tt.len, len(re.Data), "Request ID: %s", r.Result().Header.Get("x-request-id"))
+		})
+	}
+}
+
+// TestGoalsV3GetInvalidQuery verifies that invalid filtering queries
+// return a HTTP Bad Request.
+func (suite *TestSuiteStandard) TestGoalsV3GetInvalidQuery() {
+	tests := []string{
+		"envelope=ThisIsDefinitelyACat!",
+		"month=A long time ago",
+		"archived=0.00",
+		"amount=Seventeen Cents",
+		"offset=-1",             // offset is a uint
+		"limit=name",            // limit is an int
+		"untilMonth=2023-11-01", // Format is "YYYY-MM"
+		"fromMonth=Yesterday",
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt, func(t *testing.T) {
+			recorder := test.Request(suite.controller, t, http.MethodGet, fmt.Sprintf("http://example.com/v3/goals?%s", tt), "")
+			assertHTTPStatus(t, &recorder, http.StatusBadRequest)
+		})
+	}
+}
+
+// TestGoalsV3CreateInvalidBody verifies that creation of goals
+// with an unparseable request body returns a HTTP Bad Request.
+func (suite *TestSuiteStandard) TestGoalsV3CreateInvalidBody() {
+	r := test.Request(suite.controller, suite.T(), http.MethodPost, "http://example.com/v3/goals", `{ Invalid request": Body }`)
+	assertHTTPStatus(suite.T(), &r, http.StatusBadRequest)
+
+	var response controllers.GoalCreateResponseV3
+	suite.decodeResponse(&r, &response)
+
+	assert.Equal(suite.T(), httperrors.ErrInvalidBody.Error(), *response.Error)
+	assert.Nil(suite.T(), response.Data)
+}
+
+// TestGoalsV3Create verifies that transaction goal works.
+func (suite *TestSuiteStandard) TestGoalsV3Create() {
+	envelope := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{Name: "An envelope for this test"})
+
+	tests := []struct {
+		name           string
+		goals          []controllers.GoalV3Editable
+		expectedStatus int
+		expectedError  *error   // Error expected in the response
+		expectedErrors []string // Errors expected for the individual transactions
+	}{
+		{
+			"One success, one fail",
+			[]controllers.GoalV3Editable{
+				{
+					EnvelopeID: uuid.New(),
+					Amount:     decimal.NewFromFloat(17.23),
+					Note:       "v3 non-existing envelope ID",
+					Name:       "One success, one fail",
+				},
+				{
+					EnvelopeID: envelope.Data.ID,
+					Amount:     decimal.NewFromFloat(57.01),
+				},
+			},
+			http.StatusNotFound,
+			nil,
+			[]string{
+				"there is no Envelope with this ID",
+				"",
+			},
+		},
+		{
+			"Both succeed",
+			[]controllers.GoalV3Editable{
+				{
+					Name:       "Both succeed - 1",
+					EnvelopeID: envelope.Data.ID,
+					Amount:     decimal.NewFromFloat(17.23),
+				},
+				{
+					Name:       "Unique Name for the Envelope",
+					EnvelopeID: envelope.Data.ID,
+					Amount:     decimal.NewFromFloat(57.01),
+				},
+			},
+			http.StatusCreated,
+			nil,
+			[]string{
+				"",
+				"",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			r := test.Request(suite.controller, t, http.MethodPost, "http://example.com/v3/goals", tt.goals)
+			assertHTTPStatus(t, &r, tt.expectedStatus)
+
+			var response controllers.GoalCreateResponseV3
+			suite.decodeResponse(&r, &response)
+
+			for i, goal := range response.Data {
+				if tt.expectedErrors[i] == "" {
+					assert.Equal(t, fmt.Sprintf("http://example.com/v3/goals/%s", goal.Data.ID), goal.Data.Links.Self)
+				} else {
+					// This needs to be in the else to prevent nil pointer errors since we're dereferencing pointers
+					assert.Equal(t, tt.expectedErrors[i], *goal.Error)
+				}
+			}
+		})
+	}
+}
+
+// TestGoalsV3GetSingle verifies that a goal can be read from the API via its link
+// and that the link is for API v3.
+func (suite *TestSuiteStandard) TestGoalsV3GetSingle() {
+	tests := []struct {
+		name     string        // Name for the test
+		status   int           // Expected HTTP status
+		id       string        // String to use as ID. Ignored when pathFunc is non-nil
+		pathFunc func() string // Function returning the path
+	}{
+		{
+			"Standard transaction",
+			http.StatusOK,
+			"",
+			func() string {
+				return suite.createTestGoalV3(suite.T(), controllers.GoalV3Editable{Amount: decimal.NewFromFloat(42)}).Data.Links.Self
+			},
+		},
+		{
+			"Invalid UUID",
+			http.StatusBadRequest,
+			"NotParseableAsUUID",
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			var p string
+			if tt.pathFunc != nil {
+				p = tt.pathFunc()
+			} else {
+				p = fmt.Sprintf("%s/%s", "http://example.com/v3/goals", tt.id)
+			}
+
+			r := test.Request(suite.controller, suite.T(), http.MethodGet, p, "")
+			assertHTTPStatus(suite.T(), &r, tt.status)
+		})
+	}
+}
+
+// TestGoalsV3Delete verifies the correct success and error responses
+// for DELETE requests.
+func (suite *TestSuiteStandard) TestGoalsV3Delete() {
+	tests := []struct {
+		name   string // Name for the test
+		status int    // Expected HTTP status
+		id     string // String to use as ID.
+	}{
+		{
+			"Standard deletion",
+			http.StatusNoContent,
+			suite.createTestGoalV3(suite.T(), controllers.GoalV3Editable{Amount: decimal.NewFromFloat(2100)}).Data.ID.String(),
+		},
+		{
+			"Does not exist",
+			http.StatusNotFound,
+			"4bcb6d09-ced1-41e8-a3fe-bf4f16c5e501",
+		},
+		{
+			"Null transaction",
+			http.StatusBadRequest,
+			"00000000-0000-0000-0000-000000000000",
+		},
+		{
+			"Invalid UUID",
+			http.StatusBadRequest,
+			"Definitely an Invalid ID",
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			p := fmt.Sprintf("%s/%s", "http://example.com/v3/goals", tt.id)
+
+			r := test.Request(suite.controller, t, http.MethodDelete, p, "")
+			assertHTTPStatus(t, &r, tt.status)
+		})
+	}
+}
+
+// TestGoalsV3UpdateFail verifies that goal updates fail where they should.
+func (suite *TestSuiteStandard) TestGoalsV3UpdateFail() {
+	goal := suite.createTestGoalV3(suite.T(), controllers.GoalV3Editable{Amount: decimal.NewFromFloat(170), Note: "Test note for goal"})
+
+	tests := []struct {
+		name   string // Name for the test
+		id     string // ID of the Goal to update
+		status int    // Expected HTTP status
+		body   any    // Body to send to the PATCH endpoint
+	}{
+		{
+			"Invalid body",
+			goal.Data.ID.String(),
+			http.StatusBadRequest,
+			`{ "amount": 2" }`,
+		},
+		{
+			"Invalid type",
+			goal.Data.ID.String(),
+			http.StatusBadRequest,
+			map[string]any{
+				"amount": false,
+			},
+		},
+		{
+			"Invalid goal ID",
+			"Not a valid UUID",
+			http.StatusBadRequest,
+			``,
+		},
+		{
+			"Invalid envelope ID",
+			goal.Data.ID.String(),
+			http.StatusBadRequest,
+			controllers.GoalV3Editable{}, // Sets the EnvelopeID to uuid.Nil
+		},
+		{
+			"Negative amount",
+			goal.Data.ID.String(),
+			http.StatusBadRequest,
+			`{ "amount": -58.23 }`,
+		},
+		{
+			"Non-existing envelope",
+			goal.Data.ID.String(),
+			http.StatusNotFound,
+			`{ "envelopeId": "e6fa8eb5-5f2c-4292-8ef9-02f0c2af1ce4" }`,
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			p := fmt.Sprintf("%s/%s", "http://example.com/v3/goals", tt.id)
+
+			r := test.Request(suite.controller, t, http.MethodPatch, p, tt.body)
+			assertHTTPStatus(t, &r, tt.status)
+		})
+	}
+}
+
+// TestUpdateNonExistingGoalV3 verifies that patching a non-existent transaction returns a 404.
+func (suite *TestSuiteStandard) TestUpdateNonExistingGoalV3() {
+	recorder := test.Request(suite.controller, suite.T(), http.MethodPatch, "http://example.com/v3/goals/c08c0a04-2a12-4cb9-8b4a-87cf270cdd8d", `{ "note": "2" }`)
+	assertHTTPStatus(suite.T(), &recorder, http.StatusNotFound)
+}
+
+// TestGoalsV3Update verifies that transaction updates are successful.
+func (suite *TestSuiteStandard) TestGoalsV3Update() {
+	envelope := suite.createTestEnvelopeV3(suite.T(), controllers.EnvelopeCreateV3{})
+
+	goal := suite.createTestGoalV3(suite.T(), controllers.GoalV3Editable{
+		Amount:     decimal.NewFromFloat(23.14),
+		Note:       "Test note for transaction",
+		Archived:   true,
+		EnvelopeID: envelope.Data.ID,
+	})
+
+	tests := []struct {
+		name string // Name for the test
+		body any    // Body to send to the PATCH endpoint
+	}{
+		{
+			"Empty note",
+			map[string]any{
+				"note": "",
+			},
+		},
+		{
+			"Change amount",
+			map[string]any{
+				"amount": decimal.NewFromFloat(130),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			r := test.Request(suite.controller, t, http.MethodPatch, goal.Data.Links.Self, tt.body)
+			assertHTTPStatus(t, &r, http.StatusOK)
+		})
+	}
+}

--- a/pkg/controllers/goals_v3_types.go
+++ b/pkg/controllers/goals_v3_types.go
@@ -1,0 +1,141 @@
+package controllers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/envelope-zero/backend/v3/internal/types"
+	"github.com/envelope-zero/backend/v3/pkg/database"
+	"github.com/envelope-zero/backend/v3/pkg/httperrors"
+	"github.com/envelope-zero/backend/v3/pkg/httputil"
+	"github.com/envelope-zero/backend/v3/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+type GoalV3Editable struct {
+	Name       string          `json:"name" example:"New TV" default:""`                                     // Name of the goal
+	Note       string          `json:"note" example:"We want to replace the old CRT TV soon-ish" default:""` // Note about the goal
+	EnvelopeID uuid.UUID       `json:"envelopeId" example:"f81566d9-af4d-4f13-9830-c62c4b5e4c7e"`            // The ID of the envelope this goal is for
+	Amount     decimal.Decimal `json:"amount" example:"127" default:"0"`                                     // How much money should be saved for this goal?
+	Month      types.Month     `json:"month" example:"2024-07-01T00:00:00.000000Z"`                          // The month the balance of the envelope should be the set amount
+	Archived   bool            `json:"archived" example:"true" default:"false"`                              // If this goal is still in use or not
+}
+
+// model returns the database resource for the API representation of the editable fields
+func (editable GoalV3Editable) model() models.Goal {
+	return models.Goal{
+		Name:       editable.Name,
+		Note:       editable.Note,
+		EnvelopeID: editable.EnvelopeID,
+		Amount:     editable.Amount,
+		Month:      editable.Month,
+		Archived:   editable.Archived,
+	}
+}
+
+type GoalV3Links struct {
+	Self     string `json:"self" example:"https://example.com/api/v3/goals/438cc6c0-9baf-49fd-a75a-d76bd5cab19c"`         // The Goal itself
+	Envelope string `json:"envelope" example:"https://example.com/api/v3/envelopes/c1a96ae4-80e3-4827-8ed0-c7656f224fee"` // The Envelope this goal references
+}
+
+type GoalV3 struct {
+	models.DefaultModel
+	GoalV3Editable
+	Links GoalV3Links `json:"links"`
+}
+
+// newGoalV3 returns the API v3 representation of the resource
+func newGoalV3(c *gin.Context, model models.Goal) GoalV3 {
+	url := c.GetString(string(database.ContextURL))
+
+	return GoalV3{
+		DefaultModel: model.DefaultModel,
+		GoalV3Editable: GoalV3Editable{
+			Name:       model.Name,
+			Note:       model.Note,
+			EnvelopeID: model.EnvelopeID,
+			Amount:     model.Amount,
+			Month:      model.Month,
+			Archived:   model.Archived,
+		},
+		Links: GoalV3Links{
+			Self:     fmt.Sprintf("%s/v3/goals/%s", url, model.ID),
+			Envelope: fmt.Sprintf("%s/v3/envelopes/%s", url, model.EnvelopeID),
+		},
+	}
+}
+
+type GoalListResponseV3 struct {
+	Data       []GoalV3    `json:"data"`                                                          // List of resources
+	Error      *string     `json:"error" example:"the specified resource ID is not a valid UUID"` // The error, if any occurred
+	Pagination *Pagination `json:"pagination"`                                                    // Pagination information
+}
+
+type GoalCreateResponseV3 struct {
+	Error *string          `json:"error" example:"the specified resource ID is not a valid UUID"` // The error, if any occurred
+	Data  []GoalResponseV3 `json:"data"`                                                          // List of created resources
+}
+
+func (t *GoalCreateResponseV3) appendError(err httperrors.Error, status int) int {
+	s := err.Error()
+	t.Data = append(t.Data, GoalResponseV3{Error: &s})
+
+	// The final status code is the highest HTTP status code number
+	if err.Status > status {
+		status = err.Status
+	}
+
+	return status
+}
+
+type GoalResponseV3 struct {
+	Error *string `json:"error" example:"the specified resource ID is not a valid UUID"` // The error, if any occurred
+	Data  *GoalV3 `json:"data"`                                                          // The resource
+}
+
+type GoalQueryFilterV3 struct {
+	Name              string          `form:"name" filterField:"false"`              // By name
+	Note              string          `form:"note" filterField:"false"`              // By the note
+	Search            string          `form:"search" filterField:"false"`            // By string in name or note
+	Archived          bool            `form:"archived"`                              // Is the goal archived?
+	EnvelopeID        string          `form:"envelope"`                              // ID of the envelope
+	Month             string          `form:"month"`                                 // Exact month
+	FromMonth         string          `form:"fromMonth" filterField:"false"`         // From this month
+	UntilMonth        string          `form:"untilMonth" filterField:"false"`        // Until this month
+	Amount            decimal.Decimal `form:"amount"`                                // Exact amount
+	AmountLessOrEqual decimal.Decimal `form:"amountLessOrEqual" filterField:"false"` // Amount less than or equal to this
+	AmountMoreOrEqual decimal.Decimal `form:"amountMoreOrEqual" filterField:"false"` // Amount more than or equal to this
+	Offset            uint            `form:"offset" filterField:"false"`            // The offset of the first goal returned. Defaults to 0.
+	Limit             int             `form:"limit" filterField:"false"`             // Maximum number of goals to return. Defaults to 50.
+}
+
+func (f GoalQueryFilterV3) model() (models.Goal, httperrors.Error) {
+	envelopeID, err := httputil.UUIDFromString(f.EnvelopeID)
+	if !err.Nil() {
+		return models.Goal{}, err
+	}
+
+	var month types.Month
+	if f.Month != "" {
+		m, e := types.ParseMonth(f.Month)
+		if e != nil {
+			return models.Goal{}, httperrors.Error{
+				Err:    e,
+				Status: http.StatusBadRequest,
+			}
+		}
+
+		month = m
+	}
+
+	// This does not set the string fields since they are
+	// handled in the controller function
+	return GoalV3Editable{
+		EnvelopeID: envelopeID,
+		Amount:     f.Amount,
+		Month:      month,
+		Archived:   f.Archived,
+	}.model(), httperrors.Error{}
+}

--- a/pkg/controllers/test_options_test.go
+++ b/pkg/controllers/test_options_test.go
@@ -31,6 +31,7 @@ func (suite *TestSuiteStandard) TestOptionsHeaderResources() {
 		{"http://example.com/v3/budgets", "OPTIONS, GET, POST"},
 		{"http://example.com/v3/categories", "OPTIONS, GET, POST"},
 		{"http://example.com/v3/envelopes", "OPTIONS, GET, POST"},
+		{"http://example.com/v3/goals", "OPTIONS, GET, POST"},
 		{"http://example.com/v3/import", "OPTIONS, GET"},
 		{"http://example.com/v3/import/ynab-import-preview", "OPTIONS, POST"},
 		{"http://example.com/v3/import/ynab4", "OPTIONS, POST"},

--- a/pkg/controllers/transaction_v3_test.go
+++ b/pkg/controllers/transaction_v3_test.go
@@ -270,7 +270,7 @@ func (suite *TestSuiteStandard) TestTransactionsV3GetFilter() {
 	}
 }
 
-// TestTransactionsV3GetSingleInvalidQuery verifies that invalid filtering queries
+// TestTransactionsV3GetInvalidQuery verifies that invalid filtering queries
 // return a HTTP Bad Request.
 func (suite *TestSuiteStandard) TestTransactionsV3GetInvalidQuery() {
 	tests := []string{
@@ -548,7 +548,7 @@ func (suite *TestSuiteStandard) TestTransactionsV3Update() {
 		body any    // Body to send to the PATCH endpoint
 	}{
 		{
-			"Source Equals Destination",
+			"Empty note",
 			map[string]any{
 				"note": "",
 			},

--- a/pkg/httperrors/errors.go
+++ b/pkg/httperrors/errors.go
@@ -159,9 +159,8 @@ func Parse(c *gin.Context, err error) Error {
 		}
 	}
 
-	// Database error
-	if reflect.TypeOf(err) == reflect.TypeOf(&sqlite.Error{}) {
-		return DBError(c, err)
+	if errors.Is(err, models.ErrGoalAmountNotPositive) {
+		return Error{Status: http.StatusBadRequest, Err: err}
 	}
 
 	// Allocation is 0
@@ -170,6 +169,11 @@ func Parse(c *gin.Context, err error) Error {
 			Status: http.StatusBadRequest,
 			Err:    err,
 		}
+	}
+
+	// Database error
+	if reflect.TypeOf(err) == reflect.TypeOf(&sqlite.Error{}) {
+		return DBError(c, err)
 	}
 
 	if reflect.TypeOf(err) == reflect.TypeOf(&time.ParseError{}) {

--- a/pkg/httperrors/errors_test.go
+++ b/pkg/httperrors/errors_test.go
@@ -208,6 +208,7 @@ func TestParse(t *testing.T) {
 		{http.StatusNotFound, httperrors.ErrNoResource.Error(), gorm.ErrRecordNotFound},
 		{http.StatusInternalServerError, "an error occurred on the server during your request", &sqlite.Error{}},
 		{http.StatusBadRequest, models.ErrAllocationZero.Error(), models.ErrAllocationZero},
+		{http.StatusBadRequest, models.ErrGoalAmountNotPositive.Error(), models.ErrGoalAmountNotPositive},
 		{http.StatusInternalServerError, httperrors.ErrDatabaseClosed.Error(), errors.New("sql: database is closed")},
 		{http.StatusBadRequest, httperrors.ErrRequestBodyEmpty.Error(), io.EOF},
 		{http.StatusBadRequest, "Test Message", &time.ParseError{Message: "Test Message"}},

--- a/pkg/importer/parser/ynab4/parse.go
+++ b/pkg/importer/parser/ynab4/parse.go
@@ -472,7 +472,7 @@ func parseTransactions(resources *importer.ParsedResources, transactions []Trans
 
 func parseMonthlyBudgets(resources *importer.ParsedResources, monthlyBudgets []MonthlyBudget, envelopeIDNames IDToEnvelopes) error {
 	for _, monthBudget := range monthlyBudgets {
-		month, err := types.ParseMonth(monthBudget.Month)
+		month, err := types.ParseDateToMonth(monthBudget.Month)
 		if err != nil {
 			return fmt.Errorf("could not parse date, the Budget.yfull file seems to be corrupt: %w", err)
 		}

--- a/pkg/models/database.go
+++ b/pkg/models/database.go
@@ -30,7 +30,7 @@ func Migrate(db *gorm.DB) (err error) {
 		}
 	}
 
-	err = db.AutoMigrate(Budget{}, Account{}, Category{}, Envelope{}, Transaction{}, Allocation{}, MonthConfig{}, MatchRule{})
+	err = db.AutoMigrate(Budget{}, Account{}, Category{}, Envelope{}, Transaction{}, Allocation{}, MonthConfig{}, MatchRule{}, Goal{})
 	if err != nil {
 		return fmt.Errorf("error during DB migration: %w", err)
 	}

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -2,4 +2,7 @@ package models
 
 import "errors"
 
-var ErrAllocationZero = errors.New("allocation amounts must be non-zero. Instead of setting to zero, delete the Allocation")
+var (
+	ErrAllocationZero        = errors.New("allocation amounts must be non-zero. Instead of setting to zero, delete the Allocation")
+	ErrGoalAmountNotPositive = errors.New("goal amounts must be larger than zero")
+)

--- a/pkg/models/goal.go
+++ b/pkg/models/goal.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"strings"
+
+	"github.com/envelope-zero/backend/v3/internal/types"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+type Goal struct {
+	DefaultModel
+	Name       string `gorm:"uniqueIndex:goal_name_envelope"`
+	Note       string
+	Envelope   Envelope
+	EnvelopeID uuid.UUID       `gorm:"uniqueIndex:goal_name_envelope"`
+	Amount     decimal.Decimal `json:"amount" gorm:"type:DECIMAL(20,8)" example:"750" minimum:"0.00000001" maximum:"999999999999.99999999" multipleOf:"0.00000001"` // The target for the goal
+	Month      types.Month
+	Archived   bool
+}
+
+func (g Goal) Self() string {
+	return "Goal"
+}
+
+func (g *Goal) BeforeSave(_ *gorm.DB) error {
+	g.Name = strings.TrimSpace(g.Name)
+	g.Note = strings.TrimSpace(g.Note)
+
+	return nil
+}
+
+func (g *Goal) AfterSave(_ *gorm.DB) error {
+	if !decimal.Decimal.IsPositive(g.Amount) {
+		return ErrGoalAmountNotPositive
+	}
+
+	return nil
+}

--- a/pkg/models/goal_test.go
+++ b/pkg/models/goal_test.go
@@ -1,0 +1,52 @@
+package models_test
+
+import (
+	"strings"
+
+	"github.com/envelope-zero/backend/v3/pkg/models"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+func (suite *TestSuiteStandard) TestGoalSelf() {
+	assert.Equal(suite.T(), "Goal", models.Goal{}.Self())
+}
+
+func (suite *TestSuiteStandard) TestGoalAfterSave() {
+	tests := []struct {
+		amount decimal.Decimal
+		err    error
+	}{
+		{decimal.NewFromFloat(-10), models.ErrGoalAmountNotPositive},
+		{decimal.NewFromFloat(750), nil},
+	}
+
+	for _, tt := range tests {
+		g := models.Goal{
+			Amount: tt.amount,
+		}
+
+		err := g.AfterSave(&gorm.DB{})
+		assert.Equal(suite.T(), tt.err, err)
+	}
+}
+
+func (suite *TestSuiteStandard) TestGoalTrimWhitespace() {
+	budget := suite.createTestBudget(models.BudgetCreate{})
+	category := suite.createTestCategory(models.CategoryCreate{BudgetID: budget.ID})
+	envelope := suite.createTestEnvelope(models.EnvelopeCreate{CategoryID: category.ID})
+
+	note := " Whitespace    "
+	name := "  There is whitespace here  \t"
+
+	goal := suite.createTestGoal(models.Goal{
+		EnvelopeID: envelope.ID,
+		Amount:     decimal.NewFromFloat(100),
+		Name:       name,
+		Note:       note,
+	})
+
+	assert.Equal(suite.T(), strings.TrimSpace(name), goal.Name)
+	assert.Equal(suite.T(), strings.TrimSpace(note), goal.Note)
+}

--- a/pkg/models/test_suite_test.go
+++ b/pkg/models/test_suite_test.go
@@ -149,3 +149,12 @@ func (suite *TestSuiteStandard) createTestMonthConfig(c models.MonthConfig) mode
 
 	return c
 }
+
+func (suite *TestSuiteStandard) createTestGoal(goal models.Goal) models.Goal {
+	err := suite.db.Save(&goal).Error
+	if err != nil {
+		suite.Assert().FailNow("Goal could not be saved", "Error: %s, Goal: %#v", err, goal)
+	}
+
+	return goal
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -163,6 +163,7 @@ func AttachRoutes(co controllers.Controller, group *gin.RouterGroup) {
 	co.RegisterBudgetRoutesV3(v3.Group("/budgets"))
 	co.RegisterCategoryRoutesV3(v3.Group("/categories"))
 	co.RegisterEnvelopeRoutesV3(v3.Group("/envelopes"))
+	co.RegisterGoalRoutesV3(v3.Group("/goals"))
 	co.RegisterImportRoutesV3(v3.Group("/import"))
 	co.RegisterMatchRuleRoutesV3(v3.Group("/match-rules"))
 	co.RegisterMonthConfigRoutesV3(v3.Group("/envelopes"))
@@ -350,6 +351,7 @@ type V3Links struct {
 	Budgets      string `json:"budgets" example:"https://example.com/api/v3/budgets"`           // URL of Budget collection endpoint
 	Categories   string `json:"categories" example:"https://example.com/api/v3/categories"`     // URL of Category collection endpoint
 	Envelopes    string `json:"envelopes" example:"https://example.com/api/v3/envelopes"`       // URL of Envelope collection endpoint
+	Goals        string `json:"goals" example:"https://example.com/api/v3/goals"`               // URL of goal collection endpoint
 	Import       string `json:"import" example:"https://example.com/api/v3/import"`             // URL of import list endpoint
 	MatchRules   string `json:"matchRules" example:"https://example.com/api/v3/match-rules"`    // URL of Match Rule collection endpoint
 	Months       string `json:"months" example:"https://example.com/api/v3/months"`             // URL of Month endpoint
@@ -372,6 +374,7 @@ func GetV3(c *gin.Context) {
 			Budgets:      url + "/v3/budgets",
 			Categories:   url + "/v3/categories",
 			Envelopes:    url + "/v3/envelopes",
+			Goals:        url + "/v3/goals",
 			Import:       url + "/v3/import",
 			MatchRules:   url + "/v3/match-rules",
 			Months:       url + "/v3/months",

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -193,6 +193,7 @@ func TestGetV3(t *testing.T) {
 			Budgets:      "/v3/budgets",
 			Categories:   "/v3/categories",
 			Envelopes:    "/v3/envelopes",
+			Goals:        "/v3/goals",
 			Import:       "/v3/import",
 			MatchRules:   "/v3/match-rules",
 			Months:       "/v3/months",


### PR DESCRIPTION
This adds initial support goals, enabling users to create goals.
Note that there is no computation for these yet, so they're not
useful as of now.

Resolves #902.
