### PR TITLE
fix: add envelope links to month endpoint

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -8024,6 +8024,9 @@ const docTemplate = `{
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
+                "links": {
+                    "$ref": "#/definitions/controllers.EnvelopeV3Links"
+                },
                 "name": {
                     "description": "Name of the envelope",
                     "type": "string",
@@ -8112,24 +8115,11 @@ const docTemplate = `{
                 },
                 "links": {
                     "description": "Links to related resources",
-                    "type": "object",
-                    "properties": {
-                        "month": {
-                            "description": "The MonthConfig for the envelope",
-                            "type": "string",
-                            "example": "https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/YYYY-MM"
-                        },
-                        "self": {
-                            "description": "The envelope itself",
-                            "type": "string",
-                            "example": "https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166"
-                        },
-                        "transactions": {
-                            "description": "The envelope's transactions",
-                            "type": "string",
-                            "example": "https://example.com/api/v3/transactions?envelope=45b6b5b9-f746-4ae9-b77b-7688b91f8166"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/controllers.EnvelopeV3Links"
                         }
-                    }
+                    ]
                 },
                 "name": {
                     "description": "Name of the envelope",
@@ -8145,6 +8135,26 @@ const docTemplate = `{
                     "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
+                }
+            }
+        },
+        "controllers.EnvelopeV3Links": {
+            "type": "object",
+            "properties": {
+                "month": {
+                    "description": "The MonthConfig for the envelope",
+                    "type": "string",
+                    "example": "https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/YYYY-MM"
+                },
+                "self": {
+                    "description": "The envelope itself",
+                    "type": "string",
+                    "example": "https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166"
+                },
+                "transactions": {
+                    "description": "The envelope's transactions",
+                    "type": "string",
+                    "example": "https://example.com/api/v3/transactions?envelope=45b6b5b9-f746-4ae9-b77b-7688b91f8166"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -8013,6 +8013,9 @@
                     "type": "string",
                     "example": "65392deb-5e92-4268-b114-297faad6cdce"
                 },
+                "links": {
+                    "$ref": "#/definitions/controllers.EnvelopeV3Links"
+                },
                 "name": {
                     "description": "Name of the envelope",
                     "type": "string",
@@ -8101,24 +8104,11 @@
                 },
                 "links": {
                     "description": "Links to related resources",
-                    "type": "object",
-                    "properties": {
-                        "month": {
-                            "description": "The MonthConfig for the envelope",
-                            "type": "string",
-                            "example": "https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/YYYY-MM"
-                        },
-                        "self": {
-                            "description": "The envelope itself",
-                            "type": "string",
-                            "example": "https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166"
-                        },
-                        "transactions": {
-                            "description": "The envelope's transactions",
-                            "type": "string",
-                            "example": "https://example.com/api/v3/transactions?envelope=45b6b5b9-f746-4ae9-b77b-7688b91f8166"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/controllers.EnvelopeV3Links"
                         }
-                    }
+                    ]
                 },
                 "name": {
                     "description": "Name of the envelope",
@@ -8134,6 +8124,26 @@
                     "description": "Last time the resource was updated",
                     "type": "string",
                     "example": "2022-04-17T20:14:01.048145Z"
+                }
+            }
+        },
+        "controllers.EnvelopeV3Links": {
+            "type": "object",
+            "properties": {
+                "month": {
+                    "description": "The MonthConfig for the envelope",
+                    "type": "string",
+                    "example": "https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/YYYY-MM"
+                },
+                "self": {
+                    "description": "The envelope itself",
+                    "type": "string",
+                    "example": "https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166"
+                },
+                "transactions": {
+                    "description": "The envelope's transactions",
+                    "type": "string",
+                    "example": "https://example.com/api/v3/transactions?envelope=45b6b5b9-f746-4ae9-b77b-7688b91f8166"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -953,6 +953,8 @@ definitions:
         description: UUID for the resource
         example: 65392deb-5e92-4268-b114-297faad6cdce
         type: string
+      links:
+        $ref: '#/definitions/controllers.EnvelopeV3Links'
       name:
         description: Name of the envelope
         example: Groceries
@@ -1015,21 +1017,9 @@ definitions:
         example: 65392deb-5e92-4268-b114-297faad6cdce
         type: string
       links:
+        allOf:
+        - $ref: '#/definitions/controllers.EnvelopeV3Links'
         description: Links to related resources
-        properties:
-          month:
-            description: The MonthConfig for the envelope
-            example: https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/YYYY-MM
-            type: string
-          self:
-            description: The envelope itself
-            example: https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166
-            type: string
-          transactions:
-            description: The envelope's transactions
-            example: https://example.com/api/v3/transactions?envelope=45b6b5b9-f746-4ae9-b77b-7688b91f8166
-            type: string
-        type: object
       name:
         description: Name of the envelope
         example: Groceries
@@ -1041,6 +1031,21 @@ definitions:
       updatedAt:
         description: Last time the resource was updated
         example: "2022-04-17T20:14:01.048145Z"
+        type: string
+    type: object
+  controllers.EnvelopeV3Links:
+    properties:
+      month:
+        description: The MonthConfig for the envelope
+        example: https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/YYYY-MM
+        type: string
+      self:
+        description: The envelope itself
+        example: https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166
+        type: string
+      transactions:
+        description: The envelope's transactions
+        example: https://example.com/api/v3/transactions?envelope=45b6b5b9-f746-4ae9-b77b-7688b91f8166
         type: string
     type: object
   controllers.GoalCreateResponseV3:

--- a/pkg/controllers/envelope_v3.go
+++ b/pkg/controllers/envelope_v3.go
@@ -31,24 +31,25 @@ func (e EnvelopeCreateV3) ToCreate() models.EnvelopeCreate {
 	}
 }
 
-type EnvelopeV3 struct {
-	models.Envelope
-	Hidden bool `json:"hidden,omitempty"` // Remove the hidden field
-
-	Links struct {
-		Self         string `json:"self" example:"https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166"`                     // The envelope itself
-		Transactions string `json:"transactions" example:"https://example.com/api/v3/transactions?envelope=45b6b5b9-f746-4ae9-b77b-7688b91f8166"` // The envelope's transactions
-		Month        string `json:"month" example:"https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/YYYY-MM"`            // The MonthConfig for the envelope
-	} `json:"links"` // Links to related resources
+type EnvelopeV3Links struct {
+	Self         string `json:"self" example:"https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166"`                     // The envelope itself
+	Transactions string `json:"transactions" example:"https://example.com/api/v3/transactions?envelope=45b6b5b9-f746-4ae9-b77b-7688b91f8166"` // The envelope's transactions
+	Month        string `json:"month" example:"https://example.com/api/v3/envelopes/45b6b5b9-f746-4ae9-b77b-7688b91f8166/YYYY-MM"`            // The MonthConfig for the envelope
 }
 
-func (e *EnvelopeV3) links(c *gin.Context) {
+func (l *EnvelopeV3Links) links(c *gin.Context, e models.Envelope) {
 	url := c.GetString(string(database.ContextURL))
 	self := fmt.Sprintf("%s/v3/envelopes/%s", url, e.ID)
 
-	e.Links.Self = self
-	e.Links.Transactions = fmt.Sprintf("%s/v3/transactions?envelope=%s", url, e.ID)
-	e.Links.Month = fmt.Sprintf("%s/v3/envelopes/%s/YYYY-MM", url, e.ID)
+	l.Self = self
+	l.Transactions = fmt.Sprintf("%s/v3/transactions?envelope=%s", url, e.ID)
+	l.Month = fmt.Sprintf("%s/v3/envelopes/%s/YYYY-MM", url, e.ID)
+}
+
+type EnvelopeV3 struct {
+	models.Envelope
+	Links  EnvelopeV3Links `json:"links"`            // Links to related resources
+	Hidden bool            `json:"hidden,omitempty"` // Remove the hidden field
 }
 
 func (co Controller) getEnvelopeV3(c *gin.Context, id uuid.UUID) (EnvelopeV3, httperrors.Error) {
@@ -61,7 +62,7 @@ func (co Controller) getEnvelopeV3(c *gin.Context, id uuid.UUID) (EnvelopeV3, ht
 		Envelope: m,
 	}
 
-	r.links(c)
+	r.Links.links(c, m)
 	return r, httperrors.Error{}
 }
 

--- a/pkg/controllers/month_v3.go
+++ b/pkg/controllers/month_v3.go
@@ -45,6 +45,7 @@ type EnvelopeMonthV3 struct {
 	Spent      decimal.Decimal `json:"spent" example:"73.12"`      // The amount spent over the whole month
 	Balance    decimal.Decimal `json:"balance" example:"12.32"`    // The balance at the end of the monht
 	Allocation decimal.Decimal `json:"allocation" example:"85.44"` // The amount of money allocated
+	Links      EnvelopeV3Links `json:"links"`
 }
 
 // RegisterMonthRoutesV3 registers the routes for months with
@@ -160,7 +161,7 @@ func (co Controller) GetMonthV3(c *gin.Context) {
 		}
 
 		for _, envelope := range envelopes {
-			envelopeMonth, err := envelopeMonthV3(co.DB, envelope, result.Month)
+			envelopeMonth, err := envelopeMonthV3(c, co.DB, envelope, result.Month)
 			if err != nil {
 				e := httperrors.Parse(c, err)
 				s := e.Error()
@@ -359,7 +360,7 @@ func (co Controller) SetAllocationsV3(c *gin.Context) {
 }
 
 // envelopeMonthV3 calculates the month specific values for an envelope and returns an EnvelopeMonthV3 with them
-func envelopeMonthV3(db *gorm.DB, e models.Envelope, month types.Month) (EnvelopeMonthV3, error) {
+func envelopeMonthV3(c *gin.Context, db *gorm.DB, e models.Envelope, month types.Month) (EnvelopeMonthV3, error) {
 	spent := e.Spent(db, month)
 
 	envelopeMonth := EnvelopeMonthV3{
@@ -388,5 +389,8 @@ func envelopeMonthV3(db *gorm.DB, e models.Envelope, month types.Month) (Envelop
 	}
 
 	envelopeMonth.Allocation = allocation.Amount
+
+	// Set the links
+	envelopeMonth.Links.links(c, e)
 	return envelopeMonth, nil
 }

--- a/pkg/controllers/month_v3_test.go
+++ b/pkg/controllers/month_v3_test.go
@@ -483,6 +483,9 @@ func (suite *TestSuiteStandard) TestMonthsV3() {
 				suite.Assert().FailNow("Response envelope length does not match!", "Envelope list does not have exactly 1 item, it has %d, Request ID: %s", len(month.Categories[0].Envelopes))
 			}
 
+			// Verify the links are set correctly
+			assert.Equal(t, envelope.Data.Links.Month, month.Categories[0].Envelopes[0].Links.Month)
+
 			// Category calculations
 			expectedCategory := tt.result.Categories[0]
 			category := month.Categories[0]


### PR DESCRIPTION
This adds the envelope links to the month endpoint so that clients do not
need to compute their own URLs.
