### PR TITLE
fix(v4): filtering transactions by note

### DIFF
--- a/pkg/controllers/v4/transaction.go
+++ b/pkg/controllers/v4/transaction.go
@@ -216,9 +216,9 @@ func GetTransactions(c *gin.Context) {
 	}
 
 	if filter.Note != "" {
-		q = q.Where("note LIKE ?", fmt.Sprintf("%%%s%%", filter.Note))
+		q = q.Where("transactions.note LIKE ?", fmt.Sprintf("%%%s%%", filter.Note))
 	} else if slices.Contains(setFields, "Note") {
-		q = q.Where("note = ''")
+		q = q.Where("transactions.note = ''")
 	}
 
 	// Set the offset. Does not need checking since the default is 0

--- a/pkg/controllers/v4/transaction_test.go
+++ b/pkg/controllers/v4/transaction_test.go
@@ -231,6 +231,7 @@ func (suite *TestSuiteStandard) TestTransactionsGetFilter() {
 		{"Before date", fmt.Sprintf("untilDate=%s", time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)), 1},
 		{"Between two dates", fmt.Sprintf("untilDate=%s&fromDate=%s", time.Date(2019, 8, 17, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano), time.Date(2015, 12, 24, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)), 2},
 		{"Budget Match", fmt.Sprintf("budget=%s", b.Data.ID), 3},
+		{"Budget and Note", fmt.Sprintf("budget=%s&note=Not", b.Data.ID), 1},
 		{"Destination Account", fmt.Sprintf("destination=%s", a2.Data.ID), 2},
 		{"Envelope 2", fmt.Sprintf("envelope=%s", e2.Data.ID), 1},
 		{"Exact Amount", fmt.Sprintf("amount=%s", decimal.NewFromFloat(2.718).String()), 2},


### PR DESCRIPTION
Filtering transactions by note was broken in API v4 before this
commit since the query did not specify the table name.
