### PR TITLE
chore: deprecate API v3

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -86,6 +86,7 @@ const docTemplate = `{
                     "v3"
                 ],
                 "summary": "v3 API",
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -101,6 +102,7 @@ const docTemplate = `{
                     "v3"
                 ],
                 "summary": "Delete everything",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -133,6 +135,7 @@ const docTemplate = `{
                     "v3"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -150,6 +153,7 @@ const docTemplate = `{
                     "Accounts"
                 ],
                 "summary": "List accounts",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -236,6 +240,7 @@ const docTemplate = `{
                     "Accounts"
                 ],
                 "summary": "Creates accounts",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Accounts",
@@ -283,6 +288,7 @@ const docTemplate = `{
                     "Accounts"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -300,6 +306,7 @@ const docTemplate = `{
                     "Accounts"
                 ],
                 "summary": "Get account",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -345,6 +352,7 @@ const docTemplate = `{
                     "Accounts"
                 ],
                 "summary": "Delete account",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -384,6 +392,7 @@ const docTemplate = `{
                     "Accounts"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -426,6 +435,7 @@ const docTemplate = `{
                     "Accounts"
                 ],
                 "summary": "Update account",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -482,6 +492,7 @@ const docTemplate = `{
                     "Budgets"
                 ],
                 "summary": "List budgets",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -547,6 +558,7 @@ const docTemplate = `{
                     "Budgets"
                 ],
                 "summary": "Create budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Budget",
@@ -588,6 +600,7 @@ const docTemplate = `{
                     "Budgets"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -605,6 +618,7 @@ const docTemplate = `{
                     "Budgets"
                 ],
                 "summary": "Get budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -647,6 +661,7 @@ const docTemplate = `{
                     "Budgets"
                 ],
                 "summary": "Delete budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -686,6 +701,7 @@ const docTemplate = `{
                     "Budgets"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -731,6 +747,7 @@ const docTemplate = `{
                     "Budgets"
                 ],
                 "summary": "Update budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -787,6 +804,7 @@ const docTemplate = `{
                     "Categories"
                 ],
                 "summary": "Get categories",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -861,6 +879,7 @@ const docTemplate = `{
                     "Categories"
                 ],
                 "summary": "Create category",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Categories",
@@ -908,6 +927,7 @@ const docTemplate = `{
                     "Categories"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -925,6 +945,7 @@ const docTemplate = `{
                     "Categories"
                 ],
                 "summary": "Get category",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -967,6 +988,7 @@ const docTemplate = `{
                     "Categories"
                 ],
                 "summary": "Delete category",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1006,6 +1028,7 @@ const docTemplate = `{
                     "Categories"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1051,6 +1074,7 @@ const docTemplate = `{
                     "Categories"
                 ],
                 "summary": "Update category",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1107,6 +1131,7 @@ const docTemplate = `{
                     "Envelopes"
                 ],
                 "summary": "Get envelopes",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1181,6 +1206,7 @@ const docTemplate = `{
                     "Envelopes"
                 ],
                 "summary": "Create envelope",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Envelopes",
@@ -1228,6 +1254,7 @@ const docTemplate = `{
                     "Envelopes"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -1245,6 +1272,7 @@ const docTemplate = `{
                     "Envelopes"
                 ],
                 "summary": "Get Envelope",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1287,6 +1315,7 @@ const docTemplate = `{
                     "Envelopes"
                 ],
                 "summary": "Delete envelope",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1326,6 +1355,7 @@ const docTemplate = `{
                     "Envelopes"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1371,6 +1401,7 @@ const docTemplate = `{
                     "Envelopes"
                 ],
                 "summary": "Update envelope",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1427,6 +1458,7 @@ const docTemplate = `{
                     "Envelopes"
                 ],
                 "summary": "Get MonthConfig",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1476,6 +1508,7 @@ const docTemplate = `{
                     "Envelopes"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1513,6 +1546,7 @@ const docTemplate = `{
                     "Envelopes"
                 ],
                 "summary": "Update MonthConfig",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1576,6 +1610,7 @@ const docTemplate = `{
                     "Goals"
                 ],
                 "summary": "Get goals",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1686,6 +1721,7 @@ const docTemplate = `{
                     "Goals"
                 ],
                 "summary": "Create goals",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Goals",
@@ -1733,6 +1769,7 @@ const docTemplate = `{
                     "Goals"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -1750,6 +1787,7 @@ const docTemplate = `{
                     "Goals"
                 ],
                 "summary": "Get goal",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1792,6 +1830,7 @@ const docTemplate = `{
                     "Goals"
                 ],
                 "summary": "Delete goal",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1831,6 +1870,7 @@ const docTemplate = `{
                     "Goals"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1876,6 +1916,7 @@ const docTemplate = `{
                     "Goals"
                 ],
                 "summary": "Update goal",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1929,6 +1970,7 @@ const docTemplate = `{
                     "Import"
                 ],
                 "summary": "Import API overview",
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -1944,6 +1986,7 @@ const docTemplate = `{
                     "Import"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -1964,6 +2007,7 @@ const docTemplate = `{
                     "Import"
                 ],
                 "summary": "Transaction Import Preview",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "file",
@@ -2012,6 +2056,7 @@ const docTemplate = `{
                     "Import"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -2032,6 +2077,7 @@ const docTemplate = `{
                     "Import"
                 ],
                 "summary": "Import YNAB 4 budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "file",
@@ -2074,6 +2120,7 @@ const docTemplate = `{
                     "Import"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -2091,6 +2138,7 @@ const docTemplate = `{
                     "MatchRules"
                 ],
                 "summary": "Get matchRules",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "integer",
@@ -2153,6 +2201,7 @@ const docTemplate = `{
                     "MatchRules"
                 ],
                 "summary": "Create matchRules",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "MatchRules",
@@ -2200,6 +2249,7 @@ const docTemplate = `{
                     "MatchRules"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -2217,6 +2267,7 @@ const docTemplate = `{
                     "MatchRules"
                 ],
                 "summary": "Get matchRule",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2259,6 +2310,7 @@ const docTemplate = `{
                     "MatchRules"
                 ],
                 "summary": "Delete matchRule",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2298,6 +2350,7 @@ const docTemplate = `{
                     "MatchRules"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2343,6 +2396,7 @@ const docTemplate = `{
                     "MatchRules"
                 ],
                 "summary": "Update matchRule",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2399,6 +2453,7 @@ const docTemplate = `{
                     "Months"
                 ],
                 "summary": "Get data about a month",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2448,6 +2503,7 @@ const docTemplate = `{
                     "Months"
                 ],
                 "summary": "Set allocations for a month",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2503,6 +2559,7 @@ const docTemplate = `{
                     "Months"
                 ],
                 "summary": "Delete allocations for a month",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2549,6 +2606,7 @@ const docTemplate = `{
                     "Months"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -2566,6 +2624,7 @@ const docTemplate = `{
                     "Transactions"
                 ],
                 "summary": "Get transactions",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2694,6 +2753,7 @@ const docTemplate = `{
                     "Transactions"
                 ],
                 "summary": "Create transactions",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Transactions",
@@ -2741,6 +2801,7 @@ const docTemplate = `{
                     "Transactions"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -2758,6 +2819,7 @@ const docTemplate = `{
                     "Transactions"
                 ],
                 "summary": "Get transaction",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2800,6 +2862,7 @@ const docTemplate = `{
                     "Transactions"
                 ],
                 "summary": "Delete transaction",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2839,6 +2902,7 @@ const docTemplate = `{
                     "Transactions"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2884,6 +2948,7 @@ const docTemplate = `{
                     "Transactions"
                 ],
                 "summary": "Update transaction",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -75,6 +75,7 @@
                     "v3"
                 ],
                 "summary": "v3 API",
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -90,6 +91,7 @@
                     "v3"
                 ],
                 "summary": "Delete everything",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -122,6 +124,7 @@
                     "v3"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -139,6 +142,7 @@
                     "Accounts"
                 ],
                 "summary": "List accounts",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -225,6 +229,7 @@
                     "Accounts"
                 ],
                 "summary": "Creates accounts",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Accounts",
@@ -272,6 +277,7 @@
                     "Accounts"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -289,6 +295,7 @@
                     "Accounts"
                 ],
                 "summary": "Get account",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -334,6 +341,7 @@
                     "Accounts"
                 ],
                 "summary": "Delete account",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -373,6 +381,7 @@
                     "Accounts"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -415,6 +424,7 @@
                     "Accounts"
                 ],
                 "summary": "Update account",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -471,6 +481,7 @@
                     "Budgets"
                 ],
                 "summary": "List budgets",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -536,6 +547,7 @@
                     "Budgets"
                 ],
                 "summary": "Create budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Budget",
@@ -577,6 +589,7 @@
                     "Budgets"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -594,6 +607,7 @@
                     "Budgets"
                 ],
                 "summary": "Get budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -636,6 +650,7 @@
                     "Budgets"
                 ],
                 "summary": "Delete budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -675,6 +690,7 @@
                     "Budgets"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -720,6 +736,7 @@
                     "Budgets"
                 ],
                 "summary": "Update budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -776,6 +793,7 @@
                     "Categories"
                 ],
                 "summary": "Get categories",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -850,6 +868,7 @@
                     "Categories"
                 ],
                 "summary": "Create category",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Categories",
@@ -897,6 +916,7 @@
                     "Categories"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -914,6 +934,7 @@
                     "Categories"
                 ],
                 "summary": "Get category",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -956,6 +977,7 @@
                     "Categories"
                 ],
                 "summary": "Delete category",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -995,6 +1017,7 @@
                     "Categories"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1040,6 +1063,7 @@
                     "Categories"
                 ],
                 "summary": "Update category",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1096,6 +1120,7 @@
                     "Envelopes"
                 ],
                 "summary": "Get envelopes",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1170,6 +1195,7 @@
                     "Envelopes"
                 ],
                 "summary": "Create envelope",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Envelopes",
@@ -1217,6 +1243,7 @@
                     "Envelopes"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -1234,6 +1261,7 @@
                     "Envelopes"
                 ],
                 "summary": "Get Envelope",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1276,6 +1304,7 @@
                     "Envelopes"
                 ],
                 "summary": "Delete envelope",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1315,6 +1344,7 @@
                     "Envelopes"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1360,6 +1390,7 @@
                     "Envelopes"
                 ],
                 "summary": "Update envelope",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1416,6 +1447,7 @@
                     "Envelopes"
                 ],
                 "summary": "Get MonthConfig",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1465,6 +1497,7 @@
                     "Envelopes"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1502,6 +1535,7 @@
                     "Envelopes"
                 ],
                 "summary": "Update MonthConfig",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1565,6 +1599,7 @@
                     "Goals"
                 ],
                 "summary": "Get goals",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1675,6 +1710,7 @@
                     "Goals"
                 ],
                 "summary": "Create goals",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Goals",
@@ -1722,6 +1758,7 @@
                     "Goals"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -1739,6 +1776,7 @@
                     "Goals"
                 ],
                 "summary": "Get goal",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1781,6 +1819,7 @@
                     "Goals"
                 ],
                 "summary": "Delete goal",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1820,6 +1859,7 @@
                     "Goals"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1865,6 +1905,7 @@
                     "Goals"
                 ],
                 "summary": "Update goal",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1918,6 +1959,7 @@
                     "Import"
                 ],
                 "summary": "Import API overview",
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -1933,6 +1975,7 @@
                     "Import"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -1953,6 +1996,7 @@
                     "Import"
                 ],
                 "summary": "Transaction Import Preview",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "file",
@@ -2001,6 +2045,7 @@
                     "Import"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -2021,6 +2066,7 @@
                     "Import"
                 ],
                 "summary": "Import YNAB 4 budget",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "file",
@@ -2063,6 +2109,7 @@
                     "Import"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -2080,6 +2127,7 @@
                     "MatchRules"
                 ],
                 "summary": "Get matchRules",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "integer",
@@ -2142,6 +2190,7 @@
                     "MatchRules"
                 ],
                 "summary": "Create matchRules",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "MatchRules",
@@ -2189,6 +2238,7 @@
                     "MatchRules"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -2206,6 +2256,7 @@
                     "MatchRules"
                 ],
                 "summary": "Get matchRule",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2248,6 +2299,7 @@
                     "MatchRules"
                 ],
                 "summary": "Delete matchRule",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2287,6 +2339,7 @@
                     "MatchRules"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2332,6 +2385,7 @@
                     "MatchRules"
                 ],
                 "summary": "Update matchRule",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2388,6 +2442,7 @@
                     "Months"
                 ],
                 "summary": "Get data about a month",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2437,6 +2492,7 @@
                     "Months"
                 ],
                 "summary": "Set allocations for a month",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2492,6 +2548,7 @@
                     "Months"
                 ],
                 "summary": "Delete allocations for a month",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2538,6 +2595,7 @@
                     "Months"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -2555,6 +2613,7 @@
                     "Transactions"
                 ],
                 "summary": "Get transactions",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2683,6 +2742,7 @@
                     "Transactions"
                 ],
                 "summary": "Create transactions",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Transactions",
@@ -2730,6 +2790,7 @@
                     "Transactions"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -2747,6 +2808,7 @@
                     "Transactions"
                 ],
                 "summary": "Get transaction",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2789,6 +2851,7 @@
                     "Transactions"
                 ],
                 "summary": "Delete transaction",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2828,6 +2891,7 @@
                     "Transactions"
                 ],
                 "summary": "Allowed HTTP verbs",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -2873,6 +2937,7 @@
                     "Transactions"
                 ],
                 "summary": "Update transaction",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2716,6 +2716,7 @@ paths:
       - General
   /v3:
     delete:
+      deprecated: true
       description: Permanently deletes all resources
       parameters:
       - description: Confirmation to delete all resources. Must have the value 'yes-please-delete-everything'
@@ -2737,6 +2738,7 @@ paths:
       tags:
       - v3
     get:
+      deprecated: true
       description: Returns general information about the v3 API
       responses:
         "200":
@@ -2747,6 +2749,7 @@ paths:
       tags:
       - v3
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       responses:
@@ -2757,6 +2760,7 @@ paths:
       - v3
   /v3/accounts:
     get:
+      deprecated: true
       description: Returns a list of accounts
       parameters:
       - description: Filter by name
@@ -2814,6 +2818,7 @@ paths:
       tags:
       - Accounts
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       responses:
@@ -2823,6 +2828,7 @@ paths:
       tags:
       - Accounts
     post:
+      deprecated: true
       description: Creates new accounts
       parameters:
       - description: Accounts
@@ -2857,6 +2863,7 @@ paths:
       - Accounts
   /v3/accounts/{id}:
     delete:
+      deprecated: true
       description: Deletes an account
       parameters:
       - description: ID formatted as string
@@ -2885,6 +2892,7 @@ paths:
       tags:
       - Accounts
     get:
+      deprecated: true
       description: Returns a specific account
       parameters:
       - description: ID formatted as string
@@ -2915,6 +2923,7 @@ paths:
       tags:
       - Accounts
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
@@ -2942,6 +2951,7 @@ paths:
       tags:
       - Accounts
     patch:
+      deprecated: true
       description: Updates an account. Only values to be updated need to be specified.
       parameters:
       - description: ID formatted as string
@@ -2979,6 +2989,7 @@ paths:
       - Accounts
   /v3/budgets:
     get:
+      deprecated: true
       description: Returns a list of budgets
       parameters:
       - description: Filter by name
@@ -3020,6 +3031,7 @@ paths:
       tags:
       - Budgets
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       responses:
@@ -3031,6 +3043,7 @@ paths:
     post:
       consumes:
       - application/json
+      deprecated: true
       description: Creates a new budget
       parameters:
       - description: Budget
@@ -3061,6 +3074,7 @@ paths:
       - Budgets
   /v3/budgets/{id}:
     delete:
+      deprecated: true
       description: Deletes a budget
       parameters:
       - description: ID formatted as string
@@ -3087,6 +3101,7 @@ paths:
       tags:
       - Budgets
     get:
+      deprecated: true
       description: Returns a specific budget
       parameters:
       - description: ID formatted as string
@@ -3117,6 +3132,7 @@ paths:
       tags:
       - Budgets
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
@@ -3146,6 +3162,7 @@ paths:
     patch:
       consumes:
       - application/json
+      deprecated: true
       description: Update an existing budget. Only values to be updated need to be
         specified.
       parameters:
@@ -3184,6 +3201,7 @@ paths:
       - Budgets
   /v3/categories:
     get:
+      deprecated: true
       description: Returns a list of categories
       parameters:
       - description: Filter by name
@@ -3233,6 +3251,7 @@ paths:
       tags:
       - Categories
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       responses:
@@ -3242,6 +3261,7 @@ paths:
       tags:
       - Categories
     post:
+      deprecated: true
       description: Creates a new category
       parameters:
       - description: Categories
@@ -3276,6 +3296,7 @@ paths:
       - Categories
   /v3/categories/{id}:
     delete:
+      deprecated: true
       description: Deletes a category
       parameters:
       - description: ID formatted as string
@@ -3302,6 +3323,7 @@ paths:
       tags:
       - Categories
     get:
+      deprecated: true
       description: Returns a specific category
       parameters:
       - description: ID formatted as string
@@ -3332,6 +3354,7 @@ paths:
       tags:
       - Categories
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
@@ -3361,6 +3384,7 @@ paths:
     patch:
       consumes:
       - application/json
+      deprecated: true
       description: Update an existing category. Only values to be updated need to
         be specified.
       parameters:
@@ -3399,6 +3423,7 @@ paths:
       - Categories
   /v3/envelopes:
     get:
+      deprecated: true
       description: Returns a list of envelopes
       parameters:
       - description: Filter by name
@@ -3448,6 +3473,7 @@ paths:
       tags:
       - Envelopes
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       responses:
@@ -3457,6 +3483,7 @@ paths:
       tags:
       - Envelopes
     post:
+      deprecated: true
       description: Creates a new envelope
       parameters:
       - description: Envelopes
@@ -3491,6 +3518,7 @@ paths:
       - Envelopes
   /v3/envelopes/{id}:
     delete:
+      deprecated: true
       description: Deletes an envelope
       parameters:
       - description: ID formatted as string
@@ -3517,6 +3545,7 @@ paths:
       tags:
       - Envelopes
     get:
+      deprecated: true
       description: Returns a specific Envelope
       parameters:
       - description: ID formatted as string
@@ -3547,6 +3576,7 @@ paths:
       tags:
       - Envelopes
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
@@ -3576,6 +3606,7 @@ paths:
     patch:
       consumes:
       - application/json
+      deprecated: true
       description: Updates an existing envelope. Only values to be updated need to
         be specified.
       parameters:
@@ -3614,6 +3645,7 @@ paths:
       - Envelopes
   /v3/envelopes/{id}/{month}:
     get:
+      deprecated: true
       description: Returns configuration for a specific month
       parameters:
       - description: ID of the Envelope
@@ -3649,6 +3681,7 @@ paths:
       tags:
       - Envelopes
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
@@ -3673,6 +3706,7 @@ paths:
       tags:
       - Envelopes
     patch:
+      deprecated: true
       description: Changes configuration for a Month. If there is no configuration
         for the month yet, this endpoint transparently creates a configuration resource.
       parameters:
@@ -3716,6 +3750,7 @@ paths:
       - Envelopes
   /v3/goals:
     get:
+      deprecated: true
       description: Returns a list of goals
       parameters:
       - description: Filter by name
@@ -3792,6 +3827,7 @@ paths:
       tags:
       - Goals
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       responses:
@@ -3801,6 +3837,7 @@ paths:
       tags:
       - Goals
     post:
+      deprecated: true
       description: Creates new goals
       parameters:
       - description: Goals
@@ -3835,6 +3872,7 @@ paths:
       - Goals
   /v3/goals/{id}:
     delete:
+      deprecated: true
       description: Deletes a goal
       parameters:
       - description: ID formatted as string
@@ -3861,6 +3899,7 @@ paths:
       tags:
       - Goals
     get:
+      deprecated: true
       description: Returns a specific goal
       parameters:
       - description: ID formatted as string
@@ -3891,6 +3930,7 @@ paths:
       tags:
       - Goals
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
@@ -3920,6 +3960,7 @@ paths:
     patch:
       consumes:
       - application/json
+      deprecated: true
       description: Updates an existing goal. Only values to be updated need to be
         specified.
       parameters:
@@ -3958,6 +3999,7 @@ paths:
       - Goals
   /v3/import:
     get:
+      deprecated: true
       description: Returns general information about the v3 API
       responses:
         "200":
@@ -3968,6 +4010,7 @@ paths:
       tags:
       - Import
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs.
       responses:
@@ -3978,6 +4021,7 @@ paths:
       - Import
   /v3/import/ynab-import-preview:
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       responses:
@@ -3989,6 +4033,7 @@ paths:
     post:
       consumes:
       - multipart/form-data
+      deprecated: true
       description: Returns a preview of transactions to be imported after parsing
         a YNAB Import format csv file
       parameters:
@@ -4025,6 +4070,7 @@ paths:
       - Import
   /v3/import/ynab4:
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       responses:
@@ -4036,6 +4082,7 @@ paths:
     post:
       consumes:
       - multipart/form-data
+      deprecated: true
       description: Imports budgets from YNAB 4
       parameters:
       - description: File to import
@@ -4067,6 +4114,7 @@ paths:
       - Import
   /v3/match-rules:
     get:
+      deprecated: true
       description: Returns a list of matchRules
       parameters:
       - description: Filter by priority
@@ -4108,6 +4156,7 @@ paths:
       tags:
       - MatchRules
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       responses:
@@ -4117,6 +4166,7 @@ paths:
       tags:
       - MatchRules
     post:
+      deprecated: true
       description: Creates matchRules from the list of submitted matchRule data. The
         response code is the highest response code number that a single matchRule
         creation would have caused. If it is not equal to 201, at least one matchRule
@@ -4154,6 +4204,7 @@ paths:
       - MatchRules
   /v3/match-rules/{id}:
     delete:
+      deprecated: true
       description: Deletes an matchRule
       parameters:
       - description: ID formatted as string
@@ -4180,6 +4231,7 @@ paths:
       tags:
       - MatchRules
     get:
+      deprecated: true
       description: Returns a specific matchRule
       parameters:
       - description: ID formatted as string
@@ -4210,6 +4262,7 @@ paths:
       tags:
       - MatchRules
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
@@ -4239,6 +4292,7 @@ paths:
     patch:
       consumes:
       - application/json
+      deprecated: true
       description: Update a matchRule. Only values to be updated need to be specified.
       parameters:
       - description: ID formatted as string
@@ -4276,6 +4330,7 @@ paths:
       - MatchRules
   /v3/months:
     delete:
+      deprecated: true
       description: Deletes all allocation for the specified month
       parameters:
       - description: ID formatted as string
@@ -4307,6 +4362,7 @@ paths:
       tags:
       - Months
     get:
+      deprecated: true
       description: Returns data about a specific month.
       parameters:
       - description: ID formatted as string
@@ -4342,6 +4398,7 @@ paths:
       tags:
       - Months
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs.
       responses:
@@ -4351,6 +4408,7 @@ paths:
       tags:
       - Months
     post:
+      deprecated: true
       description: Sets allocations for a month for all envelopes that do not have
         an allocation yet
       parameters:
@@ -4390,6 +4448,7 @@ paths:
       - Months
   /v3/transactions:
     get:
+      deprecated: true
       description: Returns a list of transactions
       parameters:
       - description: Date of the transaction. Ignores exact time, matches on the day
@@ -4479,6 +4538,7 @@ paths:
       tags:
       - Transactions
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       responses:
@@ -4488,6 +4548,7 @@ paths:
       tags:
       - Transactions
     post:
+      deprecated: true
       description: Creates transactions from the list of submitted transaction data.
         The response code is the highest response code number that a single transaction
         creation would have caused. If it is not equal to 201, at least one transaction
@@ -4525,6 +4586,7 @@ paths:
       - Transactions
   /v3/transactions/{id}:
     delete:
+      deprecated: true
       description: Deletes a transaction
       parameters:
       - description: ID formatted as string
@@ -4551,6 +4613,7 @@ paths:
       tags:
       - Transactions
     get:
+      deprecated: true
       description: Returns a specific transaction
       parameters:
       - description: ID formatted as string
@@ -4581,6 +4644,7 @@ paths:
       tags:
       - Transactions
     options:
+      deprecated: true
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
@@ -4610,6 +4674,7 @@ paths:
     patch:
       consumes:
       - application/json
+      deprecated: true
       description: Updates an existing transaction. Only values to be updated need
         to be specified.
       parameters:

--- a/pkg/controllers/v3/account.go
+++ b/pkg/controllers/v3/account.go
@@ -33,7 +33,8 @@ func RegisterAccountRoutes(r *gin.RouterGroup) {
 // @Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
 // @Tags			Accounts
 // @Success		204
-// @Router			/v3/accounts [options].
+// @Router			/v3/accounts [options]
+// @Deprecated		true
 func OptionsAccountList(c *gin.Context) {
 	httputil.OptionsGetPost(c)
 }
@@ -46,7 +47,8 @@ func OptionsAccountList(c *gin.Context) {
 // @Failure		404	{object}	httperrors.HTTPError
 // @Failure		500	{object}	httperrors.HTTPError
 // @Param			id	path		string	true	"ID formatted as string"
-// @Router			/v3/accounts/{id} [options].
+// @Router			/v3/accounts/{id} [options]
+// @Deprecated		true
 func OptionsAccountDetail(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -77,6 +79,7 @@ func OptionsAccountDetail(c *gin.Context) {
 // @Failure		500			{object}	AccountCreateResponse
 // @Param			accounts	body		[]AccountEditable	true	"Accounts"
 // @Router			/v3/accounts [post]
+// @Deprecated		true
 func CreateAccounts(c *gin.Context) {
 	var editables []AccountEditable
 
@@ -139,6 +142,7 @@ func CreateAccounts(c *gin.Context) {
 // @Param			search		query	string	false	"Search for this text in name and note"
 // @Param			offset		query	uint	false	"The offset of the first Account returned. Defaults to 0."
 // @Param			limit		query	int		false	"Maximum number of Accounts to return. Defaults to 50."
+// @Deprecated		true
 func GetAccounts(c *gin.Context) {
 	var filter AccountQueryFilter
 	if err := c.Bind(&filter); err != nil {
@@ -232,6 +236,7 @@ func GetAccounts(c *gin.Context) {
 // @Failure		500	{object}	AccountResponse
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/accounts/{id} [get]
+// @Deprecated		true
 func GetAccount(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -273,6 +278,7 @@ func GetAccount(c *gin.Context) {
 // @Param			id		path		string			true	"ID formatted as string"
 // @Param			account	body		AccountEditable	true	"Account"
 // @Router			/v3/accounts/{id} [patch]
+// @Deprecated		true
 func UpdateAccount(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -342,6 +348,7 @@ func UpdateAccount(c *gin.Context) {
 // @Failure		500	{object}	httperrors.HTTPError
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/accounts/{id} [delete]
+// @Deprecated		true
 func DeleteAccount(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {

--- a/pkg/controllers/v3/budget.go
+++ b/pkg/controllers/v3/budget.go
@@ -34,6 +34,7 @@ func RegisterBudgetRoutes(r *gin.RouterGroup) {
 // @Tags			Budgets
 // @Success		204
 // @Router			/v3/budgets [options]
+// @Deprecated		true
 func OptionsBudgetList(c *gin.Context) {
 	httputil.OptionsGetPost(c)
 }
@@ -47,6 +48,7 @@ func OptionsBudgetList(c *gin.Context) {
 // @Failure		500	{object}	httperrors.HTTPError
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/budgets/{id} [options]
+// @Deprecated		true
 func OptionsBudgetDetail(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -77,6 +79,7 @@ func OptionsBudgetDetail(c *gin.Context) {
 // @Failure		500		{object}	BudgetCreateResponse
 // @Param			budget	body		[]BudgetEditable	true	"Budget"
 // @Router			/v3/budgets [post]
+// @Deprecated		true
 func CreateBudgets(c *gin.Context) {
 	var budgets []BudgetEditable
 
@@ -124,6 +127,7 @@ func CreateBudgets(c *gin.Context) {
 // @Param			search		query	string	false	"Search for this text in name and note"
 // @Param			offset		query	uint	false	"The offset of the first Budget returned. Defaults to 0."
 // @Param			limit		query	int		false	"Maximum number of Budgets to return. Defaults to 50."
+// @Deprecated		true
 func GetBudgets(c *gin.Context) {
 	var filter BudgetQueryFilter
 
@@ -197,6 +201,7 @@ func GetBudgets(c *gin.Context) {
 // @Failure		500	{object}	BudgetResponse
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/budgets/{id} [get]
+// @Deprecated		true
 func GetBudget(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -232,6 +237,7 @@ func GetBudget(c *gin.Context) {
 // @Param			id		path		string			true	"ID formatted as string"
 // @Param			budget	body		BudgetEditable	true	"Budget"
 // @Router			/v3/budgets/{id} [patch]
+// @Deprecated		true
 func UpdateBudget(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -292,6 +298,7 @@ func UpdateBudget(c *gin.Context) {
 // @Failure		500	{object}	httperrors.HTTPError
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/budgets/{id} [delete]
+// @Deprecated		true
 func DeleteBudget(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {

--- a/pkg/controllers/v3/category.go
+++ b/pkg/controllers/v3/category.go
@@ -34,6 +34,7 @@ func RegisterCategoryRoutes(r *gin.RouterGroup) {
 // @Tags			Categories
 // @Success		204
 // @Router			/v3/categories [options]
+// @Deprecated		true
 func OptionsCategoryList(c *gin.Context) {
 	httputil.OptionsGetPost(c)
 }
@@ -47,6 +48,7 @@ func OptionsCategoryList(c *gin.Context) {
 // @Failure		500	{object}	httperrors.HTTPError
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/categories/{id} [options]
+// @Deprecated		true
 func OptionsCategoryDetail(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -77,6 +79,7 @@ func OptionsCategoryDetail(c *gin.Context) {
 // @Failure		500			{object}	CategoryCreateResponse
 // @Param			categories	body		[]CategoryEditable	true	"Categories"
 // @Router			/v3/categories [post]
+// @Deprecated		true
 func CreateCategories(c *gin.Context) {
 	var editables []CategoryEditable
 
@@ -138,6 +141,7 @@ func CreateCategories(c *gin.Context) {
 // @Param			search		query	string	false	"Search for this text in name and note"
 // @Param			offset		query	uint	false	"The offset of the first Category returned. Defaults to 0."
 // @Param			limit		query	int		false	"Maximum number of Categories to return. Defaults to 50."
+// @Deprecated		true
 func GetCategories(c *gin.Context) {
 	var filter CategoryQueryFilter
 
@@ -227,6 +231,7 @@ func GetCategories(c *gin.Context) {
 // @Failure		500	{object}	CategoryResponse
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/categories/{id} [get]
+// @Deprecated		true
 func GetCategory(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -269,6 +274,7 @@ func GetCategory(c *gin.Context) {
 // @Param			id			path		string				true	"ID formatted as string"
 // @Param			category	body		CategoryEditable	true	"Category"
 // @Router			/v3/categories/{id} [patch]
+// @Deprecated		true
 func UpdateCategory(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -337,6 +343,7 @@ func UpdateCategory(c *gin.Context) {
 // @Failure		500	{object}	httperrors.HTTPError
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/categories/{id} [delete]
+// @Deprecated		true
 func DeleteCategory(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {

--- a/pkg/controllers/v3/cleanup.go
+++ b/pkg/controllers/v3/cleanup.go
@@ -16,6 +16,7 @@ import (
 // @Failure		500		{object}	httperrors.HTTPError
 // @Param			confirm	query		string	false	"Confirmation to delete all resources. Must have the value 'yes-please-delete-everything'"
 // @Router			/v3 [delete]
+// @Deprecated		true
 func Cleanup(c *gin.Context) {
 	var params struct {
 		Confirm string `form:"confirm"`

--- a/pkg/controllers/v3/envelope.go
+++ b/pkg/controllers/v3/envelope.go
@@ -34,6 +34,7 @@ func RegisterEnvelopeRoutes(r *gin.RouterGroup) {
 // @Tags			Envelopes
 // @Success		204
 // @Router			/v3/envelopes [options]
+// @Deprecated		true
 func OptionsEnvelopeList(c *gin.Context) {
 	httputil.OptionsGetPost(c)
 }
@@ -47,6 +48,7 @@ func OptionsEnvelopeList(c *gin.Context) {
 // @Failure		500	{object}	httperrors.HTTPError
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/envelopes/{id} [options]
+// @Deprecated		true
 func OptionsEnvelopeDetail(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -77,6 +79,7 @@ func OptionsEnvelopeDetail(c *gin.Context) {
 // @Failure		500			{object}	EnvelopeCreateResponse
 // @Param			envelope	body		[]v3.EnvelopeEditable	true	"Envelopes"
 // @Router			/v3/envelopes [post]
+// @Deprecated		true
 func CreateEnvelopes(c *gin.Context) {
 	var envelopes []EnvelopeEditable
 
@@ -134,6 +137,7 @@ func CreateEnvelopes(c *gin.Context) {
 // @Param			search		query	string	false	"Search for this text in name and note"
 // @Param			offset		query	uint	false	"The offset of the first Envelope returned. Defaults to 0."
 // @Param			limit		query	int		false	"Maximum number of Envelopes to return. Defaults to 50."
+// @Deprecated		true
 func GetEnvelopes(c *gin.Context) {
 	var filter EnvelopeQueryFilter
 
@@ -215,6 +219,7 @@ func GetEnvelopes(c *gin.Context) {
 // @Failure		500	{object}	EnvelopeResponse
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/envelopes/{id} [get]
+// @Deprecated		true
 func GetEnvelope(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -250,6 +255,7 @@ func GetEnvelope(c *gin.Context) {
 // @Param			id			path		string				true	"ID formatted as string"
 // @Param			envelope	body		v3.EnvelopeEditable	true	"Envelope"
 // @Router			/v3/envelopes/{id} [patch]
+// @Deprecated		true
 func UpdateEnvelope(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -310,6 +316,7 @@ func UpdateEnvelope(c *gin.Context) {
 // @Failure		500	{object}	httperrors.HTTPError
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/envelopes/{id} [delete]
+// @Deprecated		true
 func DeleteEnvelope(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {

--- a/pkg/controllers/v3/goal.go
+++ b/pkg/controllers/v3/goal.go
@@ -30,6 +30,7 @@ func RegisterGoalRoutes(r *gin.RouterGroup) {
 // @Tags			Goals
 // @Success		204
 // @Router			/v3/goals [options]
+// @Deprecated		true
 func OptionsGoals(c *gin.Context) {
 	httputil.OptionsGetPost(c)
 }
@@ -43,6 +44,7 @@ func OptionsGoals(c *gin.Context) {
 // @Failure		500	{object}	httperrors.HTTPError
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/goals/{id} [options]
+// @Deprecated		true
 func OptionsGoalDetail(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -73,6 +75,7 @@ func OptionsGoalDetail(c *gin.Context) {
 // @Failure		500		{object}	GoalCreateResponse
 // @Param			goals	body		[]GoalEditable	true	"Goals"
 // @Router			/v3/goals [post]
+// @Deprecated		true
 func CreateGoals(c *gin.Context) {
 	var goals []GoalEditable
 
@@ -136,6 +139,7 @@ func CreateGoals(c *gin.Context) {
 // @Param			amountMoreOrEqual	query	string	false	"Amount more than or equal to this"
 // @Param			offset				query	uint	false	"The offset of the first goal returned. Defaults to 0."
 // @Param			limit				query	int		false	"Maximum number of goal to return. Defaults to 50."
+// @Deprecated		true
 func GetGoals(c *gin.Context) {
 	var filter GoalQueryFilter
 
@@ -256,6 +260,7 @@ func GetGoals(c *gin.Context) {
 // @Failure		500	{object}	GoalResponse
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/goals/{id} [get]
+// @Deprecated		true
 func GetGoal(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -292,6 +297,7 @@ func GetGoal(c *gin.Context) {
 // @Param			id		path		string			true	"ID formatted as string"
 // @Param			goal	body		GoalEditable	true	"Goal"
 // @Router			/v3/goals/{id} [patch]
+// @Deprecated		true
 func UpdateGoal(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -366,6 +372,7 @@ func UpdateGoal(c *gin.Context) {
 // @Failure		500	{object}	httperrors.HTTPError
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/goals/{id} [delete]
+// @Deprecated		true
 func DeleteGoal(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {

--- a/pkg/controllers/v3/import.go
+++ b/pkg/controllers/v3/import.go
@@ -190,6 +190,7 @@ func RegisterImportRoutes(r *gin.RouterGroup) {
 // @Tags			Import
 // @Success		204
 // @Router			/v3/import [options]
+// @Deprecated		true
 func OptionsImport(c *gin.Context) {
 	httputil.OptionsGet(c)
 }
@@ -208,6 +209,7 @@ type ImportLinks struct {
 // @Tags			Import
 // @Success		200	{object}	ImportResponse
 // @Router			/v3/import [get]
+// @Deprecated		true
 func GetImport(c *gin.Context) {
 	c.JSON(http.StatusOK, ImportResponse{
 		Links: ImportLinks{
@@ -222,6 +224,7 @@ func GetImport(c *gin.Context) {
 // @Tags			Import
 // @Success		204
 // @Router			/v3/import/ynab4 [options]
+// @Deprecated		true
 func OptionsImportYnab4(c *gin.Context) {
 	httputil.OptionsPost(c)
 }
@@ -231,6 +234,7 @@ func OptionsImportYnab4(c *gin.Context) {
 // @Tags			Import
 // @Success		204
 // @Router			/v3/import/ynab-import-preview [options]
+// @Deprecated		true
 func OptionsImportYnabImportPreview(c *gin.Context) {
 	httputil.OptionsPost(c)
 }
@@ -247,6 +251,7 @@ func OptionsImportYnabImportPreview(c *gin.Context) {
 // @Param			file		formData	file	true	"File to import"
 // @Param			accountId	query		string	false	"ID of the account to import transactions for"
 // @Router			/v3/import/ynab-import-preview [post]
+// @Deprecated		true
 func ImportYnabImportPreview(c *gin.Context) {
 	var query ImportPreviewQuery
 	err := c.BindQuery(&query)
@@ -369,6 +374,7 @@ func ImportYnabImportPreview(c *gin.Context) {
 // @Param			file		formData	file	true	"File to import"
 // @Param			budgetName	query		string	false	"Name of the Budget to create"
 // @Router			/v3/import/ynab4 [post]
+// @Deprecated		true
 func ImportYnab4(c *gin.Context) {
 	var query ImportQuery
 	if err := c.BindQuery(&query); err != nil {

--- a/pkg/controllers/v3/match_rule.go
+++ b/pkg/controllers/v3/match_rule.go
@@ -36,6 +36,7 @@ func RegisterMatchRuleRoutes(r *gin.RouterGroup) {
 // @Tags			MatchRules
 // @Success		204
 // @Router			/v3/match-rules [options]
+// @Deprecated		true
 func OptionsMatchRuleList(c *gin.Context) {
 	httputil.OptionsGetPost(c)
 }
@@ -49,6 +50,7 @@ func OptionsMatchRuleList(c *gin.Context) {
 // @Failure		500	{object}	httperrors.HTTPError
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/match-rules/{id} [options]
+// @Deprecated		true
 func OptionsMatchRuleDetail(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -74,6 +76,7 @@ func OptionsMatchRuleDetail(c *gin.Context) {
 // @Failure		500			{object}	MatchRuleCreateResponse
 // @Param			matchRules	body		[]MatchRuleEditable	true	"MatchRules"
 // @Router			/v3/match-rules [post]
+// @Deprecated		true
 func CreateMatchRules(c *gin.Context) {
 	var matchRules []MatchRuleEditable
 
@@ -119,6 +122,7 @@ func CreateMatchRules(c *gin.Context) {
 // @Param			offset		query		uint	false	"The offset of the first Match Rule returned. Defaults to 0."
 // @Param			limit		query		int		false	"Maximum number of Match Rules to return. Defaults to 50.".
 // @Router			/v3/match-rules [get]
+// @Deprecated		true
 func GetMatchRules(c *gin.Context) {
 	var filter MatchRuleQueryFilter
 	if err := c.Bind(&filter); err != nil {
@@ -207,6 +211,7 @@ func GetMatchRules(c *gin.Context) {
 // @Failure		500	{object}	MatchRuleResponse
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/match-rules/{id} [get]
+// @Deprecated		true
 func GetMatchRule(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -241,6 +246,7 @@ func GetMatchRule(c *gin.Context) {
 // @Param			id			path		string				true	"ID formatted as string"
 // @Param			matchRule	body		MatchRuleEditable	true	"MatchRule"
 // @Router			/v3/match-rules/{id} [patch]
+// @Deprecated		true
 func UpdateMatchRule(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -315,6 +321,8 @@ func UpdateMatchRule(c *gin.Context) {
 // @Failure		500	{object}	httperrors.HTTPError
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/match-rules/{id} [delete]
+//
+// @Deprecated		true
 func DeleteMatchRule(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {

--- a/pkg/controllers/v3/month.go
+++ b/pkg/controllers/v3/month.go
@@ -64,6 +64,7 @@ func RegisterMonthRoutes(r *gin.RouterGroup) {
 // @Tags			Months
 // @Success		204
 // @Router			/v3/months [options]
+// @Deprecated		true
 func OptionsMonth(c *gin.Context) {
 	httputil.OptionsGetPostDelete(c)
 }
@@ -79,6 +80,7 @@ func OptionsMonth(c *gin.Context) {
 // @Param			budget	query		string	true	"ID formatted as string"
 // @Param			month	query		string	true	"The month in YYYY-MM format"
 // @Router			/v3/months [get]
+// @Deprecated		true
 func GetMonth(c *gin.Context) {
 	qMonth, b, e := parseMonthQuery(c)
 	if !e.Nil() {
@@ -244,6 +246,7 @@ func GetMonth(c *gin.Context) {
 // @Param			budget	query		string	true	"ID formatted as string"
 // @Param			month	query		string	true	"The month in YYYY-MM format"
 // @Router			/v3/months [delete]
+// @Deprecated		true
 func DeleteAllocations(c *gin.Context) {
 	month, budget, err := parseMonthQuery(c)
 	if !err.Nil() {
@@ -296,6 +299,7 @@ func DeleteAllocations(c *gin.Context) {
 // @Param			month	query		string					true	"The month in YYYY-MM format"
 // @Param			mode	body		BudgetAllocationMode	true	"Budget"
 // @Router			/v3/months [post]
+// @Deprecated		true
 func SetAllocations(c *gin.Context) {
 	month, _, err := parseMonthQuery(c)
 	if !err.Nil() {

--- a/pkg/controllers/v3/month_config.go
+++ b/pkg/controllers/v3/month_config.go
@@ -27,6 +27,7 @@ func RegisterMonthConfigRoutes(r *gin.RouterGroup) {
 // @Param			id		path		string	true	"ID of the Envelope"
 // @Param			month	path		string	true	"The month in YYYY-MM format"
 // @Router			/v3/envelopes/{id}/{month} [options]
+// @Deprecated		true
 func OptionsMonthConfigDetail(c *gin.Context) {
 	_, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -59,6 +60,7 @@ func OptionsMonthConfigDetail(c *gin.Context) {
 // @Param			id		path		string	true	"ID of the Envelope"
 // @Param			month	path		string	true	"The month in YYYY-MM format"
 // @Router			/v3/envelopes/{id}/{month} [get]
+// @Deprecated		true
 func GetMonthConfig(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -123,6 +125,7 @@ func GetMonthConfig(c *gin.Context) {
 // @Param			month		path		string				true	"The month in YYYY-MM format"
 // @Param			monthConfig	body		MonthConfigEditable	true	"MonthConfig"
 // @Router			/v3/envelopes/{id}/{month} [patch]
+// @Deprecated		true
 func UpdateMonthConfig(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {

--- a/pkg/controllers/v3/root.go
+++ b/pkg/controllers/v3/root.go
@@ -37,6 +37,8 @@ type Links struct {
 //	@Tags			v3
 //	@Success		200	{object}	Response
 //	@Router			/v3 [get]
+//
+//	@Deprecated		true
 func Get(c *gin.Context) {
 	url := c.GetString(string(models.DBContextURL))
 
@@ -62,6 +64,8 @@ func Get(c *gin.Context) {
 //	@Tags			v3
 //	@Success		204
 //	@Router			/v3 [options]
+//
+//	@Deprecated		true
 func Options(c *gin.Context) {
 	httputil.OptionsGetDelete(c)
 }

--- a/pkg/controllers/v3/transaction.go
+++ b/pkg/controllers/v3/transaction.go
@@ -40,6 +40,7 @@ func RegisterTransactionRoutes(r *gin.RouterGroup) {
 // @Tags			Transactions
 // @Success		204
 // @Router			/v3/transactions [options]
+// @Deprecated		true
 func OptionsTransactions(c *gin.Context) {
 	httputil.OptionsGetPost(c)
 }
@@ -53,6 +54,7 @@ func OptionsTransactions(c *gin.Context) {
 // @Failure		500	{object}	httperrors.HTTPError
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/transactions/{id} [options]
+// @Deprecated		true
 func OptionsTransactionDetail(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -84,6 +86,7 @@ func OptionsTransactionDetail(c *gin.Context) {
 // @Failure		500	{object}	TransactionResponse
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/transactions/{id} [get]
+// @Deprecated		true
 func GetTransaction(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {
@@ -132,6 +135,7 @@ func GetTransaction(c *gin.Context) {
 // @Param			reconciledDestination	query	bool	false	"Reconcilication state in destination account"
 // @Param			offset					query	uint	false	"The offset of the first Transaction returned. Defaults to 0."
 // @Param			limit					query	int		false	"Maximum number of Transactions to return. Defaults to 50."
+// @Deprecated		true
 func GetTransactions(c *gin.Context) {
 	var filter TransactionQueryFilter
 	if err := c.Bind(&filter); err != nil {
@@ -259,6 +263,7 @@ func GetTransactions(c *gin.Context) {
 // @Failure		500				{object}	TransactionCreateResponse
 // @Param			transactions	body		[]TransactionEditable	true	"Transactions"
 // @Router			/v3/transactions [post]
+// @Deprecated		true
 func CreateTransactions(c *gin.Context) {
 	var editables []TransactionEditable
 
@@ -306,6 +311,7 @@ func CreateTransactions(c *gin.Context) {
 // @Param			id			path		string				true	"ID formatted as string"
 // @Param			transaction	body		TransactionEditable	true	"Transaction"
 // @Router			/v3/transactions/{id} [patch]
+// @Deprecated		true
 func UpdateTransaction(c *gin.Context) {
 	// Get the resource ID
 	id, err := httputil.UUIDFromString(c.Param("id"))
@@ -414,6 +420,7 @@ func UpdateTransaction(c *gin.Context) {
 // @Failure		500	{object}	httperrors.HTTPError
 // @Param			id	path		string	true	"ID formatted as string"
 // @Router			/v3/transactions/{id} [delete]
+// @Deprecated		true
 func DeleteTransaction(c *gin.Context) {
 	id, err := httputil.UUIDFromString(c.Param("id"))
 	if !err.Nil() {


### PR DESCRIPTION
chore: deprecate API v3

This deprecates API v3, since v4 is available now.
