### PR TITLE
docs: update contact email address

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-Please do not open an issue if you find a vulnerability. Send an email to envelope-zero@maurice-meyer.de and a maintainer will get in touch with you as soon as possible. This might take up to 72 hours.
+Please do not open an issue if you find a vulnerability. Send an email to security@envelope-zero.org and a maintainer will get in touch with you as soon as possible. This might take up to 72 hours.
 
 You will be kept up to date with all developments via email.
 


### PR DESCRIPTION
Update contact email to the envelope-zero.org domain.