### PR TITLE
feat: implement transaction "direction" filter

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2733,6 +2733,17 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "INCOMING",
+                            "OUTGOING",
+                            "TRANSFER"
+                        ],
+                        "type": "string",
+                        "description": "Filter by direction of transaction",
+                        "name": "direction",
+                        "in": "query"
+                    },
+                    {
                         "type": "string",
                         "description": "Filter by envelope ID",
                         "name": "envelope",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2722,6 +2722,17 @@
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "INCOMING",
+                            "OUTGOING",
+                            "TRANSFER"
+                        ],
+                        "type": "string",
+                        "description": "Filter by direction of transaction",
+                        "name": "direction",
+                        "in": "query"
+                    },
+                    {
                         "type": "string",
                         "description": "Filter by envelope ID",
                         "name": "envelope",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3219,6 +3219,14 @@ paths:
         in: query
         name: destination
         type: string
+      - description: Filter by direction of transaction
+        enum:
+        - INCOMING
+        - OUTGOING
+        - TRANSFER
+        in: query
+        name: direction
+        type: string
       - description: Filter by envelope ID
         in: query
         name: envelope

--- a/pkg/controllers/v4/errors.go
+++ b/pkg/controllers/v4/errors.go
@@ -24,14 +24,14 @@ func status(err error) int {
 	return http.StatusBadRequest
 }
 
-// Cleanup errors
-var (
-	errCleanupConfirmation = errors.New("the confirmation for the cleanup API call was incorrect")
-)
-
 var (
 	errAccountIDParameter = errors.New("the accountId parameter must be set")
 	errMonthNotSetInQuery = errors.New("the month query parameter must be set")
+)
+
+// Cleanup errors
+var (
+	errCleanupConfirmation = errors.New("the confirmation for the cleanup API call was incorrect")
 )
 
 // Import errors
@@ -40,4 +40,9 @@ var (
 	errWrongFileSuffix  = errors.New("this endpoint only supports files of the following types")
 	errBudgetNameInUse  = errors.New("this budget name is already in use. Imports from YNAB 4 create a new budget, therefore the name needs to be unique")
 	errBudgetNameNotSet = errors.New("the budgetName parameter must be set")
+)
+
+// Transaction errors
+var (
+	errTransactionDirectionInvalid = errors.New("the specified transaction direction is invalid")
 )

--- a/pkg/controllers/v4/month.go
+++ b/pkg/controllers/v4/month.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
+	"golang.org/x/exp/slices"
 	"gorm.io/gorm"
 )
 
@@ -305,7 +306,7 @@ func SetAllocations(c *gin.Context) {
 		return
 	}
 
-	if data.Mode != AllocateLastMonthBudget && data.Mode != AllocateLastMonthSpend {
+	if !slices.Contains([]AllocationMode{AllocateLastMonthBudget, AllocateLastMonthSpend}, data.Mode) {
 		c.JSON(http.StatusBadRequest, httpError{
 			Error: fmt.Sprintf("The mode must be %s or %s", AllocateLastMonthBudget, AllocateLastMonthSpend),
 		})

--- a/pkg/controllers/v4/transaction_types.go
+++ b/pkg/controllers/v4/transaction_types.go
@@ -110,23 +110,33 @@ type TransactionResponse struct {
 	Data  *Transaction `json:"data"`                                                          // The Transaction data, if creation was successful
 }
 
+// swagger:enum TransactionDirection
+type TransactionDirection string
+
+const (
+	DirectionIncoming TransactionDirection = "INCOMING"
+	DirectionOutgoing TransactionDirection = "OUTGOING"
+	DirectionTransfer TransactionDirection = "TRANSFER"
+)
+
 type TransactionQueryFilter struct {
-	Date                  time.Time       `form:"date" filterField:"false"`              // Exact date. Time is ignored.
-	FromDate              time.Time       `form:"fromDate" filterField:"false"`          // From this date. Time is ignored.
-	UntilDate             time.Time       `form:"untilDate" filterField:"false"`         // Until this date. Time is ignored.
-	Amount                decimal.Decimal `form:"amount"`                                // Exact amount
-	AmountLessOrEqual     decimal.Decimal `form:"amountLessOrEqual" filterField:"false"` // Amount less than or equal to this
-	AmountMoreOrEqual     decimal.Decimal `form:"amountMoreOrEqual" filterField:"false"` // Amount more than or equal to this
-	Note                  string          `form:"note" filterField:"false"`              // Note contains this string
-	BudgetID              string          `form:"budget" filterField:"false"`            // ID of the budget
-	SourceAccountID       string          `form:"source"`                                // ID of the source account
-	DestinationAccountID  string          `form:"destination"`                           // ID of the destination account
-	EnvelopeID            string          `form:"envelope"`                              // ID of the envelope
-	ReconciledSource      bool            `form:"reconciledSource"`                      // Is the transaction reconciled in the source account?
-	ReconciledDestination bool            `form:"reconciledDestination"`                 // Is the transaction reconciled in the destination account?
-	AccountID             string          `form:"account" filterField:"false"`           // ID of either source or destination account
-	Offset                uint            `form:"offset" filterField:"false"`            // The offset of the first Transaction returned. Defaults to 0.
-	Limit                 int             `form:"limit" filterField:"false"`             // Maximum number of transactions to return. Defaults to 50.
+	Date                  time.Time            `form:"date" filterField:"false"`              // Exact date. Time is ignored.
+	FromDate              time.Time            `form:"fromDate" filterField:"false"`          // From this date. Time is ignored.
+	UntilDate             time.Time            `form:"untilDate" filterField:"false"`         // Until this date. Time is ignored.
+	Amount                decimal.Decimal      `form:"amount"`                                // Exact amount
+	AmountLessOrEqual     decimal.Decimal      `form:"amountLessOrEqual" filterField:"false"` // Amount less than or equal to this
+	AmountMoreOrEqual     decimal.Decimal      `form:"amountMoreOrEqual" filterField:"false"` // Amount more than or equal to this
+	Note                  string               `form:"note" filterField:"false"`              // Note contains this string
+	BudgetID              string               `form:"budget" filterField:"false"`            // ID of the budget
+	SourceAccountID       string               `form:"source"`                                // ID of the source account
+	DestinationAccountID  string               `form:"destination"`                           // ID of the destination account
+	Direction             TransactionDirection `form:"direction" filterField:"false"`         // Direction of the transaction
+	EnvelopeID            string               `form:"envelope"`                              // ID of the envelope
+	ReconciledSource      bool                 `form:"reconciledSource"`                      // Is the transaction reconciled in the source account?
+	ReconciledDestination bool                 `form:"reconciledDestination"`                 // Is the transaction reconciled in the destination account?
+	AccountID             string               `form:"account" filterField:"false"`           // ID of either source or destination account
+	Offset                uint                 `form:"offset" filterField:"false"`            // The offset of the first Transaction returned. Defaults to 0.
+	Limit                 int                  `form:"limit" filterField:"false"`             // Maximum number of transactions to return. Defaults to 50.
 }
 
 func (f TransactionQueryFilter) model() (models.Transaction, error) {


### PR DESCRIPTION
This adds the ability to filter transactions by the transaction direction:

* Incoming: Funds moved from an off-budget to an on-budget account
* Outgoing: Funds moved from an on-budget to an off-budget account
* Transfer: Funds moved between internal accounts

Resolves #565
