### PR TITLE
feat: add export

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,5 +56,7 @@ repos:
         name: "Find FIXME:|BUG: comments"
         description: "Check for FIXME:|BUG: comments in all files"
         language: pygrep
-        entry: '(^|//!?|#|<!--|;|/\*(\*|!)?|\.\.)\s*(FIXME:|BUG:)(?!#i#)'
+
+        # This contains "FIMXE" because I often mistype it
+        entry: '(^|//!?|#|<!--|;|/\*(\*|!)?|\.\.)\s*(FIXME:|FIMXE:|BUG:)(?!#i#)'
         exclude: CONTRIBUTING.md

--- a/api/docs.go
+++ b/api/docs.go
@@ -1665,6 +1665,44 @@ const docTemplate = `{
                 }
             }
         },
+        "/v4/export": {
+            "get": {
+                "description": "Exports all resources for the instance",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Export"
+                ],
+                "summary": "Export",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v4.ExportResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/v4.ExportResponse"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "tags": [
+                    "Export"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
         "/v4/goals": {
             "get": {
                 "description": "Returns a list of goals",
@@ -3460,7 +3498,7 @@ const docTemplate = `{
                     }
                 },
                 "error": {
-                    "description": "FIMXE: make this *error for ALL responses",
+                    "description": "The error, if any occurred",
                     "type": "string",
                     "example": "the specified resource ID is not a valid UUID"
                 }
@@ -4018,6 +4056,33 @@ const docTemplate = `{
                     "description": "The error, if any occurred",
                     "type": "string",
                     "example": "the specified resource ID is not a valid UUID"
+                }
+            }
+        },
+        "v4.ExportResponse": {
+            "type": "object",
+            "properties": {
+                "clacks": {
+                    "description": "This will always have the value \"GNU Terry Pratchett\"",
+                    "type": "string"
+                },
+                "creationTime": {
+                    "description": "Time the export was created",
+                    "type": "string"
+                },
+                "data": {
+                    "description": "The exported data",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "version": {
+                    "description": "The version of the backend the export was made with",
+                    "type": "string"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1654,6 +1654,44 @@
                 }
             }
         },
+        "/v4/export": {
+            "get": {
+                "description": "Exports all resources for the instance",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Export"
+                ],
+                "summary": "Export",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v4.ExportResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/v4.ExportResponse"
+                        }
+                    }
+                }
+            },
+            "options": {
+                "description": "Returns an empty response with the HTTP Header \"allow\" set to the allowed HTTP verbs",
+                "tags": [
+                    "Export"
+                ],
+                "summary": "Allowed HTTP verbs",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
         "/v4/goals": {
             "get": {
                 "description": "Returns a list of goals",
@@ -3449,7 +3487,7 @@
                     }
                 },
                 "error": {
-                    "description": "FIMXE: make this *error for ALL responses",
+                    "description": "The error, if any occurred",
                     "type": "string",
                     "example": "the specified resource ID is not a valid UUID"
                 }
@@ -4007,6 +4045,33 @@
                     "description": "The error, if any occurred",
                     "type": "string",
                     "example": "the specified resource ID is not a valid UUID"
+                }
+            }
+        },
+        "v4.ExportResponse": {
+            "type": "object",
+            "properties": {
+                "clacks": {
+                    "description": "This will always have the value \"GNU Terry Pratchett\"",
+                    "type": "string"
+                },
+                "creationTime": {
+                    "description": "Time the export was created",
+                    "type": "string"
+                },
+                "data": {
+                    "description": "The exported data",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "version": {
+                    "description": "The version of the backend the export was made with",
+                    "type": "string"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -293,7 +293,7 @@ definitions:
           $ref: '#/definitions/v4.BudgetResponse'
         type: array
       error:
-        description: 'FIMXE: make this *error for ALL responses'
+        description: The error, if any occurred
         example: the specified resource ID is not a valid UUID
         type: string
     type: object
@@ -699,6 +699,25 @@ definitions:
       error:
         description: The error, if any occurred
         example: the specified resource ID is not a valid UUID
+        type: string
+    type: object
+  v4.ExportResponse:
+    properties:
+      clacks:
+        description: This will always have the value "GNU Terry Pratchett"
+        type: string
+      creationTime:
+        description: Time the export was created
+        type: string
+      data:
+        additionalProperties:
+          items:
+            type: integer
+          type: array
+        description: The exported data
+        type: object
+      version:
+        description: The version of the backend the export was made with
         type: string
     type: object
   v4.Goal:
@@ -2493,6 +2512,32 @@ paths:
       summary: Update MonthConfig
       tags:
       - Envelopes
+  /v4/export:
+    get:
+      description: Exports all resources for the instance
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v4.ExportResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/v4.ExportResponse'
+      summary: Export
+      tags:
+      - Export
+    options:
+      description: Returns an empty response with the HTTP Header "allow" set to the
+        allowed HTTP verbs
+      responses:
+        "204":
+          description: No Content
+      summary: Allowed HTTP verbs
+      tags:
+      - Export
   /v4/goals:
     get:
       description: Returns a list of goals

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envelope-zero/backend/v5
 
-go 1.20
+go 1.22
 
 require (
 	github.com/gin-contrib/cors v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,7 @@ github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcP
 github.com/gin-contrib/cors v1.7.1 h1:s9SIppU/rk8enVvkzwiC2VK3UZ/0NNGsWfUKvV55rqs=
 github.com/gin-contrib/cors v1.7.1/go.mod h1:n/Zj7B4xyrgk/cX1WCX2dkzFfaNm/xJb6oIUk7WTtps=
 github.com/gin-contrib/gzip v0.0.6 h1:NjcunTcGAj5CO1gn4N8jHOSIeRFHIbn51z6K+xaN4d4=
+github.com/gin-contrib/gzip v0.0.6/go.mod h1:QOJlmV2xmayAjkNS2Y8NQsMneuRShOU/kjovCXNuzzk=
 github.com/gin-contrib/logger v1.1.1 h1:78Qzfpx3JvpnNX/6bErifIcnFqwbVKl2gS5WGExFPOs=
 github.com/gin-contrib/logger v1.1.1/go.mod h1:Cmqqcc6Yce4+r776VET1AcU4ydAR6sMKuDtBKLje20Y=
 github.com/gin-contrib/pprof v1.4.0 h1:XxiBSf5jWZ5i16lNOPbMTVdgHBdhfGRD5PZ1LWazzvg=
@@ -59,6 +60,7 @@ github.com/go-openapi/swag v0.22.4 h1:QLMzNJnMGPRNDCbySlcj1x01tzU8/9LTTL9hZZZogB
 github.com/go-openapi/swag v0.22.4/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.0/go.mod h1:sawfccIbzZTqEDETgFXqTho0QybSa7l++s0DH+LDiLs=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
@@ -75,8 +77,10 @@ github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26 h1:Xim43kblpZXfIBQsbuBVKCudVG457BR2GZFIz3uw3hQ=
+github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26/go.mod h1:dDKJzRmX4S37WGHujM7tX//fmj1uioxKzKxz3lo4HJo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
@@ -95,6 +99,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -140,6 +145,7 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qq
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.32.0 h1:keLypqrlIjaFsbmJOBdB/qvyF8KEtCWHwobLp5l/mQ0=
 github.com/rs/zerolog v1.32.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
@@ -185,6 +191,7 @@ golang.org/x/exp v0.0.0-20240213143201-ec583247a57a h1:HinSgX1tJRX3KsL//Gxynpw5C
 golang.org/x/exp v0.0.0-20240213143201-ec583247a57a/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.15.0 h1:SernR4v+D55NyBH2QiEQrlBAnj1ECL6AGrA5+dPaMY8=
+golang.org/x/mod v0.15.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=

--- a/pkg/controllers/v4/budget_types.go
+++ b/pkg/controllers/v4/budget_types.go
@@ -65,7 +65,6 @@ type BudgetListResponse struct {
 }
 
 type BudgetCreateResponse struct {
-	// FIMXE: make this *error for ALL responses
 	Error *string          `json:"error" example:"the specified resource ID is not a valid UUID"` // The error, if any occurred
 	Data  []BudgetResponse `json:"data"`                                                          // List of created Budgets
 }

--- a/pkg/controllers/v4/export.go
+++ b/pkg/controllers/v4/export.go
@@ -1,0 +1,62 @@
+package v4
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"time"
+
+	"github.com/envelope-zero/backend/v5/pkg/httputil"
+	"github.com/envelope-zero/backend/v5/pkg/models"
+	"github.com/gin-gonic/gin"
+)
+
+var backendVersion string
+
+func RegisterExportRoutes(r *gin.RouterGroup, version string) {
+	backendVersion = version
+
+	{
+		r.OPTIONS("", OptionsExport)
+		r.GET("", GetExport)
+	}
+}
+
+// @Summary		Allowed HTTP verbs
+// @Description	Returns an empty response with the HTTP Header "allow" set to the allowed HTTP verbs
+// @Tags			Export
+// @Success		204
+// @Router			/v4/export [options]
+func OptionsExport(c *gin.Context) {
+	httputil.OptionsGet(c)
+}
+
+// @Summary		Export
+// @Description	Exports all resources for the instance
+// @Tags			Export
+// @Produce		json
+// @Success		200	{object}	ExportResponse
+// @Failure		500	{object}	ExportResponse
+// @Router			/v4/export [get]
+func GetExport(c *gin.Context) {
+	resources := make(map[string]json.RawMessage)
+
+	for _, model := range models.Registry {
+		b, err := model.Export()
+		if err != nil {
+			c.JSON(status(err), httpError{
+				Error: err.Error(),
+			})
+			return
+		}
+
+		resources[reflect.TypeOf(model).Name()] = b
+	}
+
+	c.JSON(http.StatusOK, ExportResponse{
+		Version:      backendVersion,
+		Data:         resources,
+		CreationTime: time.Now(),
+		Clacks:       "GNU Terry Pratchett",
+	})
+}

--- a/pkg/controllers/v4/export_test.go
+++ b/pkg/controllers/v4/export_test.go
@@ -1,0 +1,55 @@
+package v4_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	v4 "github.com/envelope-zero/backend/v5/pkg/controllers/v4"
+	"github.com/envelope-zero/backend/v5/pkg/models"
+	"github.com/envelope-zero/backend/v5/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExport verifies that the export works correctly
+//
+// Thorough checks are only executed for the non-data fields since
+// the data fields are populated by the Export() methods of the models
+func (suite *TestSuiteStandard) TestExport() {
+	t := suite.T()
+
+	b := createTestBudget(t, v4.BudgetEditable{})
+	c := createTestCategory(t, v4.CategoryEditable{BudgetID: b.Data.ID})
+
+	recorder := test.Request(t, http.MethodGet, "http://example.com/v4/export", "")
+	test.AssertHTTPStatus(t, &recorder, http.StatusOK)
+
+	var response v4.ExportResponse
+	test.DecodeResponse(t, &recorder, &response)
+
+	// Verify the version and clacks fields
+	assert.Equal(t, "GNU Terry Pratchett", response.Clacks)
+	assert.Equal(t, "0.0.0", response.Version)
+
+	// Not sure if this is a good test, if it ever fails we'll re-evaluate
+	now := time.Now()
+	difference := response.CreationTime.Sub(now).Seconds()
+	assert.Less(t, difference, float64(1))
+
+	// Basic tests for the data fields. Full testing is done in the respective Export() methods
+	// of the models
+	assert.Len(t, response.Data, len(models.Registry), "Number of models in export does not match registry")
+
+	// CreatedAt check for budget
+	var budgets []models.Budget
+	require.Nil(t, json.Unmarshal(response.Data["Budget"], &budgets))
+	require.Len(t, budgets, 1, "Number of budgets in export must be 1")
+	assert.Equal(t, b.Data.CreatedAt, budgets[0].CreatedAt)
+
+	// CreatedAt check for category
+	var categories []models.Category
+	require.Nil(t, json.Unmarshal(response.Data["Category"], &categories))
+	require.Len(t, categories, 1, "Number of categories in export must be 1")
+	assert.Equal(t, c.Data.CreatedAt, categories[0].CreatedAt)
+}

--- a/pkg/controllers/v4/export_types.go
+++ b/pkg/controllers/v4/export_types.go
@@ -1,0 +1,13 @@
+package v4
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type ExportResponse struct {
+	Version      string                     `json:"version"`      // The version of the backend the export was made with
+	Data         map[string]json.RawMessage `json:"data"`         // The exported data
+	CreationTime time.Time                  `json:"creationTime"` // Time the export was created
+	Clacks       string                     `json:"clacks"`       // This will always have the value "GNU Terry Pratchett"
+}

--- a/pkg/controllers/v4/test_options_test.go
+++ b/pkg/controllers/v4/test_options_test.go
@@ -18,6 +18,7 @@ func (suite *TestSuiteStandard) TestOptionsHeaderResources() {
 		{"http://example.com/v4/budgets", "OPTIONS, GET, POST"},
 		{"http://example.com/v4/categories", "OPTIONS, GET, POST"},
 		{"http://example.com/v4/envelopes", "OPTIONS, GET, POST"},
+		{"http://example.com/v4/export", "OPTIONS, GET"},
 		{"http://example.com/v4/goals", "OPTIONS, GET, POST"},
 		{"http://example.com/v4/import", "OPTIONS, GET"},
 		{"http://example.com/v4/import/ynab-import-preview", "OPTIONS, POST"},

--- a/pkg/models/account_test.go
+++ b/pkg/models/account_test.go
@@ -1,6 +1,7 @@
 package models_test
 
 import (
+	"encoding/json"
 	"strconv"
 	"strings"
 	"time"
@@ -371,4 +372,29 @@ func (suite *TestSuiteStandard) TestAccountRecentEnvelopes() {
 	suite.Assert().Equal(nilUUIDPointer, ids[1])
 
 	// Order for envelopes with the same frequency is undefined
+}
+
+func (suite *TestSuiteStandard) TestAccountExport() {
+	t := suite.T()
+
+	budget := suite.createTestBudget(models.Budget{
+		Name: "TestAccountExport",
+	})
+
+	for range 2 {
+		_ = suite.createTestAccount(models.Account{BudgetID: budget.ID})
+	}
+
+	raw, err := models.Account{}.Export()
+	if err != nil {
+		require.Fail(t, "account export failed", err)
+	}
+
+	var accounts []models.Account
+	err = json.Unmarshal(raw, &accounts)
+	if err != nil {
+		require.Fail(t, "JSON could not be unmarshaled", err)
+	}
+
+	require.Len(t, accounts, 2, "Number of accounts in export is wrong")
 }

--- a/pkg/models/budget.go
+++ b/pkg/models/budget.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/envelope-zero/backend/v5/internal/types"
@@ -14,9 +15,9 @@ import (
 // resources reference it directly or transitively.
 type Budget struct {
 	DefaultModel
-	Name     string
-	Note     string
-	Currency string
+	Name     string `json:"name"`
+	Note     string `json:"note"`
+	Currency string `json:"currency"`
 }
 
 func (b *Budget) BeforeSave(_ *gorm.DB) error {
@@ -96,4 +97,19 @@ func (b Budget) Allocated(db *gorm.DB, month types.Month) (allocated decimal.Dec
 	}
 
 	return
+}
+
+// Returns all budgets on this instance for export
+func (Budget) Export() (json.RawMessage, error) {
+	var budgets []Budget
+	err := DB.Unscoped().Where(&Budget{}).Find(&budgets).Error
+	if err != nil {
+		return nil, err
+	}
+
+	j, err := json.Marshal(&budgets)
+	if err != nil {
+		return json.RawMessage{}, err
+	}
+	return json.RawMessage(j), nil
 }

--- a/pkg/models/budget_test.go
+++ b/pkg/models/budget_test.go
@@ -1,6 +1,7 @@
 package models_test
 
 import (
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/envelope-zero/backend/v5/pkg/models"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func (suite *TestSuiteStandard) TestBudgetTrimWhitespace() {
@@ -197,4 +199,25 @@ func (suite *TestSuiteStandard) TestBudgetBudgetedDBFail() {
 
 	_, err := budget.Allocated(models.DB, types.NewMonth(200, 2))
 	suite.Assert().ErrorIs(err, models.ErrGeneral)
+}
+
+func (suite *TestSuiteStandard) TestBudgetExport() {
+	t := suite.T()
+
+	_ = suite.createTestBudget(models.Budget{
+		Name: "TestBudgetExport",
+	})
+
+	raw, err := models.Budget{}.Export()
+	if err != nil {
+		require.Fail(t, "budget export failed", err)
+	}
+
+	var budgets []models.Budget
+	err = json.Unmarshal(raw, &budgets)
+	if err != nil {
+		require.Fail(t, "JSON could not be unmarshaled", err)
+	}
+
+	require.Len(t, budgets, 1, "Number of budgets in export is wrong")
 }

--- a/pkg/models/category.go
+++ b/pkg/models/category.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 
@@ -11,7 +12,7 @@ import (
 // Category represents a category of envelopes.
 type Category struct {
 	DefaultModel
-	Budget   Budget
+	Budget   Budget    `json:"-"`
 	BudgetID uuid.UUID `gorm:"uniqueIndex:category_budget_name"`
 	Name     string    `gorm:"uniqueIndex:category_budget_name"`
 	Note     string
@@ -78,4 +79,19 @@ func (c *Category) Envelopes(tx *gorm.DB) ([]Envelope, error) {
 	}
 
 	return envelopes, nil
+}
+
+// Returns all categories on this instance for export
+func (Category) Export() (json.RawMessage, error) {
+	var categories []Category
+	err := DB.Unscoped().Where(&Category{}).Find(&categories).Error
+	if err != nil {
+		return nil, err
+	}
+
+	j, err := json.Marshal(&categories)
+	if err != nil {
+		return json.RawMessage{}, err
+	}
+	return json.RawMessage(j), nil
 }

--- a/pkg/models/category_test.go
+++ b/pkg/models/category_test.go
@@ -1,10 +1,13 @@
 package models_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/envelope-zero/backend/v5/pkg/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func (suite *TestSuiteStandard) TestCategoryTrimWhitespace() {
@@ -90,4 +93,27 @@ func (suite *TestSuiteStandard) TestCategorySetEnvelopesDBFail() {
 
 	_, err := category.Envelopes(models.DB)
 	suite.Assert().ErrorIs(err, models.ErrGeneral)
+}
+
+func (suite *TestSuiteStandard) TestCategoryExport() {
+	t := suite.T()
+
+	budget := suite.createTestBudget(models.Budget{})
+
+	for i := range 2 {
+		_ = suite.createTestCategory(models.Category{BudgetID: budget.ID, Name: fmt.Sprint(i)})
+	}
+
+	raw, err := models.Category{}.Export()
+	if err != nil {
+		require.Fail(t, "category export failed", err)
+	}
+
+	var categories []models.Category
+	err = json.Unmarshal(raw, &categories)
+	if err != nil {
+		require.Fail(t, "JSON could not be unmarshaled", err)
+	}
+
+	require.Len(t, categories, 2, "Number of categories in export is wrong")
 }

--- a/pkg/models/interfaces.go
+++ b/pkg/models/interfaces.go
@@ -1,0 +1,23 @@
+package models
+
+import "encoding/json"
+
+// Model is an interface that
+type Model interface {
+	Export() (json.RawMessage, error) // All instances of this model for export.
+}
+
+// The "Registry" is a slice of all models available
+//
+// It is maintained so that operations that affect all models do not need to explicitly iterate over every single model,
+// increasing the risk of forgetting something when adding a new model
+var Registry = []Model{
+	Account{},
+	Budget{},
+	Category{},
+	Envelope{},
+	Goal{},
+	MatchRule{},
+	MonthConfig{},
+	Transaction{},
+}

--- a/pkg/models/match_rule.go
+++ b/pkg/models/match_rule.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"encoding/json"
+
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
@@ -34,4 +36,19 @@ func (m *MatchRule) BeforeUpdate(tx *gorm.DB) (err error) {
 // checkIntegrity verifies references to other resources
 func (m *MatchRule) checkIntegrity(tx *gorm.DB, toSave MatchRule) error {
 	return tx.First(&Account{}, toSave.AccountID).Error
+}
+
+// Returns all match rules on this instance for export
+func (MatchRule) Export() (json.RawMessage, error) {
+	var matchRules []MatchRule
+	err := DB.Unscoped().Where(&MatchRule{}).Find(&matchRules).Error
+	if err != nil {
+		return nil, err
+	}
+
+	j, err := json.Marshal(&matchRules)
+	if err != nil {
+		return json.RawMessage{}, err
+	}
+	return json.RawMessage(j), nil
 }

--- a/pkg/models/match_rule_test.go
+++ b/pkg/models/match_rule_test.go
@@ -1,11 +1,13 @@
 package models_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/envelope-zero/backend/v5/pkg/models"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func (suite *TestSuiteStandard) TestMatchRuleBeforeCreate() {
@@ -48,4 +50,28 @@ func (suite *TestSuiteStandard) TestMatchRuleBeforeUpdate() {
 			assert.ErrorIs(t, err, tt.err)
 		})
 	}
+}
+
+func (suite *TestSuiteStandard) TestMatchRuleExport() {
+	t := suite.T()
+
+	budget := suite.createTestBudget(models.Budget{})
+	account := suite.createTestAccount(models.Account{BudgetID: budget.ID})
+
+	for range 2 {
+		_ = suite.createTestMatchRule(models.MatchRule{AccountID: account.ID})
+	}
+
+	raw, err := models.MatchRule{}.Export()
+	if err != nil {
+		require.Fail(t, "match rule export failed", err)
+	}
+
+	var matchRules []models.MatchRule
+	err = json.Unmarshal(raw, &matchRules)
+	if err != nil {
+		require.Fail(t, "JSON could not be unmarshaled", err)
+	}
+
+	require.Len(t, matchRules, 2, "number of match rules in export is wrong")
 }

--- a/pkg/models/month_config.go
+++ b/pkg/models/month_config.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 
@@ -23,4 +24,19 @@ var ErrMonthConfigMonthNotUnique = errors.New("you can not create multiple month
 func (m *MonthConfig) BeforeSave(_ *gorm.DB) error {
 	m.Note = strings.TrimSpace(m.Note)
 	return nil
+}
+
+// Returns all match rules on this instance for export
+func (MonthConfig) Export() (json.RawMessage, error) {
+	var monthConfigs []MonthConfig
+	err := DB.Unscoped().Where(&MonthConfig{}).Find(&monthConfigs).Error
+	if err != nil {
+		return nil, err
+	}
+
+	j, err := json.Marshal(&monthConfigs)
+	if err != nil {
+		return json.RawMessage{}, err
+	}
+	return json.RawMessage(j), nil
 }

--- a/pkg/models/month_config_test.go
+++ b/pkg/models/month_config_test.go
@@ -1,10 +1,14 @@
 package models_test
 
 import (
+	"encoding/json"
 	"strings"
+	"time"
 
+	"github.com/envelope-zero/backend/v5/internal/types"
 	"github.com/envelope-zero/backend/v5/pkg/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func (suite *TestSuiteStandard) TestMonthConfigTrimWhitespace() {
@@ -20,4 +24,28 @@ func (suite *TestSuiteStandard) TestMonthConfigTrimWhitespace() {
 	})
 
 	assert.Equal(suite.T(), strings.TrimSpace(note), account.Note)
+}
+
+func (suite *TestSuiteStandard) TestMonthConfigExport() {
+	t := suite.T()
+
+	budget := suite.createTestBudget(models.Budget{})
+	category := suite.createTestCategory(models.Category{BudgetID: budget.ID})
+	envelope := suite.createTestEnvelope(models.Envelope{CategoryID: category.ID})
+
+	_ = suite.createTestMonthConfig(models.MonthConfig{EnvelopeID: envelope.ID, Month: types.NewMonth(1977, time.January)})
+	_ = suite.createTestMonthConfig(models.MonthConfig{EnvelopeID: envelope.ID, Month: types.NewMonth(1977, time.February)})
+
+	raw, err := models.MonthConfig{}.Export()
+	if err != nil {
+		require.Fail(t, "month config export failed", err)
+	}
+
+	var monthConfigs []models.MonthConfig
+	err = json.Unmarshal(raw, &monthConfigs)
+	if err != nil {
+		require.Fail(t, "JSON could not be unmarshaled", err)
+	}
+
+	require.Len(t, monthConfigs, 2, "Number of monthc configs in export is wrong")
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -157,6 +157,7 @@ func AttachRoutes(group *gin.RouterGroup) {
 		v4.RegisterBudgetRoutes(v4Group.Group("/budgets"))
 		v4.RegisterCategoryRoutes(v4Group.Group("/categories"))
 		v4.RegisterEnvelopeRoutes(v4Group.Group("/envelopes"))
+		v4.RegisterExportRoutes(v4Group.Group("/export"), version)
 		v4.RegisterGoalRoutes(v4Group.Group("/goals"))
 		v4.RegisterImportRoutes(v4Group.Group("/import"))
 		v4.RegisterMatchRuleRoutes(v4Group.Group("/match-rules"))

--- a/test/request.go
+++ b/test/request.go
@@ -67,7 +67,7 @@ func Request(t *testing.T, method, reqURL string, body any, headers ...map[strin
 }
 
 // DecodeResponse decodes an HTTP response into a target struct.
-func DecodeResponse(t *testing.T, r *httptest.ResponseRecorder, target interface{}) {
+func DecodeResponse(t *testing.T, r *httptest.ResponseRecorder, target any) {
 	err := json.NewDecoder(r.Body).Decode(target)
 	if err != nil {
 		assert.FailNow(t, "Parsing error", "Unable to parse response from server %q into %v, '%v', Request ID: %s", r.Body, reflect.TypeOf(target), err, r.Result().Header.Get("x-request-id"))


### PR DESCRIPTION
This adds functionality to export the whole state of the instance with an API call.
The API call to /v4/export returns a JSON object with some meta information:

* the version used to generate the export
* the creation time

With this change, go 1.22 is required since the tests now use range clauses over integers.

This commit also creates a registry for models so that we do not need to re-implement iteration over all models in the places we need it (database migrations, cleanup, …).
