### PR TITLE
feat: add filtering of transactions by availability

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,6 @@ issues:
 
 linters:
   enable:
-    - gocyclo
     - gofumpt
     - goimports
     - govet
@@ -32,5 +31,3 @@ linters:
 linters-settings:
   gofumpt:
     extra-rules: true
-  gocyclo:
-    min-complexity: 25

--- a/api/docs.go
+++ b/api/docs.go
@@ -2724,6 +2724,24 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "description": "Availability date of the transaction. Ignores exact time, matches on the day of the RFC3339 timestamp provided.",
+                        "name": "availableFromDate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Transactions available at and after this date. Ignores exact time, matches on the day of the RFC3339 timestamp provided.",
+                        "name": "availableFromFromDate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Transactions available before and at this date. Ignores exact time, matches on the day of the RFC3339 timestamp provided.",
+                        "name": "availableFromUntilDate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by amount",
                         "name": "amount",
                         "in": "query"

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2713,6 +2713,24 @@
                     },
                     {
                         "type": "string",
+                        "description": "Availability date of the transaction. Ignores exact time, matches on the day of the RFC3339 timestamp provided.",
+                        "name": "availableFromDate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Transactions available at and after this date. Ignores exact time, matches on the day of the RFC3339 timestamp provided.",
+                        "name": "availableFromFromDate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Transactions available before and at this date. Ignores exact time, matches on the day of the RFC3339 timestamp provided.",
+                        "name": "availableFromUntilDate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by amount",
                         "name": "amount",
                         "in": "query"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3231,6 +3231,21 @@ paths:
         in: query
         name: untilDate
         type: string
+      - description: Availability date of the transaction. Ignores exact time, matches
+          on the day of the RFC3339 timestamp provided.
+        in: query
+        name: availableFromDate
+        type: string
+      - description: Transactions available at and after this date. Ignores exact
+          time, matches on the day of the RFC3339 timestamp provided.
+        in: query
+        name: availableFromFromDate
+        type: string
+      - description: Transactions available before and at this date. Ignores exact
+          time, matches on the day of the RFC3339 timestamp provided.
+        in: query
+        name: availableFromUntilDate
+        type: string
       - description: Filter by amount
         in: query
         name: amount

--- a/pkg/controllers/v4/transaction.go
+++ b/pkg/controllers/v4/transaction.go
@@ -115,6 +115,9 @@ func GetTransaction(c *gin.Context) {
 // @Param			date					query	string					false	"Date of the transaction. Ignores exact time, matches on the day of the RFC3339 timestamp provided."
 // @Param			fromDate				query	string					false	"Transactions at and after this date. Ignores exact time, matches on the day of the RFC3339 timestamp provided."
 // @Param			untilDate				query	string					false	"Transactions before and at this date. Ignores exact time, matches on the day of the RFC3339 timestamp provided."
+// @Param			availableFromDate		query	string					false	"Availability date of the transaction. Ignores exact time, matches on the day of the RFC3339 timestamp provided."
+// @Param			availableFromFromDate	query	string					false	"Transactions available at and after this date. Ignores exact time, matches on the day of the RFC3339 timestamp provided."
+// @Param			availableFromUntilDate	query	string					false	"Transactions available before and at this date. Ignores exact time, matches on the day of the RFC3339 timestamp provided."
 // @Param			amount					query	string					false	"Filter by amount"
 // @Param			amountLessOrEqual		query	string					false	"Amount less than or equal to this"
 // @Param			amountMoreOrEqual		query	string					false	"Amount more than or equal to this"
@@ -167,6 +170,20 @@ func GetTransactions(c *gin.Context) {
 
 	if !filter.UntilDate.IsZero() {
 		q = q.Where("transactions.date < date(?)", time.Date(filter.UntilDate.Year(), filter.UntilDate.Month(), filter.UntilDate.Day()+1, 0, 0, 0, 0, time.UTC))
+	}
+
+	// Filter for the transaction being available at the same date
+	if !filter.AvailableFromDate.IsZero() {
+		date := time.Date(filter.AvailableFromDate.Year(), filter.AvailableFromDate.Month(), filter.AvailableFromDate.Day(), 0, 0, 0, 0, time.UTC)
+		q = q.Where("transactions.available_from >= date(?)", date).Where("transactions.available_from < date(?)", date.AddDate(0, 0, 1))
+	}
+
+	if !filter.AvailableFromFromDate.IsZero() {
+		q = q.Where("transactions.available_from >= date(?)", time.Date(filter.AvailableFromFromDate.Year(), filter.AvailableFromFromDate.Month(), filter.AvailableFromFromDate.Day(), 0, 0, 0, 0, time.UTC))
+	}
+
+	if !filter.AvailableFromUntilDate.IsZero() {
+		q = q.Where("transactions.available_from < date(?)", time.Date(filter.AvailableFromUntilDate.Year(), filter.AvailableFromUntilDate.Month(), filter.AvailableFromUntilDate.Day()+1, 0, 0, 0, 0, time.UTC))
 	}
 
 	if filter.BudgetID != "" {

--- a/pkg/controllers/v4/transaction_types.go
+++ b/pkg/controllers/v4/transaction_types.go
@@ -120,23 +120,26 @@ const (
 )
 
 type TransactionQueryFilter struct {
-	Date                  time.Time            `form:"date" filterField:"false"`              // Exact date. Time is ignored.
-	FromDate              time.Time            `form:"fromDate" filterField:"false"`          // From this date. Time is ignored.
-	UntilDate             time.Time            `form:"untilDate" filterField:"false"`         // Until this date. Time is ignored.
-	Amount                decimal.Decimal      `form:"amount"`                                // Exact amount
-	AmountLessOrEqual     decimal.Decimal      `form:"amountLessOrEqual" filterField:"false"` // Amount less than or equal to this
-	AmountMoreOrEqual     decimal.Decimal      `form:"amountMoreOrEqual" filterField:"false"` // Amount more than or equal to this
-	Note                  string               `form:"note" filterField:"false"`              // Note contains this string
-	BudgetID              string               `form:"budget" filterField:"false"`            // ID of the budget
-	SourceAccountID       string               `form:"source"`                                // ID of the source account
-	DestinationAccountID  string               `form:"destination"`                           // ID of the destination account
-	Direction             TransactionDirection `form:"direction" filterField:"false"`         // Direction of the transaction
-	EnvelopeID            string               `form:"envelope"`                              // ID of the envelope
-	ReconciledSource      bool                 `form:"reconciledSource"`                      // Is the transaction reconciled in the source account?
-	ReconciledDestination bool                 `form:"reconciledDestination"`                 // Is the transaction reconciled in the destination account?
-	AccountID             string               `form:"account" filterField:"false"`           // ID of either source or destination account
-	Offset                uint                 `form:"offset" filterField:"false"`            // The offset of the first Transaction returned. Defaults to 0.
-	Limit                 int                  `form:"limit" filterField:"false"`             // Maximum number of transactions to return. Defaults to 50.
+	AvailableFromDate      time.Time            `form:"availableFromDate" filterField:"false"`      // Exact date. Time is ignored.
+	AvailableFromFromDate  time.Time            `form:"availableFromFromDate" filterField:"false"`  // From this date. Time is ignored.
+	AvailableFromUntilDate time.Time            `form:"availableFromUntilDate" filterField:"false"` // Until this date. Time is ignored.
+	Date                   time.Time            `form:"date" filterField:"false"`                   // Exact date. Time is ignored.
+	FromDate               time.Time            `form:"fromDate" filterField:"false"`               // From this date. Time is ignored.
+	UntilDate              time.Time            `form:"untilDate" filterField:"false"`              // Until this date. Time is ignored.
+	Amount                 decimal.Decimal      `form:"amount"`                                     // Exact amount
+	AmountLessOrEqual      decimal.Decimal      `form:"amountLessOrEqual" filterField:"false"`      // Amount less than or equal to this
+	AmountMoreOrEqual      decimal.Decimal      `form:"amountMoreOrEqual" filterField:"false"`      // Amount more than or equal to this
+	Note                   string               `form:"note" filterField:"false"`                   // Note contains this string
+	BudgetID               string               `form:"budget" filterField:"false"`                 // ID of the budget
+	SourceAccountID        string               `form:"source"`                                     // ID of the source account
+	DestinationAccountID   string               `form:"destination"`                                // ID of the destination account
+	Direction              TransactionDirection `form:"direction" filterField:"false"`              // Direction of the transaction
+	EnvelopeID             string               `form:"envelope"`                                   // ID of the envelope
+	ReconciledSource       bool                 `form:"reconciledSource"`                           // Is the transaction reconciled in the source account?
+	ReconciledDestination  bool                 `form:"reconciledDestination"`                      // Is the transaction reconciled in the destination account?
+	AccountID              string               `form:"account" filterField:"false"`                // ID of either source or destination account
+	Offset                 uint                 `form:"offset" filterField:"false"`                 // The offset of the first Transaction returned. Defaults to 0.
+	Limit                  int                  `form:"limit" filterField:"false"`                  // Maximum number of transactions to return. Defaults to 50.
 }
 
 func (f TransactionQueryFilter) model() (models.Transaction, error) {


### PR DESCRIPTION
With this, transactions can be filtered by their "Available From" date.

Also disables gocyclo as linter since I've just been bumping the limit anyways.

Resolves #1004.
