### PR TITLE
feat: filter by all ancestors

### DIFF
--- a/pkg/controllers/v4/envelope_types.go
+++ b/pkg/controllers/v4/envelope_types.go
@@ -89,6 +89,7 @@ type EnvelopeResponse struct {
 }
 
 type EnvelopeQueryFilter struct {
+	BudgetID   string `form:"budget" filterField:"false"` // By budget ID
 	CategoryID string `form:"category"`                   // By the ID of the category
 	Name       string `form:"name" filterField:"false"`   // By name
 	Note       string `form:"note" filterField:"false"`   // By the note

--- a/pkg/controllers/v4/goal_types.go
+++ b/pkg/controllers/v4/goal_types.go
@@ -94,6 +94,8 @@ type GoalResponse struct {
 }
 
 type GoalQueryFilter struct {
+	BudgetID          string          `form:"budget" filterField:"false"`            // By budget ID
+	CategoryID        string          `form:"category" filterField:"false"`          // By category ID
 	Name              string          `form:"name" filterField:"false"`              // By name
 	Note              string          `form:"note" filterField:"false"`              // By the note
 	Search            string          `form:"search" filterField:"false"`            // By string in name or note

--- a/pkg/controllers/v4/match_rule.go
+++ b/pkg/controllers/v4/match_rule.go
@@ -151,6 +151,22 @@ func GetMatchRules(c *gin.Context) {
 		q = q.Where("match = ''")
 	}
 
+	if filter.BudgetID != "" {
+		budgetID, err := httputil.UUIDFromString(filter.BudgetID)
+		if err != nil {
+			s := fmt.Sprintf("Error parsing budget ID for filtering: %s", err.Error())
+			c.JSON(status(err), MatchRuleListResponse{
+				Error: &s,
+			})
+			return
+		}
+
+		q = q.
+			Joins("JOIN accounts on accounts.id = match_rules.account_id").
+			Joins("JOIN budgets on budgets.id = accounts.budget_id").
+			Where("budgets.id = ?", budgetID)
+	}
+
 	// Set the offset. Does not need checking since the default is 0
 	q = q.Offset(int(filter.Offset))
 

--- a/pkg/controllers/v4/match_rule_test.go
+++ b/pkg/controllers/v4/match_rule_test.go
@@ -187,10 +187,11 @@ func (suite *TestSuiteStandard) TestMatchRulesDatabaseError() {
 
 // TestMatchRulesGetFilter verifies that filtering Match Rules works as expected.
 func (suite *TestSuiteStandard) TestMatchRulesGetFilter() {
-	b := createTestBudget(suite.T(), v4.BudgetEditable{})
+	b1 := createTestBudget(suite.T(), v4.BudgetEditable{})
+	b2 := createTestBudget(suite.T(), v4.BudgetEditable{})
 
-	a1 := createTestAccount(suite.T(), v4.AccountEditable{BudgetID: b.Data.ID, Name: "TestMatchRulesGetFilter 1"})
-	a2 := createTestAccount(suite.T(), v4.AccountEditable{BudgetID: b.Data.ID, Name: "TestMatchRulesGetFilter 2"})
+	a1 := createTestAccount(suite.T(), v4.AccountEditable{BudgetID: b1.Data.ID, Name: "TestMatchRulesGetFilter 1"})
+	a2 := createTestAccount(suite.T(), v4.AccountEditable{BudgetID: b2.Data.ID, Name: "TestMatchRulesGetFilter 2"})
 
 	_ = createTestMatchRule(suite.T(), v4.MatchRuleEditable{
 		Priority:  1,
@@ -215,6 +216,9 @@ func (suite *TestSuiteStandard) TestMatchRulesGetFilter() {
 		query string
 		len   int
 	}{
+		{"Budget 1", fmt.Sprintf("budget=%s", b1.Data.ID), 1},
+		{"Budget 2", fmt.Sprintf("budget=%s", b2.Data.ID), 2},
+		{"Budget does not match", fmt.Sprintf("budget=%s", uuid.New()), 0},
 		{"Limit over count", "limit=5", 3},
 		{"Limit under count", "limit=2", 2},
 		{"Offset", "offset=2", 1},

--- a/pkg/controllers/v4/match_rule_types.go
+++ b/pkg/controllers/v4/match_rule_types.go
@@ -81,6 +81,7 @@ func newMatchRule(c *gin.Context, model models.MatchRule) MatchRule {
 
 // MatchRuleQueryFilter contains the fields that Match Rules can be filtered with.
 type MatchRuleQueryFilter struct {
+	BudgetID  string `form:"budget" filterField:"false"` // By budget ID
 	Priority  uint   `form:"priority"`                   // By priority
 	Match     string `form:"match" filterField:"false"`  // By match
 	AccountID string `form:"account"`                    // By ID of the Account they map to


### PR DESCRIPTION
Envelopes, match rules and goals can now be filtered by all ancestors.

With this, clients can now request e.g. all envelopes for a budget instead of
requesting all categories and then having to loop over these, requesting all envelopes
for each category.

This partially implements #924, month configs still need to be added.