### PR TITLE
docs: better expectation management for vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,12 @@
 
 ## Reporting a Vulnerability
 
-Please do not open an issue if you find a vulnerability. Send an email to security@envelope-zero.org and a maintainer will get in touch with you as soon as possible. This might take up to 72 hours.
+Please _do not_ open an issue if you find a vulnerability. Send an email to security@envelope-zero.org and a maintainer will get in touch with you.
+Please note that this project is maintained by volunteers and therefore, an answer might take some time.
 
-You will be kept up to date with all developments via email.
+Please provide at least the following information in your report:
 
-Once your report has been checked and the vulnerability is confirmed, it will be patched as soon as possible and issue a security advisory will be released with the patch.
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by a team of volunteers on a reasonable-effort basis. As such, please give us at least 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Better expectation management for vulnerabilities.

This adds more info about **who** maintains this and when to expect a reply.