### PR TITLE
fix: response for wrong filter directions can now be unmarshaled

### DIFF
--- a/pkg/controllers/v4/transaction.go
+++ b/pkg/controllers/v4/transaction.go
@@ -227,6 +227,7 @@ func GetTransactions(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, TransactionListResponse{
 				Error: &s,
 			})
+			return
 		}
 
 		if filter.Direction == DirectionTransfer {

--- a/pkg/controllers/v4/transaction_test.go
+++ b/pkg/controllers/v4/transaction_test.go
@@ -309,6 +309,12 @@ func (suite *TestSuiteStandard) TestTransactionsGetInvalidQuery() {
 		suite.T().Run(tt, func(t *testing.T) {
 			recorder := test.Request(t, http.MethodGet, fmt.Sprintf("http://example.com/v4/transactions?%s", tt), "")
 			test.AssertHTTPStatus(t, &recorder, http.StatusBadRequest)
+
+			var body v4.TransactionListResponse
+			test.DecodeResponse(t, &recorder, &body)
+
+			assert.Len(t, body.Data, 0)
+			assert.NotEmpty(t, body.Error)
 		})
 	}
 }

--- a/test/request.go
+++ b/test/request.go
@@ -68,7 +68,7 @@ func Request(t *testing.T, method, reqURL string, body any, headers ...map[strin
 
 // DecodeResponse decodes an HTTP response into a target struct.
 func DecodeResponse(t *testing.T, r *httptest.ResponseRecorder, target any) {
-	err := json.NewDecoder(r.Body).Decode(target)
+	err := json.Unmarshal(r.Body.Bytes(), &target)
 	if err != nil {
 		assert.FailNow(t, "Parsing error", "Unable to parse response from server %q into %v, '%v', Request ID: %s", r.Body, reflect.TypeOf(target), err, r.Result().Header.Get("x-request-id"))
 	}


### PR DESCRIPTION
Requesting a transaction list with an invalid direction led to a response that was not valid JSON.

This was due to the Unmarshaling in tests not being done correctly.

This PR resolves the Unmarshal error and the broken response at the same time. 
