### PR TITLE
chore: remove UUID parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,14 +12,6 @@ repos:
     hooks:
       - id: shellcheck
 
-  - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.1
-    hooks:
-      - id: go-mod-tidy
-      - id: golangci-lint
-        args:
-          - "--timeout=5m"
-
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:
@@ -60,3 +52,11 @@ repos:
         # This contains "FIMXE" because I often mistype it
         entry: '(^|//!?|#|<!--|;|/\*(\*|!)?|\.\.)\s*(FIXME:|FIMXE:|BUG:)(?!#i#)'
         exclude: CONTRIBUTING.md
+
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
+    hooks:
+      - id: go-mod-tidy
+      - id: golangci-lint
+        args:
+          - "--timeout=5m"

--- a/api/docs.go
+++ b/api/docs.go
@@ -355,6 +355,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -400,6 +401,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -439,6 +441,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -481,6 +484,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -537,6 +541,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -707,6 +712,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -749,6 +755,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -788,6 +795,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -833,6 +841,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1027,6 +1036,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1069,6 +1079,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1108,6 +1119,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1153,6 +1165,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1347,6 +1360,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1389,6 +1403,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1428,6 +1443,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1473,6 +1489,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1529,6 +1546,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1579,6 +1597,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1617,6 +1636,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1893,6 +1913,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1935,6 +1956,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1974,6 +1996,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -2019,6 +2042,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -2362,6 +2386,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -2404,6 +2429,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -2443,6 +2469,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -2488,6 +2515,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -2932,6 +2960,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -2974,6 +3003,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -3013,6 +3043,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -3058,6 +3089,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",

--- a/api/docs.go
+++ b/api/docs.go
@@ -355,7 +355,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -400,7 +400,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -439,7 +439,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -481,7 +481,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -537,7 +537,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true

--- a/api/docs.go
+++ b/api/docs.go
@@ -1890,7 +1890,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1932,7 +1932,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1971,7 +1971,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2016,7 +2016,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true

--- a/api/docs.go
+++ b/api/docs.go
@@ -355,7 +355,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -400,7 +400,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -439,7 +439,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -481,7 +481,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -537,7 +537,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -707,7 +707,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -749,7 +749,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -788,7 +788,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -833,7 +833,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1027,7 +1027,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1069,7 +1069,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1108,7 +1108,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1153,7 +1153,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1347,7 +1347,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1389,7 +1389,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1428,7 +1428,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1473,7 +1473,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1529,14 +1529,15 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID of the Envelope",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "The month in YYYY-MM format",
+                        "example": "2013-11",
+                        "description": "Year and month in YYYY-MM format",
                         "name": "month",
                         "in": "path",
                         "required": true
@@ -1578,14 +1579,15 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID of the Envelope",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "The month in YYYY-MM format",
+                        "example": "2013-11",
+                        "description": "Year and month in YYYY-MM format",
                         "name": "month",
                         "in": "path",
                         "required": true
@@ -1615,14 +1617,15 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID of the Envelope",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "The month in YYYY-MM format",
+                        "example": "2013-11",
+                        "description": "Year and month in YYYY-MM format",
                         "name": "month",
                         "in": "path",
                         "required": true
@@ -1890,7 +1893,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1932,7 +1935,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1971,7 +1974,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2016,7 +2019,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2359,7 +2362,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2401,7 +2404,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2440,7 +2443,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2485,7 +2488,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2550,8 +2553,7 @@ const docTemplate = `{
                         "type": "string",
                         "description": "The month in YYYY-MM format",
                         "name": "month",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/api/docs.go
+++ b/api/docs.go
@@ -2932,7 +2932,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2974,7 +2974,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -3013,7 +3013,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -3058,7 +3058,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true

--- a/api/docs.go
+++ b/api/docs.go
@@ -2551,7 +2551,8 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "The month in YYYY-MM format",
+                        "example": "2022-07",
+                        "description": "Year and month in YYYY-MM format",
                         "name": "month",
                         "in": "query"
                     }

--- a/api/docs.go
+++ b/api/docs.go
@@ -648,8 +648,8 @@ const docTemplate = `{
                 "summary": "Create budget",
                 "parameters": [
                     {
-                        "description": "Budget",
-                        "name": "budget",
+                        "description": "Budgets",
+                        "name": "budgets",
                         "in": "body",
                         "required": true,
                         "schema": {
@@ -707,7 +707,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -749,7 +749,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -788,7 +788,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -833,7 +833,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true

--- a/api/docs.go
+++ b/api/docs.go
@@ -1027,7 +1027,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1069,7 +1069,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1108,7 +1108,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1153,7 +1153,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true

--- a/api/docs.go
+++ b/api/docs.go
@@ -2111,9 +2111,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "ID of the account to import transactions for",
+                        "description": "ID of the account to import the transactions for",
                         "name": "accountId",
-                        "in": "query"
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -2179,9 +2180,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Name of the Budget to create",
+                        "description": "Name for the new budget",
                         "name": "budgetName",
-                        "in": "query"
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/api/docs.go
+++ b/api/docs.go
@@ -1559,6 +1559,22 @@ const docTemplate = `{
                         "name": "month",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "UUID",
+                        "description": "ID of the resource",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "2013-11",
+                        "description": "Year and month in YYYY-MM format",
+                        "name": "month",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -1610,6 +1626,22 @@ const docTemplate = `{
                         "name": "month",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "UUID",
+                        "description": "ID of the resource",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "2013-11",
+                        "description": "Year and month in YYYY-MM format",
+                        "name": "month",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -1634,6 +1666,22 @@ const docTemplate = `{
                 ],
                 "summary": "Update MonthConfig",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "format": "UUID",
+                        "description": "ID of the resource",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "2013-11",
+                        "description": "Year and month in YYYY-MM format",
+                        "name": "month",
+                        "in": "path",
+                        "required": true
+                    },
                     {
                         "type": "string",
                         "format": "UUID",

--- a/api/docs.go
+++ b/api/docs.go
@@ -2359,7 +2359,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2401,7 +2401,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2440,7 +2440,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2485,7 +2485,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true

--- a/api/docs.go
+++ b/api/docs.go
@@ -1283,7 +1283,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "description": "Envelopes",
-                        "name": "envelope",
+                        "name": "envelopes",
                         "in": "body",
                         "required": true,
                         "schema": {
@@ -1347,7 +1347,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1389,7 +1389,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1428,7 +1428,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1473,7 +1473,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2921,7 +2921,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2963,7 +2963,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -3002,7 +3002,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -3047,7 +3047,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -344,7 +344,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -389,7 +389,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -428,7 +428,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -470,7 +470,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -526,7 +526,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1879,7 +1879,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1921,7 +1921,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1960,7 +1960,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2005,7 +2005,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1548,6 +1548,22 @@
                         "name": "month",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "UUID",
+                        "description": "ID of the resource",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "2013-11",
+                        "description": "Year and month in YYYY-MM format",
+                        "name": "month",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -1599,6 +1615,22 @@
                         "name": "month",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "UUID",
+                        "description": "ID of the resource",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "2013-11",
+                        "description": "Year and month in YYYY-MM format",
+                        "name": "month",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -1623,6 +1655,22 @@
                 ],
                 "summary": "Update MonthConfig",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "format": "UUID",
+                        "description": "ID of the resource",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "2013-11",
+                        "description": "Year and month in YYYY-MM format",
+                        "name": "month",
+                        "in": "path",
+                        "required": true
+                    },
                     {
                         "type": "string",
                         "format": "UUID",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1016,7 +1016,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1058,7 +1058,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1097,7 +1097,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1142,7 +1142,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -344,6 +344,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -389,6 +390,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -428,6 +430,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -470,6 +473,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -526,6 +530,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -696,6 +701,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -738,6 +744,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -777,6 +784,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -822,6 +830,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1016,6 +1025,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1058,6 +1068,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1097,6 +1108,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1142,6 +1154,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1336,6 +1349,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1378,6 +1392,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1417,6 +1432,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1462,6 +1478,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1518,6 +1535,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1568,6 +1586,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1606,6 +1625,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1882,6 +1902,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1924,6 +1945,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -1963,6 +1985,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -2008,6 +2031,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -2351,6 +2375,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -2393,6 +2418,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -2432,6 +2458,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -2477,6 +2504,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -2921,6 +2949,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -2963,6 +2992,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -3002,6 +3032,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
@@ -3047,6 +3078,7 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "format": "UUID",
                         "description": "ID of the resource",
                         "name": "id",
                         "in": "path",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2100,9 +2100,10 @@
                     },
                     {
                         "type": "string",
-                        "description": "ID of the account to import transactions for",
+                        "description": "ID of the account to import the transactions for",
                         "name": "accountId",
-                        "in": "query"
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -2168,9 +2169,10 @@
                     },
                     {
                         "type": "string",
-                        "description": "Name of the Budget to create",
+                        "description": "Name for the new budget",
                         "name": "budgetName",
-                        "in": "query"
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2540,7 +2540,8 @@
                     },
                     {
                         "type": "string",
-                        "description": "The month in YYYY-MM format",
+                        "example": "2022-07",
+                        "description": "Year and month in YYYY-MM format",
                         "name": "month",
                         "in": "query"
                     }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2348,7 +2348,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2390,7 +2390,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2429,7 +2429,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2474,7 +2474,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1272,7 +1272,7 @@
                 "parameters": [
                     {
                         "description": "Envelopes",
-                        "name": "envelope",
+                        "name": "envelopes",
                         "in": "body",
                         "required": true,
                         "schema": {
@@ -1336,7 +1336,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1378,7 +1378,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1417,7 +1417,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1462,7 +1462,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -637,8 +637,8 @@
                 "summary": "Create budget",
                 "parameters": [
                     {
-                        "description": "Budget",
-                        "name": "budget",
+                        "description": "Budgets",
+                        "name": "budgets",
                         "in": "body",
                         "required": true,
                         "schema": {
@@ -696,7 +696,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -738,7 +738,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -777,7 +777,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -822,7 +822,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID formatted as string",
+                        "description": "The ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -344,7 +344,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -389,7 +389,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -428,7 +428,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -470,7 +470,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -526,7 +526,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -696,7 +696,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -738,7 +738,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -777,7 +777,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -822,7 +822,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1016,7 +1016,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1058,7 +1058,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1097,7 +1097,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1142,7 +1142,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1336,7 +1336,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1378,7 +1378,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1417,7 +1417,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1462,7 +1462,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1518,14 +1518,15 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID of the Envelope",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "The month in YYYY-MM format",
+                        "example": "2013-11",
+                        "description": "Year and month in YYYY-MM format",
                         "name": "month",
                         "in": "path",
                         "required": true
@@ -1567,14 +1568,15 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID of the Envelope",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "The month in YYYY-MM format",
+                        "example": "2013-11",
+                        "description": "Year and month in YYYY-MM format",
                         "name": "month",
                         "in": "path",
                         "required": true
@@ -1604,14 +1606,15 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "ID of the Envelope",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "The month in YYYY-MM format",
+                        "example": "2013-11",
+                        "description": "Year and month in YYYY-MM format",
                         "name": "month",
                         "in": "path",
                         "required": true
@@ -1879,7 +1882,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1921,7 +1924,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -1960,7 +1963,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2005,7 +2008,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2348,7 +2351,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2390,7 +2393,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2429,7 +2432,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2474,7 +2477,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The ID of the resource",
+                        "description": "ID of the resource",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -2539,8 +2542,7 @@
                         "type": "string",
                         "description": "The month in YYYY-MM format",
                         "name": "month",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1595,6 +1595,7 @@ paths:
       description: Deletes an account
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -1623,6 +1624,7 @@ paths:
       description: Returns a specific account
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -1654,6 +1656,7 @@ paths:
         allowed HTTP verbs
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -1680,6 +1683,7 @@ paths:
       description: Updates an account. Only values to be updated need to be specified.
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -1717,6 +1721,7 @@ paths:
       description: Returns a list of objects representing recent envelopes
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -1862,6 +1867,7 @@ paths:
       description: Deletes a budget
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -1888,6 +1894,7 @@ paths:
       description: Returns a specific budget
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -1919,6 +1926,7 @@ paths:
         allowed HTTP verbs
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -1948,6 +1956,7 @@ paths:
         specified.
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -2077,6 +2086,7 @@ paths:
       description: Deletes a category
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -2103,6 +2113,7 @@ paths:
       description: Returns a specific category
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -2134,6 +2145,7 @@ paths:
         allowed HTTP verbs
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -2163,6 +2175,7 @@ paths:
         be specified.
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -2292,6 +2305,7 @@ paths:
       description: Deletes an envelope
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -2318,6 +2332,7 @@ paths:
       description: Returns a specific Envelope
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -2349,6 +2364,7 @@ paths:
         allowed HTTP verbs
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -2378,6 +2394,7 @@ paths:
         be specified.
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -2415,6 +2432,7 @@ paths:
       description: Returns configuration for a specific month
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -2452,6 +2470,7 @@ paths:
         allowed HTTP verbs
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -2477,6 +2496,7 @@ paths:
         for the month yet, this endpoint transparently creates a configuration resource.
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -2665,6 +2685,7 @@ paths:
       description: Deletes a goal
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -2691,6 +2712,7 @@ paths:
       description: Returns a specific goal
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -2722,6 +2744,7 @@ paths:
         allowed HTTP verbs
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -2751,6 +2774,7 @@ paths:
         specified.
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -2986,6 +3010,7 @@ paths:
       description: Deletes an matchRule
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -3012,6 +3037,7 @@ paths:
       description: Returns a specific matchRule
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -3043,6 +3069,7 @@ paths:
         allowed HTTP verbs
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -3071,6 +3098,7 @@ paths:
       description: Update a matchRule. Only values to be updated need to be specified.
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -3380,6 +3408,7 @@ paths:
       description: Deletes a transaction
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -3406,6 +3435,7 @@ paths:
       description: Returns a specific transaction
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -3437,6 +3467,7 @@ paths:
         allowed HTTP verbs
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true
@@ -3466,6 +3497,7 @@ paths:
         to be specified.
       parameters:
       - description: ID of the resource
+        format: UUID
         in: path
         name: id
         required: true

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3379,7 +3379,7 @@ paths:
     delete:
       description: Deletes a transaction
       parameters:
-      - description: ID formatted as string
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -3405,7 +3405,7 @@ paths:
     get:
       description: Returns a specific transaction
       parameters:
-      - description: ID formatted as string
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -3436,7 +3436,7 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: ID formatted as string
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -3465,7 +3465,7 @@ paths:
       description: Updates an existing transaction. Only values to be updated need
         to be specified.
       parameters:
-      - description: ID formatted as string
+      - description: ID of the resource
         in: path
         name: id
         required: true

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1594,7 +1594,7 @@ paths:
     delete:
       description: Deletes an account
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -1622,7 +1622,7 @@ paths:
     get:
       description: Returns a specific account
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -1653,7 +1653,7 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -1679,7 +1679,7 @@ paths:
     patch:
       description: Updates an account. Only values to be updated need to be specified.
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -1716,7 +1716,7 @@ paths:
     get:
       description: Returns a list of objects representing recent envelopes
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1831,9 +1831,9 @@ paths:
       - application/json
       description: Creates a new budget
       parameters:
-      - description: Budget
+      - description: Budgets
         in: body
-        name: budget
+        name: budgets
         required: true
         schema:
           items:
@@ -1861,7 +1861,7 @@ paths:
     delete:
       description: Deletes a budget
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -1887,7 +1887,7 @@ paths:
     get:
       description: Returns a specific budget
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -1918,7 +1918,7 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -1947,7 +1947,7 @@ paths:
       description: Update an existing budget. Only values to be updated need to be
         specified.
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2982,7 +2982,7 @@ paths:
     delete:
       description: Deletes an matchRule
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -3008,7 +3008,7 @@ paths:
     get:
       description: Returns a specific matchRule
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -3039,7 +3039,7 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -3067,7 +3067,7 @@ paths:
       - application/json
       description: Update a matchRule. Only values to be updated need to be specified.
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2661,7 +2661,7 @@ paths:
     delete:
       description: Deletes a goal
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -2687,7 +2687,7 @@ paths:
     get:
       description: Returns a specific goal
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -2718,7 +2718,7 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -2747,7 +2747,7 @@ paths:
       description: Updates an existing goal. Only values to be updated need to be
         specified.
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2076,7 +2076,7 @@ paths:
     delete:
       description: Deletes a category
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -2102,7 +2102,7 @@ paths:
     get:
       description: Returns a specific category
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -2133,7 +2133,7 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -2162,7 +2162,7 @@ paths:
       description: Update an existing category. Only values to be updated need to
         be specified.
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2821,9 +2821,10 @@ paths:
         name: file
         required: true
         type: file
-      - description: ID of the account to import transactions for
+      - description: ID of the account to import the transactions for
         in: query
         name: accountId
+        required: true
         type: string
       produces:
       - application/json
@@ -2867,9 +2868,10 @@ paths:
         name: file
         required: true
         type: file
-      - description: Name of the Budget to create
+      - description: Name for the new budget
         in: query
         name: budgetName
+        required: true
         type: string
       produces:
       - application/json

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2259,7 +2259,7 @@ paths:
       parameters:
       - description: Envelopes
         in: body
-        name: envelope
+        name: envelopes
         required: true
         schema:
           items:
@@ -2291,7 +2291,7 @@ paths:
     delete:
       description: Deletes an envelope
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -2317,7 +2317,7 @@ paths:
     get:
       description: Returns a specific Envelope
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -2348,7 +2348,7 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true
@@ -2377,7 +2377,7 @@ paths:
       description: Updates an existing envelope. Only values to be updated need to
         be specified.
       parameters:
-      - description: ID formatted as string
+      - description: The ID of the resource
         in: path
         name: id
         required: true

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1594,7 +1594,7 @@ paths:
     delete:
       description: Deletes an account
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -1622,7 +1622,7 @@ paths:
     get:
       description: Returns a specific account
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -1653,7 +1653,7 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -1679,7 +1679,7 @@ paths:
     patch:
       description: Updates an account. Only values to be updated need to be specified.
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -1716,7 +1716,7 @@ paths:
     get:
       description: Returns a list of objects representing recent envelopes
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -1861,7 +1861,7 @@ paths:
     delete:
       description: Deletes a budget
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -1887,7 +1887,7 @@ paths:
     get:
       description: Returns a specific budget
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -1918,7 +1918,7 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -1947,7 +1947,7 @@ paths:
       description: Update an existing budget. Only values to be updated need to be
         specified.
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -2076,7 +2076,7 @@ paths:
     delete:
       description: Deletes a category
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -2102,7 +2102,7 @@ paths:
     get:
       description: Returns a specific category
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -2133,7 +2133,7 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -2162,7 +2162,7 @@ paths:
       description: Update an existing category. Only values to be updated need to
         be specified.
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -2291,7 +2291,7 @@ paths:
     delete:
       description: Deletes an envelope
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -2317,7 +2317,7 @@ paths:
     get:
       description: Returns a specific Envelope
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -2348,7 +2348,7 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -2377,7 +2377,7 @@ paths:
       description: Updates an existing envelope. Only values to be updated need to
         be specified.
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -2414,12 +2414,13 @@ paths:
     get:
       description: Returns configuration for a specific month
       parameters:
-      - description: ID of the Envelope
+      - description: ID of the resource
         in: path
         name: id
         required: true
         type: string
-      - description: The month in YYYY-MM format
+      - description: Year and month in YYYY-MM format
+        example: 2013-11
         in: path
         name: month
         required: true
@@ -2450,12 +2451,13 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: ID of the Envelope
+      - description: ID of the resource
         in: path
         name: id
         required: true
         type: string
-      - description: The month in YYYY-MM format
+      - description: Year and month in YYYY-MM format
+        example: 2013-11
         in: path
         name: month
         required: true
@@ -2474,12 +2476,13 @@ paths:
       description: Changes configuration for a Month. If there is no configuration
         for the month yet, this endpoint transparently creates a configuration resource.
       parameters:
-      - description: ID of the Envelope
+      - description: ID of the resource
         in: path
         name: id
         required: true
         type: string
-      - description: The month in YYYY-MM format
+      - description: Year and month in YYYY-MM format
+        example: 2013-11
         in: path
         name: month
         required: true
@@ -2661,7 +2664,7 @@ paths:
     delete:
       description: Deletes a goal
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -2687,7 +2690,7 @@ paths:
     get:
       description: Returns a specific goal
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -2718,7 +2721,7 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -2747,7 +2750,7 @@ paths:
       description: Updates an existing goal. Only values to be updated need to be
         specified.
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -2982,7 +2985,7 @@ paths:
     delete:
       description: Deletes an matchRule
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -3008,7 +3011,7 @@ paths:
     get:
       description: Returns a specific matchRule
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -3039,7 +3042,7 @@ paths:
       description: Returns an empty response with the HTTP Header "allow" set to the
         allowed HTTP verbs
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -3067,7 +3070,7 @@ paths:
       - application/json
       description: Update a matchRule. Only values to be updated need to be specified.
       parameters:
-      - description: The ID of the resource
+      - description: ID of the resource
         in: path
         name: id
         required: true
@@ -3143,7 +3146,6 @@ paths:
       - description: The month in YYYY-MM format
         in: query
         name: month
-        required: true
         type: string
       produces:
       - application/json

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2443,6 +2443,18 @@ paths:
         name: month
         required: true
         type: string
+      - description: ID of the resource
+        format: UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Year and month in YYYY-MM format
+        example: 2013-11
+        in: path
+        name: month
+        required: true
+        type: string
       produces:
       - application/json
       responses:
@@ -2481,6 +2493,18 @@ paths:
         name: month
         required: true
         type: string
+      - description: ID of the resource
+        format: UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Year and month in YYYY-MM format
+        example: 2013-11
+        in: path
+        name: month
+        required: true
+        type: string
       responses:
         "204":
           description: No Content
@@ -2495,6 +2519,18 @@ paths:
       description: Changes configuration for a Month. If there is no configuration
         for the month yet, this endpoint transparently creates a configuration resource.
       parameters:
+      - description: ID of the resource
+        format: UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Year and month in YYYY-MM format
+        example: 2013-11
+        in: path
+        name: month
+        required: true
+        type: string
       - description: ID of the resource
         format: UUID
         in: path

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3143,7 +3143,8 @@ paths:
         name: budget
         required: true
         type: string
-      - description: The month in YYYY-MM format
+      - description: Year and month in YYYY-MM format
+        example: 2022-07
         in: query
         name: month
         type: string

--- a/internal/uuid/uuid.go
+++ b/internal/uuid/uuid.go
@@ -1,0 +1,37 @@
+package uuid
+
+import (
+	google_uuid "github.com/google/uuid"
+)
+
+type UUID struct {
+	google_uuid.UUID
+}
+
+var Nil UUID
+
+func New() UUID {
+	return UUID{google_uuid.New()}
+}
+
+func NewString() string {
+	return google_uuid.NewString()
+}
+
+// UnmarshalParam implements the uuid.Parse method
+// from https://pkg.go.dev/github.com/google/uuid#Parse
+// for UUID
+func (u *UUID) UnmarshalParam(p string) error {
+	if p == "" {
+		*u = Nil
+		return nil
+	}
+
+	parsed, e := google_uuid.Parse(p)
+	if e != nil {
+		return e
+	}
+
+	*u = UUID{parsed}
+	return nil
+}

--- a/internal/uuid/uuid_test.go
+++ b/internal/uuid/uuid_test.go
@@ -1,0 +1,37 @@
+package uuid_test
+
+import (
+	"testing"
+
+	"github.com/envelope-zero/backend/v5/internal/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNew tests that a new UUID can be generated.
+// We don't validate the result, google/uuid already has tests
+func TestNew(_ *testing.T) {
+	_ = uuid.New()
+}
+
+// TestNewString tests that a new UUID can be generated as string.
+// We don't validate the result, google/uuid already has tests
+func TestNewString(_ *testing.T) {
+	_ = uuid.NewString()
+}
+
+func TestUnmarshalParam(t *testing.T) {
+	u := uuid.UUID{}
+
+	// an invalid UUID does not parse
+	assert.NotNil(t, u.UnmarshalParam("not a valid UUID"))
+
+	// A valid UUID in a string parses
+	id := uuid.NewString()
+	assert.Nil(t, u.UnmarshalParam(id))
+	assert.Equal(t, id, u.UUID.String())
+
+	// Empty string parses to Nil UIID
+	id = ""
+	assert.Nil(t, u.UnmarshalParam(id))
+	assert.Equal(t, uuid.Nil, u)
+}

--- a/pkg/controllers/v4/account.go
+++ b/pkg/controllers/v4/account.go
@@ -3,6 +3,7 @@ package v4
 import (
 	"net/http"
 
+	"github.com/envelope-zero/backend/v5/internal/uuid"
 	"github.com/envelope-zero/backend/v5/pkg/httputil"
 	"github.com/envelope-zero/backend/v5/pkg/models"
 	"github.com/gin-gonic/gin"
@@ -46,10 +47,11 @@ func OptionsAccountList(c *gin.Context) {
 // @Failure		400	{object}	httpError
 // @Failure		404	{object}	httpError
 // @Failure		500	{object}	httpError
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/accounts/{id} [options]
 func OptionsAccountDetail(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),
@@ -57,7 +59,7 @@ func OptionsAccountDetail(c *gin.Context) {
 		return
 	}
 
-	err = models.DB.First(&models.Account{}, id).Error
+	err = models.DB.First(&models.Account{}, uri.ID).Error
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),
@@ -212,10 +214,11 @@ func GetAccounts(c *gin.Context) {
 // @Failure		400	{object}	AccountResponse
 // @Failure		404	{object}	AccountResponse
 // @Failure		500	{object}	AccountResponse
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/accounts/{id} [get]
 func GetAccount(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), AccountResponse{
@@ -225,7 +228,7 @@ func GetAccount(c *gin.Context) {
 	}
 
 	var account models.Account
-	err = models.DB.First(&account, id).Error
+	err = models.DB.First(&account, uri.ID).Error
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), AccountResponse{
@@ -238,23 +241,24 @@ func GetAccount(c *gin.Context) {
 	c.JSON(http.StatusOK, AccountResponse{Data: &data})
 }
 
-// @Summary		Get recent envelopes
-// @Description	Returns a list of objects representing recent envelopes
-// @Tags			Accounts
-// @Produce		json
-// @Success		200	{object}	RecentEnvelopesResponse
-// @Failure		400	{object}	RecentEnvelopesResponse
-// @Failure		404	{object}	RecentEnvelopesResponse
-// @Failure		500	{object}	RecentEnvelopesResponse
-// @Param			id	path		string	true	"ID formatted as string"
-// @Router			/v4/accounts/{id}/recent-envelopes [get]
+//	@Summary		Get recent envelopes
+//	@Description	Returns a list of objects representing recent envelopes
+//	@Tags			Accounts
+//	@Produce		json
+//	@Success		200	{object}	RecentEnvelopesResponse
+//	@Failure		400	{object}	RecentEnvelopesResponse
+//	@Failure		404	{object}	RecentEnvelopesResponse
+//	@Failure		500	{object}	RecentEnvelopesResponse
+//	@Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
+//	@Router			/v4/accounts/{id}/recent-envelopes [get]
 //
 // GetAccountRecentEnvelopes returns recent envelopes for an account.
 //
 // Income is returned as a RecentEnvelope with the nil ID.
 // Clients must be able to handle this.
 func GetAccountRecentEnvelopes(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), RecentEnvelopesResponse{
@@ -264,7 +268,7 @@ func GetAccountRecentEnvelopes(c *gin.Context) {
 	}
 
 	var account models.Account
-	err = models.DB.First(&account, id).Error
+	err = models.DB.First(&account, uri.ID).Error
 	if err != nil {
 		s := err.Error()
 
@@ -333,7 +337,8 @@ func GetAccountData(c *gin.Context) {
 
 	data := make([]AccountComputedData, 0)
 	for _, idString := range request.IDs {
-		id, err := httputil.UUIDFromString(idString)
+		var id uuid.UUID
+		err := id.UnmarshalParam(idString)
 		if err != nil {
 			s := err.Error()
 			c.JSON(status(err), AccountComputedDataResponse{
@@ -390,11 +395,12 @@ func GetAccountData(c *gin.Context) {
 // @Failure		400		{object}	AccountResponse
 // @Failure		404		{object}	AccountResponse
 // @Failure		500		{object}	AccountResponse
-// @Param			id		path		string			true	"ID formatted as string"
+// @Param			id		path		URIID			true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Param			account	body		AccountEditable	true	"Account"
 // @Router			/v4/accounts/{id} [patch]
 func UpdateAccount(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), AccountResponse{
@@ -404,7 +410,7 @@ func UpdateAccount(c *gin.Context) {
 	}
 
 	var account models.Account
-	err = models.DB.First(&account, id).Error
+	err = models.DB.First(&account, uri.ID).Error
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), AccountResponse{
@@ -453,10 +459,11 @@ func UpdateAccount(c *gin.Context) {
 // @Failure		400	{object}	httpError
 // @Failure		404	{object}	httpError
 // @Failure		500	{object}	httpError
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/accounts/{id} [delete]
 func DeleteAccount(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),
@@ -465,7 +472,7 @@ func DeleteAccount(c *gin.Context) {
 	}
 
 	var account models.Account
-	err = models.DB.First(&account, id).Error
+	err = models.DB.First(&account, uri.ID).Error
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),

--- a/pkg/controllers/v4/account_types.go
+++ b/pkg/controllers/v4/account_types.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/envelope-zero/backend/v5/pkg/httputil"
+	ez_uuid "github.com/envelope-zero/backend/v5/internal/uuid"
 	"github.com/envelope-zero/backend/v5/pkg/models"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -107,25 +107,20 @@ type AccountResponse struct {
 }
 
 type AccountQueryFilter struct {
-	Name     string `form:"name" filterField:"false"`   // Fuzzy filter for the account name
-	Note     string `form:"note" filterField:"false"`   // Fuzzy filter for the note
-	BudgetID string `form:"budget"`                     // By budget ID
-	OnBudget bool   `form:"onBudget"`                   // Is the account on-budget?
-	External bool   `form:"external"`                   // Is the account external?
-	Archived bool   `form:"archived"`                   // Is the account archived?
-	Search   string `form:"search" filterField:"false"` // By string in name or note
-	Offset   uint   `form:"offset" filterField:"false"` // The offset of the first Account returned. Defaults to 0.
-	Limit    int    `form:"limit" filterField:"false"`  // Maximum number of Accounts to return. Defaults to 50.
+	Name     string       `form:"name" filterField:"false"`   // Fuzzy filter for the account name
+	Note     string       `form:"note" filterField:"false"`   // Fuzzy filter for the note
+	BudgetID ez_uuid.UUID `form:"budget"`                     // By budget ID
+	OnBudget bool         `form:"onBudget"`                   // Is the account on-budget?
+	External bool         `form:"external"`                   // Is the account external?
+	Archived bool         `form:"archived"`                   // Is the account archived?
+	Search   string       `form:"search" filterField:"false"` // By string in name or note
+	Offset   uint         `form:"offset" filterField:"false"` // The offset of the first Account returned. Defaults to 0.
+	Limit    int          `form:"limit" filterField:"false"`  // Maximum number of Accounts to return. Defaults to 50.
 }
 
 func (f AccountQueryFilter) model() (models.Account, error) {
-	budgetID, err := httputil.UUIDFromString(f.BudgetID)
-	if err != nil {
-		return models.Account{}, err
-	}
-
 	return models.Account{
-		BudgetID: budgetID,
+		BudgetID: f.BudgetID.UUID,
 		OnBudget: f.OnBudget,
 		External: f.External,
 		Archived: f.Archived,

--- a/pkg/controllers/v4/account_types.go
+++ b/pkg/controllers/v4/account_types.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+// AccountEditable represents the user editable properties of an account
 type AccountEditable struct {
 	Name               string          `json:"name" example:"Cash" default:""`                                                                                           // Name of the account
 	Note               string          `json:"note" example:"Money in my wallet" default:""`                                                                             // A longer description for the account
@@ -144,7 +145,7 @@ type AccountComputedRequest struct {
 }
 
 type AccountComputedData struct {
-	ID                uuid.UUID       `json:"id" example:"95018a69-758b-46c6-8bab-db70d9614f9d"` // ID of the account
+	ID                ez_uuid.UUID    `json:"id" example:"95018a69-758b-46c6-8bab-db70d9614f9d"` // ID of the account
 	Balance           decimal.Decimal `json:"balance" example:"2735.17"`                         // Balance of the account, including all transactions referencing it
 	ReconciledBalance decimal.Decimal `json:"reconciledBalance" example:"2539.57"`               // Balance of the account, including all reconciled transactions referencing it
 }

--- a/pkg/controllers/v4/budget.go
+++ b/pkg/controllers/v4/budget.go
@@ -44,10 +44,11 @@ func OptionsBudgetList(c *gin.Context) {
 // @Failure		400	{object}	httpError
 // @Failure		404	{object}	httpError
 // @Failure		500	{object}	httpError
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/budgets/{id} [options]
 func OptionsBudgetDetail(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),
@@ -55,7 +56,7 @@ func OptionsBudgetDetail(c *gin.Context) {
 		return
 	}
 
-	err = models.DB.First(&models.Budget{}, id).Error
+	err = models.DB.First(&models.Budget{}, uri.ID).Error
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),
@@ -74,7 +75,7 @@ func OptionsBudgetDetail(c *gin.Context) {
 // @Success		201		{object}	BudgetCreateResponse
 // @Failure		400		{object}	BudgetCreateResponse
 // @Failure		500		{object}	BudgetCreateResponse
-// @Param			budget	body		[]BudgetEditable	true	"Budget"
+// @Param			budgets	body		[]BudgetEditable	true	"Budgets"
 // @Router			/v4/budgets [post]
 func CreateBudgets(c *gin.Context) {
 	var budgets []BudgetEditable
@@ -193,10 +194,11 @@ func GetBudgets(c *gin.Context) {
 // @Failure		400	{object}	BudgetResponse
 // @Failure		404	{object}	BudgetResponse
 // @Failure		500	{object}	BudgetResponse
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/budgets/{id} [get]
 func GetBudget(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), BudgetResponse{
@@ -206,7 +208,7 @@ func GetBudget(c *gin.Context) {
 	}
 
 	var budget models.Budget
-	err = models.DB.First(&budget, id).Error
+	err = models.DB.First(&budget, uri.ID).Error
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), BudgetResponse{
@@ -228,11 +230,12 @@ func GetBudget(c *gin.Context) {
 // @Failure		400		{object}	BudgetResponse
 // @Failure		404		{object}	BudgetResponse
 // @Failure		500		{object}	BudgetResponse
-// @Param			id		path		string			true	"ID formatted as string"
+// @Param			id		path		URIID			true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Param			budget	body		BudgetEditable	true	"Budget"
 // @Router			/v4/budgets/{id} [patch]
 func UpdateBudget(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), BudgetResponse{
@@ -242,7 +245,7 @@ func UpdateBudget(c *gin.Context) {
 	}
 
 	var budget models.Budget
-	err = models.DB.First(&budget, id).Error
+	err = models.DB.First(&budget, uri.ID).Error
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), BudgetResponse{
@@ -290,10 +293,11 @@ func UpdateBudget(c *gin.Context) {
 // @Failure		400	{object}	httpError
 // @Failure		404	{object}	httpError
 // @Failure		500	{object}	httpError
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/budgets/{id} [delete]
 func DeleteBudget(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),
@@ -302,7 +306,7 @@ func DeleteBudget(c *gin.Context) {
 	}
 
 	var budget models.Budget
-	err = models.DB.First(&budget, id).Error
+	err = models.DB.First(&budget, uri.ID).Error
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),

--- a/pkg/controllers/v4/category.go
+++ b/pkg/controllers/v4/category.go
@@ -44,10 +44,11 @@ func OptionsCategoryList(c *gin.Context) {
 // @Failure		400	{object}	httpError
 // @Failure		404	{object}	httpError
 // @Failure		500	{object}	httpError
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/categories/{id} [options]
 func OptionsCategoryDetail(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),
@@ -55,7 +56,7 @@ func OptionsCategoryDetail(c *gin.Context) {
 		return
 	}
 
-	err = models.DB.First(&models.Category{}, id).Error
+	err = models.DB.First(&models.Category{}, uri.ID).Error
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),
@@ -215,10 +216,11 @@ func GetCategories(c *gin.Context) {
 // @Failure		400	{object}	CategoryResponse
 // @Failure		404	{object}	CategoryResponse
 // @Failure		500	{object}	CategoryResponse
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/categories/{id} [get]
 func GetCategory(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), CategoryResponse{
@@ -228,7 +230,7 @@ func GetCategory(c *gin.Context) {
 	}
 
 	var category models.Category
-	err = models.DB.First(&category, id).Error
+	err = models.DB.First(&category, uri.ID).Error
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), CategoryResponse{
@@ -258,11 +260,12 @@ func GetCategory(c *gin.Context) {
 // @Failure		400			{object}	CategoryResponse
 // @Failure		404			{object}	CategoryResponse
 // @Failure		500			{object}	CategoryResponse
-// @Param			id			path		string				true	"ID formatted as string"
+// @Param			id			path		URIID				true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Param			category	body		CategoryEditable	true	"Category"
 // @Router			/v4/categories/{id} [patch]
 func UpdateCategory(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), CategoryResponse{
@@ -272,7 +275,7 @@ func UpdateCategory(c *gin.Context) {
 	}
 
 	var category models.Category
-	err = models.DB.First(&category, id).Error
+	err = models.DB.First(&category, uri.ID).Error
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), CategoryResponse{
@@ -328,10 +331,11 @@ func UpdateCategory(c *gin.Context) {
 // @Failure		400	{object}	httpError
 // @Failure		404	{object}	httpError
 // @Failure		500	{object}	httpError
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/categories/{id} [delete]
 func DeleteCategory(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),
@@ -340,7 +344,7 @@ func DeleteCategory(c *gin.Context) {
 	}
 
 	var category models.Category
-	err = models.DB.First(&category, id).Error
+	err = models.DB.First(&category, uri.ID).Error
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),

--- a/pkg/controllers/v4/category_types.go
+++ b/pkg/controllers/v4/category_types.go
@@ -3,7 +3,7 @@ package v4
 import (
 	"fmt"
 
-	"github.com/envelope-zero/backend/v5/pkg/httputil"
+	ez_uuid "github.com/envelope-zero/backend/v5/internal/uuid"
 	"github.com/envelope-zero/backend/v5/pkg/models"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -100,23 +100,18 @@ type CategoryResponse struct {
 }
 
 type CategoryQueryFilter struct {
-	BudgetID string `form:"budget"`                     // By ID of the Budget
-	Name     string `form:"name" filterField:"false"`   // By name
-	Note     string `form:"note" filterField:"false"`   // By note
-	Archived bool   `form:"archived"`                   // Is the Category archived?
-	Search   string `form:"search" filterField:"false"` // By string in name or note
-	Offset   uint   `form:"offset" filterField:"false"` // The offset of the first Category returned. Defaults to 0.
-	Limit    int    `form:"limit" filterField:"false"`  // Maximum number of Categories to return. Defaults to 50.
+	BudgetID ez_uuid.UUID `form:"budget"`                     // By ID of the Budget
+	Name     string       `form:"name" filterField:"false"`   // By name
+	Note     string       `form:"note" filterField:"false"`   // By note
+	Archived bool         `form:"archived"`                   // Is the Category archived?
+	Search   string       `form:"search" filterField:"false"` // By string in name or note
+	Offset   uint         `form:"offset" filterField:"false"` // The offset of the first Category returned. Defaults to 0.
+	Limit    int          `form:"limit" filterField:"false"`  // Maximum number of Categories to return. Defaults to 50.
 }
 
 func (f CategoryQueryFilter) model() (models.Category, error) {
-	budgetID, err := httputil.UUIDFromString(f.BudgetID)
-	if err != nil {
-		return models.Category{}, err
-	}
-
 	return models.Category{
-		BudgetID: budgetID,
+		BudgetID: f.BudgetID.UUID,
 		Archived: f.Archived,
 	}, nil
 }

--- a/pkg/controllers/v4/envelope.go
+++ b/pkg/controllers/v4/envelope.go
@@ -1,9 +1,9 @@
 package v4
 
 import (
-	"fmt"
 	"net/http"
 
+	ez_uuid "github.com/envelope-zero/backend/v5/internal/uuid"
 	"github.com/envelope-zero/backend/v5/pkg/httputil"
 	"github.com/envelope-zero/backend/v5/pkg/models"
 	"github.com/gin-gonic/gin"
@@ -148,20 +148,11 @@ func GetEnvelopes(c *gin.Context) {
 
 	q = stringFilters(models.DB, q, setFields, filter.Name, filter.Note, filter.Search)
 
-	if filter.BudgetID != "" {
-		budgetID, err := httputil.UUIDFromString(filter.BudgetID)
-		if err != nil {
-			s := fmt.Sprintf("Error parsing budget ID for filtering: %s", err.Error())
-			c.JSON(status(err), EnvelopeListResponse{
-				Error: &s,
-			})
-			return
-		}
-
+	if filter.BudgetID != ez_uuid.Nil {
 		q = q.
 			Joins("JOIN categories on categories.id = envelopes.category_id").
 			Joins("JOIN budgets on budgets.id = categories.budget_id").
-			Where("budgets.id = ?", budgetID)
+			Where("budgets.id = ?", filter.BudgetID.UUID)
 	}
 
 	// Set the offset. Does not need checking since the default is 0

--- a/pkg/controllers/v4/envelope.go
+++ b/pkg/controllers/v4/envelope.go
@@ -45,10 +45,11 @@ func OptionsEnvelopeList(c *gin.Context) {
 // @Failure		400	{object}	httpError
 // @Failure		404	{object}	httpError
 // @Failure		500	{object}	httpError
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/envelopes/{id} [options]
 func OptionsEnvelopeDetail(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),
@@ -56,7 +57,7 @@ func OptionsEnvelopeDetail(c *gin.Context) {
 		return
 	}
 
-	err = models.DB.First(&models.Envelope{}, id).Error
+	err = models.DB.First(&models.Envelope{}, uri.ID).Error
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),
@@ -75,7 +76,7 @@ func OptionsEnvelopeDetail(c *gin.Context) {
 // @Failure		400			{object}	EnvelopeCreateResponse
 // @Failure		404			{object}	EnvelopeCreateResponse
 // @Failure		500			{object}	EnvelopeCreateResponse
-// @Param			envelope	body		[]v4.EnvelopeEditable	true	"Envelopes"
+// @Param			envelopes	body		[]v4.EnvelopeEditable	true	"Envelopes"
 // @Router			/v4/envelopes [post]
 func CreateEnvelopes(c *gin.Context) {
 	var envelopes []EnvelopeEditable
@@ -209,10 +210,11 @@ func GetEnvelopes(c *gin.Context) {
 // @Failure		400	{object}	EnvelopeResponse
 // @Failure		404	{object}	EnvelopeResponse
 // @Failure		500	{object}	EnvelopeResponse
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/envelopes/{id} [get]
 func GetEnvelope(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), EnvelopeResponse{
@@ -222,7 +224,7 @@ func GetEnvelope(c *gin.Context) {
 	}
 
 	var envelope models.Envelope
-	err = models.DB.First(&envelope, id).Error
+	err = models.DB.First(&envelope, uri.ID).Error
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), EnvelopeResponse{
@@ -244,11 +246,12 @@ func GetEnvelope(c *gin.Context) {
 // @Failure		400			{object}	EnvelopeResponse
 // @Failure		404			{object}	EnvelopeResponse
 // @Failure		500			{object}	EnvelopeResponse
-// @Param			id			path		string				true	"ID formatted as string"
+// @Param			id			path		URIID				true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Param			envelope	body		v4.EnvelopeEditable	true	"Envelope"
 // @Router			/v4/envelopes/{id} [patch]
 func UpdateEnvelope(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), EnvelopeResponse{
@@ -258,7 +261,7 @@ func UpdateEnvelope(c *gin.Context) {
 	}
 
 	var envelope models.Envelope
-	err = models.DB.First(&envelope, id).Error
+	err = models.DB.First(&envelope, uri.ID).Error
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), EnvelopeResponse{
@@ -306,10 +309,11 @@ func UpdateEnvelope(c *gin.Context) {
 // @Failure		400	{object}	httpError
 // @Failure		404	{object}	httpError
 // @Failure		500	{object}	httpError
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/envelopes/{id} [delete]
 func DeleteEnvelope(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),
@@ -318,7 +322,7 @@ func DeleteEnvelope(c *gin.Context) {
 	}
 
 	var envelope models.Envelope
-	err = models.DB.First(&envelope, id).Error
+	err = models.DB.First(&envelope, uri.ID).Error
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),

--- a/pkg/controllers/v4/envelope_types.go
+++ b/pkg/controllers/v4/envelope_types.go
@@ -3,7 +3,7 @@ package v4
 import (
 	"fmt"
 
-	"github.com/envelope-zero/backend/v5/pkg/httputil"
+	ez_uuid "github.com/envelope-zero/backend/v5/internal/uuid"
 	"github.com/envelope-zero/backend/v5/pkg/models"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -89,24 +89,19 @@ type EnvelopeResponse struct {
 }
 
 type EnvelopeQueryFilter struct {
-	BudgetID   string `form:"budget" filterField:"false"` // By budget ID
-	CategoryID string `form:"category"`                   // By the ID of the category
-	Name       string `form:"name" filterField:"false"`   // By name
-	Note       string `form:"note" filterField:"false"`   // By the note
-	Archived   bool   `form:"archived"`                   // Is the envelope archived?
-	Search     string `form:"search" filterField:"false"` // By string in name or note
-	Offset     uint   `form:"offset" filterField:"false"` // The offset of the first Envelope returned. Defaults to 0.
-	Limit      int    `form:"limit" filterField:"false"`  // Maximum number of Envelopes to return. Defaults to 50.
+	BudgetID   ez_uuid.UUID `form:"budget" filterField:"false"` // By budget ID
+	CategoryID ez_uuid.UUID `form:"category"`                   // By the ID of the category
+	Name       string       `form:"name" filterField:"false"`   // By name
+	Note       string       `form:"note" filterField:"false"`   // By the note
+	Archived   bool         `form:"archived"`                   // Is the envelope archived?
+	Search     string       `form:"search" filterField:"false"` // By string in name or note
+	Offset     uint         `form:"offset" filterField:"false"` // The offset of the first Envelope returned. Defaults to 0.
+	Limit      int          `form:"limit" filterField:"false"`  // Maximum number of Envelopes to return. Defaults to 50.
 }
 
 func (f EnvelopeQueryFilter) model() (models.Envelope, error) {
-	categoryID, err := httputil.UUIDFromString(f.CategoryID)
-	if err != nil {
-		return models.Envelope{}, err
-	}
-
 	return models.Envelope{
-		CategoryID: categoryID,
+		CategoryID: f.CategoryID.UUID,
 		Archived:   f.Archived,
 	}, nil
 }

--- a/pkg/controllers/v4/goal.go
+++ b/pkg/controllers/v4/goal.go
@@ -41,10 +41,11 @@ func OptionsGoals(c *gin.Context) {
 // @Failure		400	{object}	httpError
 // @Failure		404	{object}	httpError
 // @Failure		500	{object}	httpError
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/goals/{id} [options]
 func OptionsGoalDetail(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),
@@ -52,7 +53,7 @@ func OptionsGoalDetail(c *gin.Context) {
 		return
 	}
 
-	err = models.DB.First(&models.Goal{}, id).Error
+	err = models.DB.First(&models.Goal{}, uri.ID).Error
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),
@@ -259,10 +260,11 @@ func GetGoals(c *gin.Context) {
 // @Failure		400	{object}	GoalResponse
 // @Failure		404	{object}	GoalResponse
 // @Failure		500	{object}	GoalResponse
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/goals/{id} [get]
 func GetGoal(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		e := err.Error()
 		c.JSON(status(err), GoalResponse{
@@ -272,7 +274,7 @@ func GetGoal(c *gin.Context) {
 	}
 
 	var goal models.Goal
-	err = models.DB.First(&goal, id).Error
+	err = models.DB.First(&goal, uri.ID).Error
 	if err != nil {
 		e := err.Error()
 		c.JSON(status(err), GoalResponse{
@@ -294,11 +296,12 @@ func GetGoal(c *gin.Context) {
 // @Failure		400		{object}	GoalResponse
 // @Failure		404		{object}	GoalResponse
 // @Failure		500		{object}	GoalResponse
-// @Param			id		path		string			true	"ID formatted as string"
+// @Param			id		path		URIID			true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Param			goal	body		GoalEditable	true	"Goal"
 // @Router			/v4/goals/{id} [patch]
 func UpdateGoal(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		e := err.Error()
 		c.JSON(status(err), GoalResponse{
@@ -308,7 +311,7 @@ func UpdateGoal(c *gin.Context) {
 	}
 
 	var goal models.Goal
-	err = models.DB.First(&goal, id).Error
+	err = models.DB.First(&goal, uri.ID).Error
 	if err != nil {
 		e := err.Error()
 		c.JSON(status(err), GoalResponse{
@@ -358,10 +361,11 @@ func UpdateGoal(c *gin.Context) {
 // @Failure		400	{object}	httpError
 // @Failure		404	{object}	httpError
 // @Failure		500	{object}	httpError
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/goals/{id} [delete]
 func DeleteGoal(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),
@@ -370,7 +374,7 @@ func DeleteGoal(c *gin.Context) {
 	}
 
 	var goal models.Goal
-	err = models.DB.First(&goal, id).Error
+	err = models.DB.First(&goal, uri.ID).Error
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),

--- a/pkg/controllers/v4/goal_types.go
+++ b/pkg/controllers/v4/goal_types.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/envelope-zero/backend/v5/internal/types"
-	"github.com/envelope-zero/backend/v5/pkg/httputil"
+	ez_uuid "github.com/envelope-zero/backend/v5/internal/uuid"
 	"github.com/envelope-zero/backend/v5/pkg/models"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -94,13 +94,13 @@ type GoalResponse struct {
 }
 
 type GoalQueryFilter struct {
-	BudgetID          string          `form:"budget" filterField:"false"`            // By budget ID
-	CategoryID        string          `form:"category" filterField:"false"`          // By category ID
+	BudgetID          ez_uuid.UUID    `form:"budget" filterField:"false"`            // By budget ID
+	CategoryID        ez_uuid.UUID    `form:"category" filterField:"false"`          // By category ID
 	Name              string          `form:"name" filterField:"false"`              // By name
 	Note              string          `form:"note" filterField:"false"`              // By the note
 	Search            string          `form:"search" filterField:"false"`            // By string in name or note
 	Archived          bool            `form:"archived"`                              // Is the goal archived?
-	EnvelopeID        string          `form:"envelope"`                              // ID of the envelope
+	EnvelopeID        ez_uuid.UUID    `form:"envelope"`                              // ID of the envelope
 	Month             string          `form:"month"`                                 // Exact month
 	FromMonth         string          `form:"fromMonth" filterField:"false"`         // From this month
 	UntilMonth        string          `form:"untilMonth" filterField:"false"`        // Until this month
@@ -112,11 +112,6 @@ type GoalQueryFilter struct {
 }
 
 func (f GoalQueryFilter) model() (models.Goal, error) {
-	envelopeID, err := httputil.UUIDFromString(f.EnvelopeID)
-	if err != nil {
-		return models.Goal{}, err
-	}
-
 	var month types.Month
 	if f.Month != "" {
 		m, err := types.ParseMonth(f.Month)
@@ -130,7 +125,7 @@ func (f GoalQueryFilter) model() (models.Goal, error) {
 	// This does not set the string fields since they are
 	// handled in the controller function
 	return GoalEditable{
-		EnvelopeID: envelopeID,
+		EnvelopeID: f.EnvelopeID.UUID,
 		Amount:     f.Amount,
 		Month:      month,
 		Archived:   f.Archived,

--- a/pkg/controllers/v4/import_test.go
+++ b/pkg/controllers/v4/import_test.go
@@ -163,7 +163,7 @@ func (suite *TestSuiteStandard) TestImportYnabImportPreviewFails() {
 		file          string
 	}{
 		{"No account ID", "", http.StatusBadRequest, "the accountId parameter must be set", ""},
-		{"Broken ID", "NotAUUID", http.StatusBadRequest, "the specified resource ID is not a valid UUID", "importer/ynab-import/empty.csv"},
+		{"Broken ID", "NotAUUID", http.StatusBadRequest, "accountId: invalid UUID length: 8", "importer/ynab-import/empty.csv"},
 		{"No account with ID", "d2525c4f-2f45-49ba-9c5d-75d6b1c26f56", http.StatusNotFound, "there is no account matching your query", "importer/ynab-import/empty.csv"},
 		{"No file sent", accountID, http.StatusBadRequest, "you must send a file to this endpoint", ""},
 		{"Wrong file name", accountID, http.StatusBadRequest, "this endpoint only supports files of the following types: .csv", "importer/ynab-import/wrong-suffix.json"},

--- a/pkg/controllers/v4/match_rule.go
+++ b/pkg/controllers/v4/match_rule.go
@@ -6,6 +6,7 @@ import (
 
 	"golang.org/x/exp/slices"
 
+	ez_uuid "github.com/envelope-zero/backend/v5/internal/uuid"
 	"github.com/envelope-zero/backend/v5/pkg/httputil"
 	"github.com/envelope-zero/backend/v5/pkg/models"
 	"github.com/gin-gonic/gin"
@@ -151,20 +152,11 @@ func GetMatchRules(c *gin.Context) {
 		q = q.Where("match = ''")
 	}
 
-	if filter.BudgetID != "" {
-		budgetID, err := httputil.UUIDFromString(filter.BudgetID)
-		if err != nil {
-			s := fmt.Sprintf("Error parsing budget ID for filtering: %s", err.Error())
-			c.JSON(status(err), MatchRuleListResponse{
-				Error: &s,
-			})
-			return
-		}
-
+	if filter.BudgetID != ez_uuid.Nil {
 		q = q.
 			Joins("JOIN accounts on accounts.id = match_rules.account_id").
 			Joins("JOIN budgets on budgets.id = accounts.budget_id").
-			Where("budgets.id = ?", budgetID)
+			Where("budgets.id = ?", filter.BudgetID.UUID)
 	}
 
 	// Set the offset. Does not need checking since the default is 0

--- a/pkg/controllers/v4/match_rule.go
+++ b/pkg/controllers/v4/match_rule.go
@@ -47,15 +47,16 @@ func OptionsMatchRuleList(c *gin.Context) {
 // @Failure		400	{object}	httpError
 // @Failure		404	{object}	httpError
 // @Failure		500	{object}	httpError
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/match-rules/{id} [options]
 func OptionsMatchRuleDetail(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		c.JSON(status(err), httpError{Error: err.Error()})
 	}
 
-	err = models.DB.First(&models.MatchRule{}, id).Error
+	err = models.DB.First(&models.MatchRule{}, uri.ID).Error
 	if err != nil {
 		c.JSON(status(err), httpError{Error: err.Error()})
 		return
@@ -212,10 +213,11 @@ func GetMatchRules(c *gin.Context) {
 // @Failure		400	{object}	MatchRuleResponse
 // @Failure		404	{object}	MatchRuleResponse
 // @Failure		500	{object}	MatchRuleResponse
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/match-rules/{id} [get]
 func GetMatchRule(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		e := err.Error()
 		c.JSON(status(err), MatchRuleResponse{
@@ -225,7 +227,7 @@ func GetMatchRule(c *gin.Context) {
 	}
 
 	var matchRule models.MatchRule
-	err = models.DB.First(&matchRule, id).Error
+	err = models.DB.First(&matchRule, uri.ID).Error
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), MatchRuleResponse{Error: &s})
@@ -247,11 +249,12 @@ func GetMatchRule(c *gin.Context) {
 // @Failure		400			{object}	MatchRuleResponse
 // @Failure		404			{object}	MatchRuleResponse
 // @Failure		500			{object}	MatchRuleResponse
-// @Param			id			path		string				true	"ID formatted as string"
+// @Param			id			path		URIID				true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Param			matchRule	body		MatchRuleEditable	true	"MatchRule"
 // @Router			/v4/match-rules/{id} [patch]
 func UpdateMatchRule(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		e := err.Error()
 		c.JSON(status(err), MatchRuleResponse{
@@ -261,7 +264,7 @@ func UpdateMatchRule(c *gin.Context) {
 	}
 
 	var matchRule models.MatchRule
-	err = models.DB.First(&matchRule, id).Error
+	err = models.DB.First(&matchRule, uri.ID).Error
 	if err != nil {
 		e := err.Error()
 		c.JSON(status(err), MatchRuleResponse{
@@ -311,17 +314,18 @@ func UpdateMatchRule(c *gin.Context) {
 // @Failure		400	{object}	httpError
 // @Failure		404	{object}	httpError
 // @Failure		500	{object}	httpError
-// @Param			id	path		string	true	"ID formatted as string"
+// @Param			id	path		URIID	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/match-rules/{id} [delete]
 func DeleteMatchRule(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		c.JSON(status(err), httpError{Error: err.Error()})
 		return
 	}
 
 	var matchRule models.MatchRule
-	err = models.DB.First(&matchRule, id).Error
+	err = models.DB.First(&matchRule, uri.ID).Error
 	if err != nil {
 		c.JSON(status(err), httpError{Error: err.Error()})
 		return

--- a/pkg/controllers/v4/match_rule_types.go
+++ b/pkg/controllers/v4/match_rule_types.go
@@ -3,7 +3,7 @@ package v4
 import (
 	"fmt"
 
-	"github.com/envelope-zero/backend/v5/pkg/httputil"
+	ez_uuid "github.com/envelope-zero/backend/v5/internal/uuid"
 	"github.com/envelope-zero/backend/v5/pkg/models"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -81,23 +81,18 @@ func newMatchRule(c *gin.Context, model models.MatchRule) MatchRule {
 
 // MatchRuleQueryFilter contains the fields that Match Rules can be filtered with.
 type MatchRuleQueryFilter struct {
-	BudgetID  string `form:"budget" filterField:"false"` // By budget ID
-	Priority  uint   `form:"priority"`                   // By priority
-	Match     string `form:"match" filterField:"false"`  // By match
-	AccountID string `form:"account"`                    // By ID of the Account they map to
-	Offset    uint   `form:"offset" filterField:"false"` // The offset of the first Match Rule returned. Defaults to 0.
-	Limit     int    `form:"limit" filterField:"false"`  // Maximum number of Match Rules to return. Defaults to 50.
+	BudgetID  ez_uuid.UUID `form:"budget" filterField:"false"` // By budget ID
+	Priority  uint         `form:"priority"`                   // By priority
+	Match     string       `form:"match" filterField:"false"`  // By match
+	AccountID ez_uuid.UUID `form:"account"`                    // By ID of the Account they map to
+	Offset    uint         `form:"offset" filterField:"false"` // The offset of the first Match Rule returned. Defaults to 0.
+	Limit     int          `form:"limit" filterField:"false"`  // Maximum number of Match Rules to return. Defaults to 50.
 }
 
 // Parse returns a models.MatchRuleCreate struct that represents the MatchRuleQueryFilter.
 func (f MatchRuleQueryFilter) model() (models.MatchRule, error) {
-	envelopeID, err := httputil.UUIDFromString(f.AccountID)
-	if err != nil {
-		return models.MatchRule{}, err
-	}
-
 	return models.MatchRule{
 		Priority:  f.Priority,
-		AccountID: envelopeID,
+		AccountID: f.AccountID.UUID,
 	}, nil
 }

--- a/pkg/controllers/v4/month.go
+++ b/pkg/controllers/v4/month.go
@@ -76,8 +76,8 @@ func OptionsMonth(c *gin.Context) {
 // @Failure		400		{object}	MonthResponse
 // @Failure		404		{object}	MonthResponse
 // @Failure		500		{object}	MonthResponse
-// @Param			budget	query		string	true	"ID formatted as string"
-// @Param			month	query		string	true	"The month in YYYY-MM format"
+// @Param			budget	query		string		true	"ID formatted as string"
+// @Param			month	query		QueryMonth	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/months [get]
 func GetMonth(c *gin.Context) {
 	qMonth, b, err := parseMonthQuery(c)

--- a/pkg/controllers/v4/month_config.go
+++ b/pkg/controllers/v4/month_config.go
@@ -23,11 +23,12 @@ func RegisterMonthConfigRoutes(r *gin.RouterGroup) {
 // @Tags			Envelopes
 // @Success		204
 // @Failure		400		{object}	httpError
-// @Param			id		path		string	true	"ID of the Envelope"
-// @Param			month	path		string	true	"The month in YYYY-MM format"
+// @Param			id		path		URIID		true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
+// @Param			month	path		URIMonth	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/envelopes/{id}/{month} [options]
 func OptionsMonthConfigDetail(c *gin.Context) {
-	_, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		c.JSON(status(err), httpError{
 			Error: err.Error(),
@@ -54,11 +55,12 @@ func OptionsMonthConfigDetail(c *gin.Context) {
 // @Failure		400		{object}	MonthConfigResponse
 // @Failure		404		{object}	MonthConfigResponse
 // @Failure		500		{object}	MonthConfigResponse
-// @Param			id		path		string	true	"ID of the Envelope"
-// @Param			month	path		string	true	"The month in YYYY-MM format"
+// @Param			id		path		URIID		true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
+// @Param			month	path		URIMonth	true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Router			/v4/envelopes/{id}/{month} [get]
 func GetMonthConfig(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), MonthConfigResponse{
@@ -76,7 +78,7 @@ func GetMonthConfig(c *gin.Context) {
 		return
 	}
 
-	err = models.DB.First(&models.Envelope{}, id).Error
+	err = models.DB.First(&models.Envelope{}, uri.ID).Error
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), MonthConfigResponse{
@@ -85,13 +87,13 @@ func GetMonthConfig(c *gin.Context) {
 		return
 	}
 
-	mConfig, err := getMonthConfigModel(id, types.MonthOf(month.Month))
+	mConfig, err := getMonthConfigModel(uri.ID.UUID, types.MonthOf(month.Month))
 	var data MonthConfig
 	if err != nil {
 		// If there is no MonthConfig in the database, return one with the zero values
 		if errors.Is(err, models.ErrResourceNotFound) {
 			data = newMonthConfig(c, models.MonthConfig{
-				EnvelopeID: id,
+				EnvelopeID: uri.ID.UUID,
 				Month:      types.MonthOf(month.Month),
 			})
 			c.JSON(http.StatusOK, MonthConfigResponse{Data: &data})
@@ -117,12 +119,13 @@ func GetMonthConfig(c *gin.Context) {
 // @Failure		400			{object}	MonthConfigResponse
 // @Failure		404			{object}	MonthConfigResponse
 // @Failure		500			{object}	MonthConfigResponse
-// @Param			id			path		string				true	"ID of the Envelope"
-// @Param			month		path		string				true	"The month in YYYY-MM format"
+// @Param			id			path		URIID				true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
+// @Param			month		path		URIMonth			true	"ignored, but needed: https://github.com/swaggo/swag/issues/1014"
 // @Param			monthConfig	body		MonthConfigEditable	true	"MonthConfig"
 // @Router			/v4/envelopes/{id}/{month} [patch]
 func UpdateMonthConfig(c *gin.Context) {
-	id, err := httputil.UUIDFromString(c.Param("id"))
+	var uri URIID
+	err := c.ShouldBindUri(&uri)
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), MonthConfigResponse{
@@ -140,7 +143,7 @@ func UpdateMonthConfig(c *gin.Context) {
 		return
 	}
 
-	err = models.DB.First(&models.Envelope{}, id).Error
+	err = models.DB.First(&models.Envelope{}, uri.ID).Error
 	if err != nil {
 		s := err.Error()
 		c.JSON(status(err), MonthConfigResponse{
@@ -168,11 +171,11 @@ func UpdateMonthConfig(c *gin.Context) {
 		return
 	}
 
-	m, err := getMonthConfigModel(id, types.MonthOf(month.Month))
+	m, err := getMonthConfigModel(uri.ID.UUID, types.MonthOf(month.Month))
 
 	// If no Month Config exists yet, create one
 	if err != nil && errors.Is(err, models.ErrResourceNotFound) {
-		data.EnvelopeID = id
+		data.EnvelopeID = uri.ID.UUID
 		data.Month = types.Month(month.Month)
 
 		model := data.model()

--- a/pkg/controllers/v4/month_config_test.go
+++ b/pkg/controllers/v4/month_config_test.go
@@ -88,7 +88,7 @@ func (suite *TestSuiteStandard) TestMonthConfigsOptions() {
 		status   int
 		errMsg   string
 	}{
-		{"Bad Envelope ID", "Definitely-Not-A-UUID", "1984-03", http.StatusBadRequest, "not a valid UUID"},
+		{"Bad Envelope ID", "Definitely-Not-A-UUID", "1984-03", http.StatusBadRequest, "invalid UUID length: 21"},
 		{"Invalid Month", envelope.Data.ID.String(), "2000-00", http.StatusBadRequest, "parsing time \"2000-00\": month out of range"},
 		{"No envelope", uuid.New().String(), "1984-03", http.StatusNoContent, ""},
 		{"No MonthConfig", envelope.Data.ID.String(), "1984-03", http.StatusNoContent, ""},

--- a/pkg/controllers/v4/transaction_types.go
+++ b/pkg/controllers/v4/transaction_types.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/envelope-zero/backend/v5/internal/types"
-	"github.com/envelope-zero/backend/v5/pkg/httputil"
+	ez_uuid "github.com/envelope-zero/backend/v5/internal/uuid"
 	"github.com/envelope-zero/backend/v5/pkg/models"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -130,46 +130,31 @@ type TransactionQueryFilter struct {
 	AmountLessOrEqual      decimal.Decimal      `form:"amountLessOrEqual" filterField:"false"`      // Amount less than or equal to this
 	AmountMoreOrEqual      decimal.Decimal      `form:"amountMoreOrEqual" filterField:"false"`      // Amount more than or equal to this
 	Note                   string               `form:"note" filterField:"false"`                   // Note contains this string
-	BudgetID               string               `form:"budget" filterField:"false"`                 // ID of the budget
-	SourceAccountID        string               `form:"source"`                                     // ID of the source account
-	DestinationAccountID   string               `form:"destination"`                                // ID of the destination account
+	BudgetID               ez_uuid.UUID         `form:"budget" filterField:"false"`                 // ID of the budget
+	SourceAccountID        ez_uuid.UUID         `form:"source"`                                     // ID of the source account
+	DestinationAccountID   ez_uuid.UUID         `form:"destination"`                                // ID of the destination account
 	Direction              TransactionDirection `form:"direction" filterField:"false"`              // Direction of the transaction
-	EnvelopeID             string               `form:"envelope"`                                   // ID of the envelope
+	EnvelopeID             ez_uuid.UUID         `form:"envelope"`                                   // ID of the envelope
 	ReconciledSource       bool                 `form:"reconciledSource"`                           // Is the transaction reconciled in the source account?
 	ReconciledDestination  bool                 `form:"reconciledDestination"`                      // Is the transaction reconciled in the destination account?
-	AccountID              string               `form:"account" filterField:"false"`                // ID of either source or destination account
+	AccountID              ez_uuid.UUID         `form:"account" filterField:"false"`                // ID of either source or destination account
 	Offset                 uint                 `form:"offset" filterField:"false"`                 // The offset of the first Transaction returned. Defaults to 0.
 	Limit                  int                  `form:"limit" filterField:"false"`                  // Maximum number of transactions to return. Defaults to 50.
 }
 
 func (f TransactionQueryFilter) model() (models.Transaction, error) {
-	sourceAccountID, err := httputil.UUIDFromString(f.SourceAccountID)
-	if err != nil {
-		return models.Transaction{}, err
-	}
-
-	destinationAccountID, err := httputil.UUIDFromString(f.DestinationAccountID)
-	if err != nil {
-		return models.Transaction{}, err
-	}
-
-	envelopeID, err := httputil.UUIDFromString(f.EnvelopeID)
-	if err != nil {
-		return models.Transaction{}, err
-	}
-
 	// If the envelopeID is nil, use an actual nil, not uuid.Nil
 	var eID *uuid.UUID
-	if envelopeID != uuid.Nil {
-		eID = &envelopeID
+	if f.EnvelopeID != ez_uuid.Nil {
+		eID = &f.EnvelopeID.UUID
 	}
 
 	// This does not set the string or date fields since they are
 	// handled in the controller function
 	return TransactionEditable{
 		Amount:                f.Amount,
-		SourceAccountID:       sourceAccountID,
-		DestinationAccountID:  destinationAccountID,
+		SourceAccountID:       f.SourceAccountID.UUID,
+		DestinationAccountID:  f.DestinationAccountID.UUID,
 		EnvelopeID:            eID,
 		ReconciledSource:      f.ReconciledSource,
 		ReconciledDestination: f.ReconciledDestination,

--- a/pkg/controllers/v4/types.go
+++ b/pkg/controllers/v4/types.go
@@ -11,13 +11,13 @@ type URITime struct {
 }
 
 type URIMonth struct {
-	Month time.Time `uri:"month" time_format:"2006-01" time_utc:"1" example:"2013-11"` // Year and month
+	Month time.Time `uri:"month" time_format:"2006-01" time_utc:"1" example:"2013-11" binding:"required"` // Year and month in YYYY-MM format
 }
 
 type URIID struct {
-	ID ez_uuid.UUID `uri:"id" binding:"required"` // The ID of the resource
+	ID ez_uuid.UUID `uri:"id" binding:"required"` // ID of the resource
 }
 
 type QueryMonth struct {
-	Month time.Time `form:"month" time_format:"2006-01" time_utc:"1" example:"2022-07"` // Year and month
+	Month time.Time `form:"month" time_format:"2006-01" time_utc:"1" example:"2022-07"` // Year and month in YYYY-MM format
 }

--- a/pkg/controllers/v4/types.go
+++ b/pkg/controllers/v4/types.go
@@ -7,6 +7,7 @@ import (
 )
 
 type URIMonth struct {
+	URIID
 	Month time.Time `uri:"month" time_format:"2006-01" time_utc:"1" example:"2013-11" binding:"required"` // Year and month in YYYY-MM format
 }
 

--- a/pkg/controllers/v4/types.go
+++ b/pkg/controllers/v4/types.go
@@ -6,16 +6,12 @@ import (
 	ez_uuid "github.com/envelope-zero/backend/v5/internal/uuid"
 )
 
-type URITime struct {
-	Time time.Time `uri:"time" example:"2024-01-07T18:43:00.271152Z"`
-}
-
 type URIMonth struct {
 	Month time.Time `uri:"month" time_format:"2006-01" time_utc:"1" example:"2013-11" binding:"required"` // Year and month in YYYY-MM format
 }
 
 type URIID struct {
-	ID ez_uuid.UUID `uri:"id" binding:"required"` // ID of the resource
+	ID ez_uuid.UUID `uri:"id" binding:"required" format:"UUID"` // ID of the resource
 }
 
 type QueryMonth struct {

--- a/pkg/controllers/v4/types.go
+++ b/pkg/controllers/v4/types.go
@@ -1,6 +1,10 @@
 package v4
 
-import "time"
+import (
+	"time"
+
+	ez_uuid "github.com/envelope-zero/backend/v5/internal/uuid"
+)
 
 type URITime struct {
 	Time time.Time `uri:"time" example:"2024-01-07T18:43:00.271152Z"`
@@ -8,6 +12,10 @@ type URITime struct {
 
 type URIMonth struct {
 	Month time.Time `uri:"month" time_format:"2006-01" time_utc:"1" example:"2013-11"` // Year and month
+}
+
+type URIID struct {
+	ID ez_uuid.UUID `uri:"id" binding:"required"` // The ID of the resource
 }
 
 type QueryMonth struct {

--- a/pkg/httputil/request.go
+++ b/pkg/httputil/request.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gin-contrib/requestid"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
 
@@ -28,21 +27,4 @@ func BindData(c *gin.Context, data interface{}) error {
 	}
 
 	return nil
-}
-
-// UUIDFromString binds a string to a UUID
-//
-// This is needed because gin does not support form binding to uuid.UUID currently.
-// Follow https://github.com/gin-gonic/gin/pull/3045 to see when this gets resolved.
-func UUIDFromString(s string) (uuid.UUID, error) {
-	if s == "" {
-		return uuid.Nil, nil
-	}
-
-	u, err := uuid.Parse(s)
-	if err != nil {
-		return uuid.Nil, ErrInvalidUUID
-	}
-
-	return u, nil
 }

--- a/pkg/httputil/request_test.go
+++ b/pkg/httputil/request_test.go
@@ -82,39 +82,3 @@ func TestBindDataJsonUnmarshalTypeError(t *testing.T) {
 	c.Request, _ = http.NewRequest(http.MethodGet, "https://example.com/", bytes.NewBuffer([]byte(`{ "name": 2 }`)))
 	r.ServeHTTP(w, c.Request)
 }
-
-func TestUUIDFromString(t *testing.T) {
-	tests := []struct {
-		name   string
-		url    string
-		status int // the expected http status
-	}{
-		{"Success", "https://example.com/?id=4e743e94-6a4b-44d6-aba5-d77c82103fa7", http.StatusOK},
-		{"Invalid UUID", "https://example.com/?id=not-a-valid-uuid", http.StatusBadRequest},
-		{"Empty UUID", "https://example.com/?id=", http.StatusOK},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			w := httptest.NewRecorder()
-			c, r := gin.CreateTestContext(w)
-
-			r.GET("/", func(_ *gin.Context) {
-				var o struct {
-					UUID string `form:"id"`
-				}
-
-				_ = c.Bind(&o)
-				_, err := httputil.UUIDFromString(o.UUID)
-				if err != nil {
-					c.AbortWithStatus(http.StatusBadRequest)
-				}
-				c.Status(http.StatusOK)
-			})
-
-			c.Request, _ = http.NewRequest(http.MethodGet, tt.url, bytes.NewBuffer([]byte("")))
-			r.ServeHTTP(w, c.Request)
-			assert.Equal(t, tt.status, w.Code)
-		})
-	}
-}


### PR DESCRIPTION
This removes the explicit UUID parsing in favor of an internal UUID implementation (wrapping google/uud) that 
includes the parsing methods for gin.

- **chore: remove UUID parsing**
- **chore: remove UUID parsing from account**
- **chore: remove UUID parsing from budget**
- **chore: remove UUID parsing from category**
- **chore: remove UUID parsing from envelope**
- **chore: remove UUID parsing from goal**
- **chore: remove UUID parsing from import**
- **chore: remove UUID parsing from match rule**
- **chore: remove UUID parsing from month config**
- **docs: improve documentation of /v4/months endpoint**
- **chore: remove UUID parsing from transaction**
- **chore: set format for URIID**
- **chore: only bind month URI once**
- **chore: move golangci-lint to the end to instantly reformat swag fmt comments**

Resolves #223.