### PR TITLE
ci: do not set token anymore

### DIFF
--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -30,7 +30,6 @@ jobs:
         uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a # v5.0.7
         with:
           files: coverage.out
-          token: ${{ secrets.CODECOV_TOKEN }}
 
         # This builds the binary and starts it. If it does not exit within 3 seconds, consider it
         # successful


### PR DESCRIPTION
Codecov now supports tokenless upload, so that's what we'll use from now on.
