### PR TITLE
feat!: set default available from to next month

### DIFF
--- a/pkg/controllers/v4/month_test.go
+++ b/pkg/controllers/v4/month_test.go
@@ -396,6 +396,7 @@ func (suite *TestSuiteStandard) TestMonths() {
 
 	_ = createTestTransaction(suite.T(), v4.TransactionEditable{
 		Date:                 time.Date(2022, 3, 1, 7, 38, 17, 0, time.UTC),
+		AvailableFrom:        types.NewMonth(2022, 3),
 		Amount:               decimal.NewFromFloat(1500),
 		Note:                 "Income for march",
 		SourceAccountID:      externalAccount.Data.ID,

--- a/pkg/controllers/v4/transaction_test.go
+++ b/pkg/controllers/v4/transaction_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/envelope-zero/backend/v5/internal/types"
 	v4 "github.com/envelope-zero/backend/v5/pkg/controllers/v4"
 	"github.com/envelope-zero/backend/v5/pkg/httputil"
 	"github.com/envelope-zero/backend/v5/pkg/models"
@@ -192,10 +193,9 @@ func (suite *TestSuiteStandard) TestTransactionsGetFilter() {
 		ReconciledDestination: false,
 	})
 
-	// Note that this transaction will be available from 2016-05-01 because it's also at
-	// that date, but by default, "available from" is set to the first of the month
 	_ = createTestTransaction(suite.T(), v4.TransactionEditable{
 		Date:                  time.Date(2016, 5, 1, 14, 13, 25, 584575, time.UTC),
+		AvailableFrom:         types.NewMonth(2016, 5),
 		Amount:                decimal.NewFromFloat(11235.813),
 		Note:                  "Not important",
 		EnvelopeID:            e2ID,

--- a/pkg/models/budget_test.go
+++ b/pkg/models/budget_test.go
@@ -169,14 +169,14 @@ func (suite *TestSuiteStandard) TestBudgetCalculations() {
 	}
 	assert.True(suite.T(), isBalance.Equal(shouldBalance), "Balance for budget is not correct. Should be %s, is %s", shouldBalance, isBalance)
 
-	// Verify income for used budget in March
+	// Verify income for used budget in March. AvailableFrom defaults to next month, so we check for April
 	shouldIncome := decimal.NewFromFloat(4620) // Income transaction from employer + income from off budget account
-	income, err := budget.Income(models.DB, marchTwentyTwentyTwo)
+	income, err := budget.Income(models.DB, marchTwentyTwentyTwo.AddDate(0, 1))
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), income.Equal(shouldIncome), "Income is %s, should be %s", income, shouldIncome)
 
-	// Verify income for empty budget in March
-	income, err = emptyBudget.Income(models.DB, marchTwentyTwentyTwo)
+	// Verify income for empty budget in March. AvailableFrom defaults to next month, so we check for April
+	income, err = emptyBudget.Income(models.DB, marchTwentyTwentyTwo.AddDate(0, 1))
 	assert.Nil(suite.T(), err)
 	assert.True(suite.T(), income.IsZero(), "Income is %s, should be 0", income)
 

--- a/pkg/models/transaction.go
+++ b/pkg/models/transaction.go
@@ -135,7 +135,7 @@ func (t *Transaction) BeforeSave(tx *gorm.DB) (err error) {
 
 	// Default the AvailableForBudget date to the transaction date
 	if t.AvailableFrom.IsZero() {
-		t.AvailableFrom = types.MonthOf(t.Date)
+		t.AvailableFrom = types.MonthOf(t.Date).AddDate(0, 1)
 	} else if t.AvailableFrom.Before(types.MonthOf(t.Date)) {
 		return fmt.Errorf("%w, transaction date: %s, available month %s", ErrAvailabilityMonthTooEarly, t.Date.Format("2006-01-02"), t.AvailableFrom)
 	}


### PR DESCRIPTION
With this, the default AvailableFrom date is set to the first of the month following the transaction, not the month of the transaction.

This makes more sense logically since it enforces funds to only be allocated after they have been received by default.
The value can still be explicitly set if that is required.
