### PR TITLE
fix: transaction filtering by direction and type

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2871,9 +2871,9 @@ const docTemplate = `{
                     },
                     {
                         "enum": [
-                            "INCOMING",
-                            "OUTGOING",
-                            "TRANSFER"
+                            "IN",
+                            "OUT",
+                            "INTERNAL"
                         ],
                         "type": "string",
                         "description": "Filter by direction of transaction",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2860,9 +2860,9 @@
                     },
                     {
                         "enum": [
-                            "INCOMING",
-                            "OUTGOING",
-                            "TRANSFER"
+                            "IN",
+                            "OUT",
+                            "INTERNAL"
                         ],
                         "type": "string",
                         "description": "Filter by direction of transaction",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3350,9 +3350,9 @@ paths:
         type: string
       - description: Filter by direction of transaction
         enum:
-        - INCOMING
-        - OUTGOING
-        - TRANSFER
+        - IN
+        - OUT
+        - INTERNAL
         in: query
         name: direction
         type: string

--- a/pkg/controllers/v4/errors.go
+++ b/pkg/controllers/v4/errors.go
@@ -45,4 +45,5 @@ var (
 // Transaction errors
 var (
 	errTransactionDirectionInvalid = errors.New("the specified transaction direction is invalid")
+	errTransactionTypeInvalid      = errors.New("the specified transaction type is invalid")
 )

--- a/pkg/controllers/v4/transaction_types.go
+++ b/pkg/controllers/v4/transaction_types.go
@@ -114,9 +114,18 @@ type TransactionResponse struct {
 type TransactionDirection string
 
 const (
-	DirectionIncoming TransactionDirection = "INCOMING"
-	DirectionOutgoing TransactionDirection = "OUTGOING"
-	DirectionTransfer TransactionDirection = "TRANSFER"
+	DirectionIn       TransactionDirection = "IN"
+	DirectionOut      TransactionDirection = "OUT"
+	DirectionInternal TransactionDirection = "INTERNAL"
+)
+
+// swagger:enum TransactionType
+type TransactionType string
+
+const (
+	TypeIncome   TransactionType = "INCOME"
+	TypeSpend    TransactionType = "SPEND"
+	TypeTransfer TransactionType = "TRANSFER"
 )
 
 type TransactionQueryFilter struct {
@@ -133,7 +142,8 @@ type TransactionQueryFilter struct {
 	BudgetID               ez_uuid.UUID         `form:"budget" filterField:"false"`                 // ID of the budget
 	SourceAccountID        ez_uuid.UUID         `form:"source"`                                     // ID of the source account
 	DestinationAccountID   ez_uuid.UUID         `form:"destination"`                                // ID of the destination account
-	Direction              TransactionDirection `form:"direction" filterField:"false"`              // Direction of the transaction
+	Direction              TransactionDirection `form:"direction" filterField:"false"`              // Direction of the transaction - are involved accounts internal or external?
+	Type                   TransactionType      `form:"type" filterField:"false"`                   // Type of the transaction - the effect the transaction has on the budget
 	EnvelopeID             ez_uuid.UUID         `form:"envelope"`                                   // ID of the envelope
 	ReconciledSource       bool                 `form:"reconciledSource"`                           // Is the transaction reconciled in the source account?
 	ReconciledDestination  bool                 `form:"reconciledDestination"`                      // Is the transaction reconciled in the destination account?


### PR DESCRIPTION
Transaction filtering was incomplete and wrong so far, which is fixed with this change.

There are now two different filters, direction and type.

direction filters by the source/destination accounts being internal or external. It has the following values:

- IN: Transaction from an external to an internal account
- OUT: Transaction from an internal account to an external account
- INTERNAL: Transaction from an internal to an internal account (same as the old direction: TRANSFER)

type filters by the effect a transaction has on the budget. It has the following values

- INCOME: From an off-budget to an on-budget account (same as the old direction: INCOMING)
- SPEND: From an on-budget to an off-budget account (same as the old direction: OUTGOING)
- TRANSFER: From an on-budget to an on-budget account

Resolves #1024.
