### PR TITLE
fix: set availableFrom to next month for imports

### DIFF
--- a/internal/controllers/v4/import_test.go
+++ b/internal/controllers/v4/import_test.go
@@ -223,9 +223,9 @@ func (suite *TestSuiteStandard) TestImportYnabImportPreviewAvailableFrom() {
 	preview := suite.parseCSV(suite.T(), account.Data.ID, "available-from-test.csv")
 
 	dates := []types.Month{
-		types.NewMonth(2019, 2),
-		types.NewMonth(2019, 4),
+		types.NewMonth(2019, 3),
 		types.NewMonth(2019, 5),
+		types.NewMonth(2019, 6),
 	}
 
 	for i, transaction := range preview.Data {

--- a/internal/importer/parser/ynab-import/parse.go
+++ b/internal/importer/parser/ynab-import/parse.go
@@ -56,10 +56,13 @@ func Parse(f io.Reader, account models.Account) ([]importer.TransactionPreview, 
 
 		t := importer.TransactionPreview{
 			Transaction: models.Transaction{
-				Date:          date,
-				AvailableFrom: types.NewMonth(date.Year(), date.Month()),
-				ImportHash:    helpers.Sha256String(strings.Join(record, ",")),
-				Note:          record[headers["Memo"]],
+				Date:       date,
+				ImportHash: helpers.Sha256String(strings.Join(record, ",")),
+				Note:       record[headers["Memo"]],
+
+				// AvailableFrom is only used for income transactions, for which it defaults to the month after the transaction.
+				// Since it is only used for income transactions, we can safely set it here.
+				AvailableFrom: types.NewMonth(date.Year(), date.Month()).AddDate(0, 1),
 			},
 		}
 


### PR DESCRIPTION
This PR sets the availableFrom month to the next month by default for imports.

I missed this in 51ba6793464e9ed029f6a6b6c796465648d0c881, so with this commit created transactions and imports behave the same again.
