### PR TITLE
fix: add URL for match rules to link list

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2325,6 +2325,12 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Filter by budget ID",
+                        "name": "budget",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "description": "The offset of the first Match Rule returned. Defaults to 0.",
                         "name": "offset",
@@ -3644,6 +3650,10 @@ const docTemplate = `{
                     "description": "Envelopes for this budget",
                     "type": "string",
                     "example": "https://example.com/api/v4/envelopes?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"
+                },
+                "matchRules": {
+                    "type": "string",
+                    "example": "https://example.com/api/v4/match-rules?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"
                 },
                 "month": {
                     "description": "This uses 'YYYY-MM' for clients to replace with the actual year and month.",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2314,6 +2314,12 @@
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Filter by budget ID",
+                        "name": "budget",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "description": "The offset of the first Match Rule returned. Defaults to 0.",
                         "name": "offset",
@@ -3633,6 +3639,10 @@
                     "description": "Envelopes for this budget",
                     "type": "string",
                     "example": "https://example.com/api/v4/envelopes?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"
+                },
+                "matchRules": {
+                    "type": "string",
+                    "example": "https://example.com/api/v4/match-rules?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"
                 },
                 "month": {
                     "description": "This uses 'YYYY-MM' for clients to replace with the actual year and month.",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -326,6 +326,9 @@ definitions:
         description: Envelopes for this budget
         example: https://example.com/api/v4/envelopes?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf
         type: string
+      matchRules:
+        example: https://example.com/api/v4/match-rules?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf
+        type: string
       month:
         description: This uses 'YYYY-MM' for clients to replace with the actual year
           and month.
@@ -2969,6 +2972,10 @@ paths:
       - description: Filter by account ID
         in: query
         name: account
+        type: string
+      - description: Filter by budget ID
+        in: query
+        name: budget
         type: string
       - description: The offset of the first Match Rule returned. Defaults to 0.
         in: query

--- a/internal/controllers/v4/budget_types.go
+++ b/internal/controllers/v4/budget_types.go
@@ -28,6 +28,7 @@ type BudgetLinks struct {
 	Envelopes    string `json:"envelopes" example:"https://example.com/api/v4/envelopes?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"`        // Envelopes for this budget
 	Transactions string `json:"transactions" example:"https://example.com/api/v4/transactions?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"`  // Transactions for this budget
 	Month        string `json:"month" example:"https://example.com/api/v4/months?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf&month=YYYY-MM"` // This uses 'YYYY-MM' for clients to replace with the actual year and month.
+	MatchRules   string `json:"matchRules" example:"https://example.com/api/v4/match-rules?budget=550dc009-cea6-4c12-b2a5-03446eb7b7cf"`
 }
 
 // Budget is the API v4 representation of a Budget.
@@ -54,6 +55,7 @@ func newBudget(c *gin.Context, model models.Budget) Budget {
 			Envelopes:    fmt.Sprintf("%s/v4/envelopes?budget=%s", url, model.ID),
 			Transactions: fmt.Sprintf("%s/v4/transactions?budget=%s", url, model.ID),
 			Month:        fmt.Sprintf("%s/v4/months?budget=%s&month=YYYY-MM", url, model.ID),
+			MatchRules:   fmt.Sprintf("%s/v4/match-rules?budget=%s", url, model.ID),
 		},
 	}
 }

--- a/internal/controllers/v4/match_rule.go
+++ b/internal/controllers/v4/match_rule.go
@@ -118,6 +118,7 @@ func CreateMatchRules(c *gin.Context) {
 // @Param			priority	query		uint	false	"Filter by priority"
 // @Param			match		query		string	false	"Filter by match"
 // @Param			account		query		string	false	"Filter by account ID"
+// @Param			budget		query		string	false	"Filter by budget ID"
 // @Param			offset		query		uint	false	"The offset of the first Match Rule returned. Defaults to 0."
 // @Param			limit		query		int		false	"Maximum number of Match Rules to return. Defaults to 50.".
 // @Router			/v4/match-rules [get]


### PR DESCRIPTION
This adds the match rules URL to the link list for a budget. Also adds the budget ID to the match rules GET endpoint documentation. The budget ID was already supported, but not documented yet.
